### PR TITLE
Fix #518

### DIFF
--- a/src/main/java/moze_intel/projecte/network/PacketHandler.java
+++ b/src/main/java/moze_intel/projecte/network/PacketHandler.java
@@ -11,6 +11,7 @@ import moze_intel.projecte.network.packets.*;
 import moze_intel.projecte.utils.PELogger;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.Packet;
+import net.minecraftforge.common.util.FakePlayer;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -153,7 +154,10 @@ public final class PacketHandler
 	 */
 	public static void sendTo(IMessage msg, EntityPlayerMP player)
 	{
-		HANDLER.sendTo(msg, player);
+		if (!(player instanceof FakePlayer))
+		{
+			HANDLER.sendTo(msg, player);
+		}
 	}
 	
 	/**


### PR DESCRIPTION
Fix for https://github.com/sinkillerj/ProjectE/issues/518
Prevent packets from trying to be sent to FakePlayers.
This caused log spam and in some cases crashed the server (Let autonomous activator transmute with phil stone, take it out, try pressing V or any other key and it crashes)
Isssues are resolved after this patch