### PR TITLE
Forgot to add TransmutationTablet class.

### DIFF
--- a/main/java/moze_intel/gameObjs/items/TransmutationTablet.java
+++ b/main/java/moze_intel/gameObjs/items/TransmutationTablet.java
@@ -23,7 +23,7 @@ public class TransmutationTablet extends ItemBase
     {
         if (!world.isRemote)
         {
-            player.openGui(MozeCore.instance, Constants.RM_FURNACE_GUI, world, (int) player.posX, (int) player.posY, (int) player.posZ);
+            player.openGui(MozeCore.instance, Constants.TRANSMUTE_STONE_GUI, world, (int) player.posX, (int) player.posY, (int) player.posZ);
         }
         return stack;
     }


### PR DESCRIPTION
In my last PR, I added the Tome, but I had also started to add the handheld tablet, but never merged the class for it, so the ObjHandler class errors out. 
