### PR TITLE
Fix for #550

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/EMCMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/EMCMapper.java
@@ -42,8 +42,11 @@ public final class EMCMapper
 		for(Iterator<Map.Entry<NormalizedSimpleStack, Integer>> iter = graphMapperValues.entrySet().iterator(); iter.hasNext();) {
 			Map.Entry<NormalizedSimpleStack, Integer> entry = iter.next();
 			NormalizedSimpleStack normStack = entry.getKey();
-			if (normStack.damage != OreDictionary.WILDCARD_VALUE && !( normStack instanceof NormalizedSimpleStack.Group) && entry.getValue() > 0) {
-				emc.put(new SimpleStack(normStack.id, 1, normStack.damage), entry.getValue());
+			if (normStack instanceof NormalizedSimpleStack.NSSItem && entry.getValue() > 0) {
+				NormalizedSimpleStack.NSSItem normStackItem = (NormalizedSimpleStack.NSSItem)normStack;
+				if (normStackItem.damage != OreDictionary.WILDCARD_VALUE) {
+					emc.put(new SimpleStack(normStackItem.id, 1, normStackItem.damage), entry.getValue());
+				}
 			}
 		}
 

--- a/src/main/java/moze_intel/projecte/emc/GraphMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/GraphMapper.java
@@ -113,6 +113,7 @@ public abstract class GraphMapper<T, V extends Comparable<V>> implements IMappin
 	 * @param type
 	 */
 	public void setValue(T something, V value, FixedValue type) {
+		if (something == null) return;
 		switch (type) {
 			case FixAndInherit:
 				if (fixValueBeforeInherit.containsKey(something))


### PR DESCRIPTION
Fix for #550

This was triggered by the FluidMapper, that tried to set a value for a `null`-Fluid.
(probably milk)

Also:
* Move itemId and metadata to `NormalizedSimpleStack.NSSItem`
* Refactor `Group` to `NSSGroup`
* Add `NormalizedSimpleStack.NSSFluid` for Fluids.
* EMCMapper only adds emc values for `NSSItems`

Tested wit `Mariculture-Deluxe-1.7.10-1.2.4.1` and  `TConstruct-1.7.10-1.8.2a`.
Crash is gone - the rest appeared to behave how it should.