### PR TITLE
Don't extract EMC from klein stars twice

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/TransmuteContainer.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/TransmuteContainer.java
@@ -117,12 +117,7 @@ public class TransmuteContainer extends Container
 			}
 			
 			tile.handleKnowledge(newStack);
-			
-			if (stack.getItem() == ObjHandler.kleinStars)
-			{
-				tile.addEmc(KleinStar.getEmc(stack));
-			}
-			
+
 			if (stack.stackSize == 0)
 			{
 				slot.putStack(null);

--- a/src/main/java/moze_intel/projecte/gameObjs/container/TransmuteTabletContainer.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/TransmuteTabletContainer.java
@@ -116,12 +116,7 @@ public class TransmuteTabletContainer extends Container
 			}
 			
 			table.handleKnowledge(newStack);
-			
-			if (stack.getItem() == ObjHandler.kleinStars)
-			{
-				table.addEmc(KleinStar.getEmc(stack));
-			}
-			
+
 			if (stack.stackSize == 0)
 			{
 				slot.putStack(null);

--- a/src/main/java/moze_intel/projecte/gameObjs/container/slots/transmuteportable/SlotTabletConsume.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/slots/transmuteportable/SlotTabletConsume.java
@@ -38,11 +38,6 @@ public class SlotTabletConsume extends Slot
 			stack.stackSize--;
 		}
 		
-		if (cache.getItem() == ObjHandler.kleinStars)
-		{
-			toAdd += KleinStar.getEmc(cache);
-		}
-		
 		table.addEmc(toAdd);
 		this.onSlotChanged();
 		table.handleKnowledge(cache);

--- a/src/main/java/moze_intel/projecte/gameObjs/container/slots/trasmute/SlotTableConsume.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/slots/trasmute/SlotTableConsume.java
@@ -35,12 +35,7 @@ public class SlotTableConsume extends Slot
 			toAdd += Utils.getEmcValue(stack);
 			stack.stackSize--;
 		}
-		
-		if (cache.getItem() == ObjHandler.kleinStars)
-		{
-			toAdd += KleinStar.getEmc(cache);
-		}
-		
+
 		tile.addEmcWithPKT(toAdd);
 		this.onSlotChanged();
 		tile.handleKnowledge(cache);


### PR DESCRIPTION
Fixes #378 

The fact that this had to be fixed at 4 places in the code made me worry even more...

I only scanned for uses of the `KleinStar`-Class, so i could have missed some places...