### PR TITLE
Don't repair items while swinging them (Repair Talisman)

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/RepairTalisman.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/RepairTalisman.java
@@ -55,6 +55,11 @@ public class RepairTalisman extends ItemPE implements IBauble
 					continue;
 				}
 
+				if (invStack.equals(player.getCurrentEquippedItem()) && player.isSwingInProgress) {
+					//Don't repair item that is currently used by the player.
+					continue;
+				}
+
 				if (!invStack.getHasSubtypes() && invStack.getMaxDamage() != 0 && invStack.getItemDamage() > 0)
 				{
 					invStack.setItemDamage(invStack.getItemDamage() - 1);


### PR DESCRIPTION
Some tools tend to abort the breaking of a block, when the item is repaired during the swing.