### PR TITLE
Fix crashes when the GUI is switched out (e.g. looking up recipes in NEI)

### DIFF
--- a/main/java/moze_intel/gameObjs/gui/GUITransmute.java
+++ b/main/java/moze_intel/gameObjs/gui/GUITransmute.java
@@ -27,6 +27,14 @@ public class GUITransmute extends GuiContainer
 	}
 
 	@Override
+	public void initGui()
+	{
+		// Ensure that the player is set on client side if the gui is re-opened after switching out
+		tile.setPlayer(Minecraft.getMinecraft().thePlayer);
+		super.initGui();
+	}
+
+	@Override
 	protected void drawGuiContainerBackgroundLayer(float var1, int var2, int var3) 
 	{
 		GL11.glColor4f(1F, 1F, 1F, 1F);


### PR DESCRIPTION
When the GUI is switched out onGuiClosed is called, which in turn calls TransmuteContainer.onContainerClosed -> TransmuteTile.closeInventory -> sets the player to null. This happens only on client side, from server POV the container is still open and player is set.

Then when the GUI is brought back, the player is still null and most interactions (search, putting item in lock slot, putting items in left pane, etc.) will crash the game.

This patch ensures that the player is re-set on client side when the GUI is (re-)initialized.

This might, or might not be related to the crash in #99 
