### PR TITLE
Remove code duplication in CataliticLens by extending DestructionCatalyst

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/CataliticLens.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/CataliticLens.java
@@ -27,112 +27,11 @@ import cpw.mods.fml.common.network.NetworkRegistry.TargetPoint;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-public class CataliticLens extends ItemCharge implements IProjectileShooter
+public class CataliticLens extends DestructionCatalyst implements IProjectileShooter
 {
 	public CataliticLens() 
 	{
-		super("catalitic_lens", (byte) 4);
-	}
-	
-	@Override
-	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player)
-	{
-		if (world.isRemote) return stack;
-
-		MovingObjectPosition mop = this.getMovingObjectPositionFromPlayer(world, player, false);
-
-		if (mop != null && mop.typeOfHit.equals(MovingObjectType.BLOCK))
-		{
-			int charge = this.getCharge(stack);
-			int numRows;
-			boolean hasAction = false;
-			
-			if (charge == 0)
-				numRows = 1;
-			else if (charge == 1)
-				numRows = 16;
-			else if (charge == 2)
-				numRows = 32;
-			else numRows = 64;
-			
-			ForgeDirection direction = ForgeDirection.getOrientation(mop.sideHit);
-			
-			Coordinates coords = new Coordinates(mop);
-			CoordinateBox box = getBoxFromDirection(direction, coords, numRows);
-			
-			List<ItemStack> drops = new ArrayList();
-			
-			for (int x = (int) box.minX; x <= box.maxX; x++)
-				for (int y = (int) box.minY; y <= box.maxY; y++)
-					for (int z = (int) box.minZ; z <= box.maxZ; z++)
-					{
-						Block block = world.getBlock(x, y, z);
-						float hardness = block.getBlockHardness(world, x, y, z);
-						
-						if (block == null || block == Blocks.air || hardness >= 50.0F || hardness == -1.0F)
-						{
-							continue;
-						}
-						
-						if (!this.consumeFuel(player, stack, 8, true))
-						{
-							break;
-						}
-						
-						if (!hasAction)
-						{
-							hasAction = true;
-						}
-						
-						ArrayList<ItemStack> list = Utils.getBlockDrops(world, player, block, stack, x, y, z);
-						
-						if (list != null && list.size() > 0)
-						{
-							drops.addAll(list);
-						}
-							
-						world.setBlockToAir(x, y, z);
-						
-						if (world.rand.nextInt(8) == 0)
-						{
-							PacketHandler.sendToAllAround(new ParticlePKT("largesmoke", x, y, z), new TargetPoint(world.provider.dimensionId, x, y + 1, z, 32));
-						}
-					}
-			
-			PacketHandler.sendTo(new SwingItemPKT(), (EntityPlayerMP) player);
-			
-			if (hasAction)
-			{
-				world.playSoundAtEntity(player, "projecte:destruct", 0.5F, 1.0F);
-				world.spawnEntityInWorld(new EntityLootBall(world, drops, player.posX, player.posY, player.posZ));
-			}
-		}
-			
-		return stack;
-	}
-	
-	public CoordinateBox getBoxFromDirection(ForgeDirection direction, Coordinates coords, int charge)
-	{
-		charge--;
-		
-		if (direction.offsetX != 0)
-		{
-			if (direction.offsetX > 0)
-				return new CoordinateBox(coords.x - charge, coords.y - 1, coords.z - 1, coords.x, coords.y + 1, coords.z + 1);
-			else return new CoordinateBox(coords.x, coords.y - 1, coords.z - 1, coords.x + charge, coords.y + 1, coords.z + 1);
-		}
-		else if (direction.offsetY != 0)
-		{
-			if (direction.offsetY > 0)
-				return new CoordinateBox(coords.x - 1, coords.y - charge, coords.z - 1, coords.x + 1, coords.y, coords.z + 1);
-			else return new CoordinateBox(coords.x - 1, coords.y, coords.z - 1, coords.x + 1, coords.y + charge, coords.z + 1);
-		}
-		else
-		{
-			if (direction.offsetZ > 0)
-				return new CoordinateBox(coords.x - 1, coords.y - 1, coords.z - charge, coords.x + 1, coords.y + 1, coords.z);
-			else return new CoordinateBox(coords.x - 1, coords.y - 1, coords.z, coords.x + 1, coords.y + 1, coords.z + charge);
-		}
+		super("catalitic_lens",new int[]{1,16,32,64});
 	}
 	
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/items/DestructionCatalyst.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/DestructionCatalyst.java
@@ -26,9 +26,14 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 public class DestructionCatalyst extends ItemCharge
 {
+	protected int[] numRowsForCharge;
 	public DestructionCatalyst() 
 	{
-		super("destruction_catalyst", (byte) 4);
+		this("destruction_catalyst",new int[]{1,4,9,16});
+	}
+	protected DestructionCatalyst(String unlocalName, int[] numRowsForCharge) {
+		super(unlocalName, (byte)numRowsForCharge.length);
+		this.numRowsForCharge = numRowsForCharge;
 	}
 	
 	@Override
@@ -44,22 +49,7 @@ public class DestructionCatalyst extends ItemCharge
 			int numRows;
 			boolean hasAction = false;
 			
-			if (charge == 0)
-			{
-				numRows = 1;
-			}
-			else if (charge == 1)
-			{
-				numRows = 4;
-			}
-			else if (charge == 2)
-			{
-				numRows = 9;
-			}
-			else 
-			{
-				numRows = 16;
-			}
+			numRows = numRowsForCharge[charge];
 			
 			ForgeDirection direction = ForgeDirection.getOrientation(mop.sideHit);
 			
@@ -109,6 +99,7 @@ public class DestructionCatalyst extends ItemCharge
 			
 			if (hasAction)
 			{
+				world.playSoundAtEntity(player, "projecte:destruct", 0.5F, 1.0F);
 				world.spawnEntityInWorld(new EntityLootBall(world, drops, player.posX, player.posY, player.posZ));
 			}
 		}


### PR DESCRIPTION
fixes #349 

Also: is it intended, that the DestructionCatalyst destroys 9 instead of 8 rows of blocks?

DestructionCatalyst: 1, 4, **9**, 16
CataliticLens: 1, 16, 32, 64