### PR TITLE
Update MinecraftForge to 1272

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ group= "java.moze_intel" // http://maven.apache.org/guides/mini/guide-naming-con
 archivesBaseName = "ProjectE"
 
 minecraft {
-    version = "1.7.10-10.13.2.1230"
+    version = "1.7.10-10.13.2.1272"
     runDir = "eclipse"
 }
 


### PR DESCRIPTION
Contains performance fixes and many mods are already past 1230.
