### PR TITLE
Transmutation and Alchemical data is saved when the PlayerData is saved.

### DIFF
--- a/main/java/moze_intel/projecte/MozeCore.java
+++ b/main/java/moze_intel/projecte/MozeCore.java
@@ -9,6 +9,7 @@ import moze_intel.projecte.emc.RecipeMapper;
 import moze_intel.projecte.events.PlayerEvents;
 import moze_intel.projecte.events.PlayerChecksEvent;
 import moze_intel.projecte.events.PlayerJoinWorld;
+import moze_intel.projecte.events.PlayerSaveData;
 import moze_intel.projecte.gameObjs.ObjHandler;
 import moze_intel.projecte.network.PacketHandler;
 import moze_intel.projecte.network.ThreadCheckUpdate;
@@ -76,6 +77,7 @@ public class MozeCore
     	NetworkRegistry.INSTANCE.registerGuiHandler(MozeCore.instance, new GuiHandler());
     	MinecraftForge.EVENT_BUS.register(new moze_intel.projecte.events.ItemPickupEvent());
     	MinecraftForge.EVENT_BUS.register(new PlayerJoinWorld());
+        MinecraftForge.EVENT_BUS.register(new PlayerSaveData());
     	
     	FMLCommonHandler.instance().bus().register(new PlayerChecksEvent());
     	FMLCommonHandler.instance().bus().register(new PlayerEvents());

--- a/main/java/moze_intel/projecte/events/PlayerSaveData.java
+++ b/main/java/moze_intel/projecte/events/PlayerSaveData.java
@@ -1,0 +1,15 @@
+package moze_intel.projecte.events;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import moze_intel.projecte.playerData.IOHandler;
+import moze_intel.projecte.utils.PELogger;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+
+public class PlayerSaveData {
+    @SubscribeEvent
+    public void playerSaveData(PlayerEvent.SaveToFile event)
+    {
+        IOHandler.saveData();
+        PELogger.logInfo("Saved transmutation and alchemical bag data. ");
+    }
+}


### PR DESCRIPTION
Currently the Transmutation and Alchemical data is only saved when a server is stopped. This can cause a problem when a server is forcibly stopped or crashes as the PlayerData is saved on disconnect. This adds an event whenever the Player Data is saved then the Alchemical / Transmutation data is saved also. 
