### PR TITLE
Fix #565

### DIFF
--- a/src/main/java/moze_intel/projecte/PECore.java
+++ b/src/main/java/moze_intel/projecte/PECore.java
@@ -71,8 +71,11 @@ public class PECore
 		PacketHandler.register();
 		
 		NetworkRegistry.INSTANCE.registerGuiHandler(PECore.instance, new GuiHandler());
-		MinecraftForge.EVENT_BUS.register(new PlayerEvents());
-		
+
+		PlayerEvents pe = new PlayerEvents();
+		MinecraftForge.EVENT_BUS.register(pe);
+		FMLCommonHandler.instance().bus().register(pe);
+
 		FMLCommonHandler.instance().bus().register(new TickEvents());
 		FMLCommonHandler.instance().bus().register(new ConnectionHandler());
 		

--- a/src/main/java/moze_intel/projecte/events/PlayerEvents.java
+++ b/src/main/java/moze_intel/projecte/events/PlayerEvents.java
@@ -17,6 +17,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
@@ -36,16 +37,16 @@ public class PlayerEvents
 			Transmutation.sync((EntityPlayer) event.entity);
 			AlchemicalBags.sync((EntityPlayer) event.entity);
 			PacketHandler.sendTo(new ClientSyncTableEMCPKT(Transmutation.getStoredEmc(event.entity.getCommandSenderName())), (EntityPlayerMP) event.entity);
+		}
+	}
 
-			if (PECore.uuids.contains(((EntityPlayer)event.entity).getUniqueID().toString()))
-			{
-				ChatComponentText joinMsg = new ChatComponentText(EnumChatFormatting.BLUE + "High alchemist " + EnumChatFormatting.GOLD + ((EntityPlayer)event.entity).getDisplayName() + EnumChatFormatting.BLUE + " has joined the server." + EnumChatFormatting.RESET);
-
-				for (EntityPlayer player : (List<EntityPlayer>) event.entity.worldObj.playerEntities)
-				{
-					player.addChatComponentMessage(joinMsg);
-				}
-			}
+	@SubscribeEvent
+	public void onHighAlchemistJoin(cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent evt)
+	{
+		if (PECore.uuids.contains((evt.player.getUniqueID().toString())))
+		{
+			ChatComponentText joinMsg = new ChatComponentText(EnumChatFormatting.BLUE + "High alchemist " + EnumChatFormatting.GOLD + evt.player.getDisplayName() + EnumChatFormatting.BLUE + " has joined the server." + EnumChatFormatting.RESET);
+			MinecraftServer.getServer().getConfigurationManager().sendChatMsg(joinMsg); // Sends to all everywhere, not just same world like before.
 		}
 	}
 


### PR DESCRIPTION
Fix for https://github.com/sinkillerj/ProjectE/issues/565
Send HA join message only on Join, not death and respawn. Sends to all players on server, not just those in current dimension.