### PR TITLE
Fix #582

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/TimeWatch.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/TimeWatch.java
@@ -9,6 +9,7 @@ import moze_intel.projecte.gameObjs.tiles.DMPedestalTile;
 import moze_intel.projecte.utils.Utils;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
+import net.minecraft.block.IGrowable;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
@@ -27,6 +28,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import moze_intel.projecte.config.ProjectEConfig;
+import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.fluids.BlockFluidBase;
 
 import java.util.ArrayList;
@@ -220,7 +222,8 @@ public class TimeWatch extends ItemCharge implements IModeChanger, IBauble, IPed
 					if (block.getTickRandomly()
 							&& !(block instanceof BlockLiquid) // Don't speed vanilla non-source blocks - dupe issues
 							&& !(block instanceof BlockFluidBase) // Don't speed Forge fluids - just in case of dupes as well
-
+							&& !(block instanceof IGrowable)
+							&& !(block instanceof IPlantable) // All plants should be sped using Harvest Goddess
 						)
 					{
 						for (int i = 0; i < bonusTicks; i++)

--- a/src/main/java/moze_intel/projecte/gameObjs/items/TimeWatch.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/TimeWatch.java
@@ -195,7 +195,10 @@ public class TimeWatch extends ItemCharge implements IModeChanger, IBauble, IPed
 			}
 			for (int i = 0; i < bonusTicks; i++)
 			{
-				tile.updateEntity();
+				if (!tile.isInvalid())
+				{
+					tile.updateEntity();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
1. Check if a tile entity is valid before giving it bonus ticks. Fixes https://github.com/sinkillerj/ProjectE/issues/582 and probably a zillion billion other crashes that haven't happened yet.

2. Nerf the ability to give random block updates to only non-IGrowables and/or IPlantables (so basically, ice, vines, and some other miscellanea). Prevents feature redundancy/overlap with the harvest goddess, which players should use if they want to speed up plants