### PR TITLE
Small null check on entity for mods that are non-compliant with Forge

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/DiviningRodHigh.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/DiviningRodHigh.java
@@ -82,7 +82,7 @@ public class DiviningRodHigh extends DiviningRodMedium
 							
 							for (Entry<ItemStack, ItemStack> entry : map.entrySet())
 							{
-								if (entry.getKey() == null)
+								if (entry == null || entry.getKey() == null)
 								{
 									continue;
 								}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/DiviningRodLow.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/DiviningRodLow.java
@@ -83,7 +83,7 @@ public class DiviningRodLow extends ItemPE
 							
 							for (Entry<ItemStack, ItemStack> entry : map.entrySet())
 							{
-								if (entry.getKey() == null)
+								if (entry == null || entry.getKey() == null)
 								{
 									continue;
 								}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/DiviningRodMedium.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/DiviningRodMedium.java
@@ -96,7 +96,7 @@ public class DiviningRodMedium extends ItemPE implements IModeChanger
 							
 							for (Entry<ItemStack, ItemStack> entry : map.entrySet())
 							{
-								if (entry.getKey() == null)
+								if (entry == null || entry.getKey() == null)
 								{
 									continue;
 								}


### PR DESCRIPTION
_cough_ Thaumcraft _cough_ Basically fixes all of the divining rod crashes
people have complained about.

Even in a perfect world, it's always best to do a null check on objects from an API before using a method on them. Especially in the world of Minecraft modding :D
