### PR TITLE
Add @API annotation

### DIFF
--- a/src/main/java/moze_intel/projecte/PECore.java
+++ b/src/main/java/moze_intel/projecte/PECore.java
@@ -37,8 +37,7 @@ import java.util.List;
 
 @Mod(modid = PECore.MODID, name = PECore.MODNAME, version = PECore.VERSION)
 public class PECore
-{	
-	public static final String APINAME = "ProjectEAPI";
+{
 	public static final String MODID = "ProjectE";
 	public static final String MODNAME = "ProjectE";
 	public static final String VERSION = "@VERSION@";

--- a/src/main/java/moze_intel/projecte/PECore.java
+++ b/src/main/java/moze_intel/projecte/PECore.java
@@ -38,6 +38,7 @@ import java.util.List;
 @Mod(modid = PECore.MODID, name = PECore.MODNAME, version = PECore.VERSION)
 public class PECore
 {	
+	public static final String APINAME = "ProjectEAPI";
 	public static final String MODID = "ProjectE";
 	public static final String MODNAME = "ProjectE";
 	public static final String VERSION = "@VERSION@";

--- a/src/main/java/moze_intel/projecte/api/ProjectEAPI.java
+++ b/src/main/java/moze_intel/projecte/api/ProjectEAPI.java
@@ -12,6 +12,12 @@ import net.minecraft.nbt.NBTTagCompound;
 public final class ProjectEAPI
 {
 	/**
+	 * Increment this every time the API changes.
+	 * (Adding methods, removing methods, changing method signatures, etc.)
+	 */
+	public static final String API_VERSION = "1";
+
+	/**
 	 * Register an EMC value for the specified itemstack.<br>
 	 * If the emcValue is <= 0, then the ItemStack will be blacklisted from any EMC mapping.<br>
 	 * The ItemStack's NBT data is completely ignored in registration.<br>

--- a/src/main/java/moze_intel/projecte/api/ProjectEAPI.java
+++ b/src/main/java/moze_intel/projecte/api/ProjectEAPI.java
@@ -12,12 +12,6 @@ import net.minecraft.nbt.NBTTagCompound;
 public final class ProjectEAPI
 {
 	/**
-	 * Increment this every time the API changes.
-	 * (Adding methods, removing methods, changing method signatures, etc.)
-	 */
-	public static final String API_VERSION = "1";
-
-	/**
 	 * Register an EMC value for the specified itemstack.<br>
 	 * If the emcValue is <= 0, then the ItemStack will be blacklisted from any EMC mapping.<br>
 	 * The ItemStack's NBT data is completely ignored in registration.<br>

--- a/src/main/java/moze_intel/projecte/api/package-info.java
+++ b/src/main/java/moze_intel/projecte/api/package-info.java
@@ -1,0 +1,5 @@
+@API(owner = PECore.MODID, apiVersion = ProjectEAPI.API_VERSION, provides = PECore.APINAME)
+package moze_intel.projecte.api;
+
+import cpw.mods.fml.common.API;
+import moze_intel.projecte.PECore;

--- a/src/main/java/moze_intel/projecte/api/package-info.java
+++ b/src/main/java/moze_intel/projecte/api/package-info.java
@@ -1,5 +1,8 @@
-@API(owner = PECore.MODID, apiVersion = ProjectEAPI.API_VERSION, provides = PECore.APINAME)
+/**
+ * Increment apiVersion every time the API changes.
+ * (Adding methods, removing methods, changing method signatures, etc.)
+ */
+@API(owner = "ProjectE", apiVersion = "1", provides = "ProjectEAPI")
 package moze_intel.projecte.api;
 
 import cpw.mods.fml.common.API;
-import moze_intel.projecte.PECore;


### PR DESCRIPTION
This PR adds the @API annotation onto the ProjectE API.
This means that mods can now safely include the PE API with more safety of mind from conflicts
It enforces that if ProjectE is present, regardless of the API version other addons include, the version provided by ProjectE will be used to process all PE API requests.

Looking to make an addon sometime soon so this'll help resolve conflicts.