### PR TITLE
Fix covalence dust repairing #601

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/customRecipes/RecipesCovalenceRepair.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/customRecipes/RecipesCovalenceRepair.java
@@ -6,8 +6,6 @@ import net.minecraft.item.*;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.world.World;
 
-import java.util.Arrays;
-
 public class RecipesCovalenceRepair implements IRecipe
 {
 	private ItemStack output;

--- a/src/main/java/moze_intel/projecte/gameObjs/customRecipes/RecipesCovalenceRepair.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/customRecipes/RecipesCovalenceRepair.java
@@ -2,18 +2,11 @@ package moze_intel.projecte.gameObjs.customRecipes;
 
 import moze_intel.projecte.gameObjs.ObjHandler;
 import net.minecraft.inventory.InventoryCrafting;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemArmor;
-import net.minecraft.item.ItemBow;
-import net.minecraft.item.ItemFishingRod;
-import net.minecraft.item.ItemFlintAndSteel;
-import net.minecraft.item.ItemHoe;
-import net.minecraft.item.ItemShears;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemSword;
-import net.minecraft.item.ItemTool;
+import net.minecraft.item.*;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.world.World;
+
+import java.util.Arrays;
 
 public class RecipesCovalenceRepair implements IRecipe
 {
@@ -22,7 +15,7 @@ public class RecipesCovalenceRepair implements IRecipe
 	@Override
 	public boolean matches(InventoryCrafting inv, World world) 
 	{
-		ItemStack[] dust = new ItemStack[3];
+		ItemStack[] dust = new ItemStack[8];
 		ItemStack tool = null;
 		boolean foundItem = false;
 		int dustCounter = 0;
@@ -50,7 +43,7 @@ public class RecipesCovalenceRepair implements IRecipe
 			}
 			else if (input.getItem() == ObjHandler.covalence)
 			{
-				if (dustCounter < 3)
+				if (dustCounter < 8)
 				{
 					dust[dustCounter] = input;
 					dustCounter++;
@@ -67,23 +60,18 @@ public class RecipesCovalenceRepair implements IRecipe
 			return false;
 		}
 
-		if (dustCounter < 3)
+		if (!correctDustCount(dustCounter, tool.getItem()))
 		{
 			return false;
 		}
-		
+
 		int dustDamage = getDustType(tool);
 		
-		for (int i = 0; i < 3; i++)
+		for (int i = 0; i < dust.length; i++)
 		{
 			ItemStack stack = dust[i];
 
-			if (stack == null)
-			{
-				return false;
-			}
-
-			if (stack.getItemDamage() < dustDamage)
+			if (stack != null && stack.getItemDamage() < dustDamage)
 			{
 				return false;
 			}
@@ -91,10 +79,44 @@ public class RecipesCovalenceRepair implements IRecipe
 		
 		output = tool.copy();
 		output.setItemDamage(0);
-		
 		return true;
 	}
-	
+
+	private boolean correctDustCount(int dustCounter, Item toRepair)
+	{
+		if (toRepair instanceof ItemSpade || toRepair instanceof ItemShears
+				|| toRepair instanceof ItemFlintAndSteel || toRepair instanceof ItemFishingRod)
+		{
+			return dustCounter == 1;
+		}
+
+		if (toRepair instanceof ItemSword)
+		{
+			return dustCounter == 2;
+		}
+
+		if (toRepair instanceof ItemAxe || toRepair instanceof ItemPickaxe || toRepair instanceof ItemBow)
+		{
+			return dustCounter == 3;
+		}
+
+		if (toRepair instanceof ItemArmor)
+		{
+			ItemArmor armor = ((ItemArmor) toRepair);
+			switch(armor.armorType)
+			{
+				case 0: return dustCounter == 5;
+				case 1: return dustCounter == 8;
+				case 2: return dustCounter == 7;
+				case 3: return dustCounter == 4;
+				default: return false;
+			}
+		}
+
+		return false;
+
+	}
+
 	private boolean isItemRepairable(ItemStack stack)
 	{
 		if (stack.getHasSubtypes())

--- a/src/main/java/moze_intel/projecte/gameObjs/customRecipes/RecipesCovalenceRepair.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/customRecipes/RecipesCovalenceRepair.java
@@ -2,7 +2,19 @@ package moze_intel.projecte.gameObjs.customRecipes;
 
 import moze_intel.projecte.gameObjs.ObjHandler;
 import net.minecraft.inventory.InventoryCrafting;
-import net.minecraft.item.*;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemArmor;
+import net.minecraft.item.ItemAxe;
+import net.minecraft.item.ItemBow;
+import net.minecraft.item.ItemFishingRod;
+import net.minecraft.item.ItemFlintAndSteel;
+import net.minecraft.item.ItemHoe;
+import net.minecraft.item.ItemPickaxe;
+import net.minecraft.item.ItemShears;
+import net.minecraft.item.ItemSpade;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemSword;
+import net.minecraft.item.ItemTool;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.world.World;
 

--- a/src/main/java/moze_intel/projecte/gameObjs/customRecipes/RecipesCovalenceRepair.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/customRecipes/RecipesCovalenceRepair.java
@@ -111,7 +111,7 @@ public class RecipesCovalenceRepair implements IRecipe
 			}
 		}
 
-		return false;
+		return dustCounter == 3;
 
 	}
 


### PR DESCRIPTION
Fix https://github.com/sinkillerj/ProjectE/issues/601

Before this commit:
Repairing items with covalence dust consumed 3 dust all the time, without regard for tool class. Dust was still tier checked (high for diamond, med for iron, etc.)

After this commit:
Original EE2 behavior has been restored. Tools and armor take the number of ingots used to make them to repair. Bows take 3 low, Rods take 1 low, and Shears and Flint and Steel take 1 medium.
Tier checking still present, though higher tier dusts can be used to repair lower tier tool types.