### PR TITLE
"Fix" #629. Also log how long EMC (re)mapping takes.

### DIFF
--- a/src/main/java/moze_intel/projecte/PECore.java
+++ b/src/main/java/moze_intel/projecte/PECore.java
@@ -124,7 +124,15 @@ public class PECore
 			new ThreadCheckUUID(true).start();
 		}
 
-		ThreadReloadEMCMap.runEMCRemap(true, null);
+		long start = System.currentTimeMillis();
+
+		CustomEMCParser.readUserData();
+
+		PELogger.logInfo("Starting server-side EMC mapping.");
+
+		EMCMapper.map();
+
+		PELogger.logInfo("Registered " + EMCMapper.emc.size() + " EMC values. (in " + (System.currentTimeMillis() - start) + " ms)");
 		
 		File dir = new File(event.getServer().getEntityWorld().getSaveHandler().getWorldDirectory(), "ProjectE");
 		

--- a/src/main/java/moze_intel/projecte/emc/ThreadReloadEMCMap.java
+++ b/src/main/java/moze_intel/projecte/emc/ThreadReloadEMCMap.java
@@ -8,38 +8,29 @@ import moze_intel.projecte.network.PacketHandler;
 import moze_intel.projecte.utils.PELogger;
 
 public class ThreadReloadEMCMap extends Thread {
-	private boolean serverStarting;
 	private World world;
 
 	/**
-	 * Runs the EMC Remap. If serverStarting is true, world can safely be null.
-	 * @param serverStarting true if this is being run when the server is starting up.
-	 * @param world The world; used for checking the condensers after an EMC remap. Can be null if serverStarting is true.
+	 * Runs the EMC Remap.
+	 * @param world The world; used for checking the condensers after an EMC remap.
 	 */
-	public static void runEMCRemap(boolean serverStarting, World world) {
-		new ThreadReloadEMCMap(serverStarting, world).start();
+	public static void runEMCRemap(World world) {
+		new ThreadReloadEMCMap(world).start();
 	}
 
-	private ThreadReloadEMCMap(boolean serverStarting, World world) {
+	private ThreadReloadEMCMap(World world) {
 		super("ProjectE Reload EMC Thread");
-		this.serverStarting = serverStarting;
 		this.world = world;
 	}
 
 	@Override
 	public void run() {
-		if (serverStarting) {
-			PELogger.logInfo("Starting server-side EMC mapping.");
-		} else {
-			EMCMapper.clearMaps();
-		}
+		long start = System.currentTimeMillis();
+		EMCMapper.clearMaps();
 		CustomEMCParser.readUserData();
 		EMCMapper.map();
-		if (serverStarting) {
-			PELogger.logInfo("Registered " + EMCMapper.emc.size() + " EMC values.");
-		} else {
-			TileEntityHandler.checkAllCondensers(world);
-			PacketHandler.sendFragmentedEmcPacketToAll();
-		}
+		TileEntityHandler.checkAllCondensers(world);
+		PacketHandler.sendFragmentedEmcPacketToAll();
+		PELogger.logInfo("Thread ran for " + (System.currentTimeMillis() - start) + " ms.");
 	}
 }

--- a/src/main/java/moze_intel/projecte/network/commands/ReloadEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ReloadEmcCMD.java
@@ -23,7 +23,7 @@ public class ReloadEmcCMD extends ProjectEBaseCMD
 	{
 		sender.addChatMessage(new ChatComponentText("[ProjectE] Reloading EMC registrations..."));
 
-		ThreadReloadEMCMap.runEMCRemap(false, sender.getEntityWorld());
+		ThreadReloadEMCMap.runEMCRemap(sender.getEntityWorld());
 	}
 
 	@Override

--- a/src/main�java/moze_intel/projecte/network/commands/RemoveEmcCMD.java
+++ b/src/main�java/moze_intel/projecte/network/commands/RemoveEmcCMD.java
@@ -1,0 +1,75 @@
+package moze_intel.projecte.network.commands;
+
+import moze_intel.projecte.config.CustomEMCParser;
+import moze_intel.projecte.emc.ThreadReloadEMCMap;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+public class RemoveEmcCMD extends ProjectEBaseCMD
+{
+	@Override
+	public String getCommandName() 
+	{
+		return "projecte_removeEMC";
+	}
+
+	@Override
+	public String getCommandUsage(ICommandSender sender) 
+	{
+		return "/projecte_removeEMC <unlocalized/ore-dictionary name> <metadata (optional)>";
+	}
+	
+	@Override
+	public int getRequiredPermissionLevel() 
+	{
+		return 4;
+	}
+
+	@Override
+	public void processCommand(ICommandSender sender, String[] params) 
+	{
+		String name = "";
+		int meta = 0;
+
+		if (params.length == 0)
+		{
+			ItemStack heldItem = getCommandSenderAsPlayer(sender).getHeldItem();
+
+			if (heldItem == null)
+			{
+				sendError(sender, "Error: player isn't holding any item!");
+				return;
+			}
+
+			name = Item.itemRegistry.getNameForObject(heldItem.getItem());
+			meta = heldItem.getItemDamage();
+		}
+		else
+		{
+			name = params[0];
+
+			if (params.length > 1)
+			{
+				meta = parseInteger(params[1]);
+
+				if (meta < 0)
+				{
+					sendError(sender, "Error: the metadata passed (" + params[1] + ") is not a valid number!");
+					return;
+				}
+			}
+		}
+
+		if (CustomEMCParser.addToFile(name, meta, 0))
+		{
+			ThreadReloadEMCMap.runEMCRemap(sender.getEntityWorld());
+
+			sendSuccess(sender, "Removed EMC value for: " + name);
+		}
+		else
+		{
+			sendError(sender, "Error: couldn't find any valid items for: " + name);
+		}
+	}
+}

--- a/src/main�java/moze_intel/projecte/network/commands/ResetEmcCMD.java
+++ b/src/main�java/moze_intel/projecte/network/commands/ResetEmcCMD.java
@@ -1,0 +1,75 @@
+package moze_intel.projecte.network.commands;
+
+import moze_intel.projecte.config.CustomEMCParser;
+import moze_intel.projecte.emc.ThreadReloadEMCMap;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+public class ResetEmcCMD extends ProjectEBaseCMD
+{
+	@Override
+	public String getCommandName() 
+	{
+		return "projecte_resetEMC";
+	}
+
+	@Override
+	public String getCommandUsage(ICommandSender sender) 
+	{
+		return "/projecte_resetEMC <unlocalized/ore-dictionary name> <metada (optional)>";
+	}
+	
+	@Override
+	public int getRequiredPermissionLevel() 
+	{
+		return 4;
+	}
+
+	@Override
+	public void processCommand(ICommandSender sender, String[] params) 
+	{
+		String name = "";
+		int meta = 0;
+
+		if (params.length == 0)
+		{
+			ItemStack heldItem = getCommandSenderAsPlayer(sender).getHeldItem();
+
+			if (heldItem == null)
+			{
+				sendError(sender, "Error: player isn't holding any item!");
+				return;
+			}
+
+			name = Item.itemRegistry.getNameForObject(heldItem.getItem());
+			meta = heldItem.getItemDamage();
+		}
+		else
+		{
+			name = params[0];
+
+			if (params.length > 1)
+			{
+				meta = parseInteger(params[1]);
+
+				if (meta < 0)
+				{
+					sendError(sender, "Error: the metadata passed (" + params[1] + ") is not a valid number!");
+					return;
+				}
+			}
+		}
+
+		if (CustomEMCParser.removeFromFile(name, meta))
+		{
+			ThreadReloadEMCMap.runEMCRemap(sender.getEntityWorld());
+
+			sendSuccess(sender, "Reset EMC value for: " + name);
+		}
+		else
+		{
+			sendError(sender, "The EMC for " + name + "," + meta + " has not been modified!");
+		}
+	}
+}

--- a/src/main�java/moze_intel/projecte/network/commands/SetEmcCMD.java
+++ b/src/main�java/moze_intel/projecte/network/commands/SetEmcCMD.java
@@ -1,0 +1,121 @@
+package moze_intel.projecte.network.commands;
+
+import moze_intel.projecte.config.CustomEMCParser;
+import moze_intel.projecte.emc.ThreadReloadEMCMap;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+public class SetEmcCMD extends ProjectEBaseCMD
+{
+	@Override
+	public String getCommandName() 
+	{
+		return "projecte_setEMC";
+	}
+
+	@Override
+	public String getCommandUsage(ICommandSender sender) 
+	{
+		return "/projecte_setEMC <unlocalized-name/ore dictionary name> <metadata (optional)> <EMC value>";
+	}
+	
+	@Override
+	public int getRequiredPermissionLevel() 
+	{
+		return 4;
+	}
+
+	@Override
+	public void processCommand(ICommandSender sender, String[] params) 
+	{
+		if (params.length < 1)
+		{
+			sendError(sender, "Error: command needs parameters!");
+			return;
+		}
+
+		String name;
+		int meta;
+		int emc;
+
+		if (params.length == 1)
+		{
+			ItemStack heldItem = getCommandSenderAsPlayer(sender).getHeldItem();
+
+			if (heldItem == null)
+			{
+				sendError(sender, "Error: player isn't holding any item!");
+				return;
+			}
+
+			name = Item.itemRegistry.getNameForObject(heldItem.getItem());
+			meta = heldItem.getItemDamage();
+			emc = parseInteger(params[0]);
+
+			if (emc < 0)
+			{
+				sendError(sender, "Error: " + params[0] + " isn't a valid number!");
+			}
+		}
+		else
+		{
+			name = params[0];
+			meta = 0;
+			boolean isOD = !name.contains(":");
+
+			if (!isOD)
+			{
+				if (params.length > 2)
+				{
+					meta = parseInteger(params[1]);
+
+					if (meta < 0)
+					{
+						sendError(sender, "Error: " + params[1] + " isn't a valid number!");
+						return;
+					}
+
+					emc = parseInteger(params[2]);
+
+					if (emc < 0)
+					{
+						sendError(sender, "Error: " + params[1] + " isn't a valid number!");
+						return;
+					}
+				}
+				else
+				{
+					emc = parseInteger(params[1]);
+
+					if (emc < 0)
+					{
+						sendError(sender, "Error: " + params[1] + " isn't a valid number!");
+						return;
+					}
+				}
+			}
+			else
+			{
+				emc = parseInteger(params[1]);
+
+				if (emc < 0)
+				{
+					sendError(sender, "Error: " + params[1] + " isn't a valid number!");
+					return;
+				}
+			}
+		}
+
+		if (CustomEMCParser.addToFile(name, meta, emc))
+		{
+			ThreadReloadEMCMap.runEMCRemap(sender.getEntityWorld());
+
+			sendSuccess(sender, "Registered EMC value for: " + name + "(" + emc + ")");
+		}
+		else
+		{
+			sendError(sender, "Error: couldn't find any valid items for: " + name);
+		}
+	}
+}


### PR DESCRIPTION
"Fix", as in, don't thread ServerStarting. Still think others shouldn't be registering recipes during that phase, but also, users should be able to have EMC values for their stuff. So, yea.

Also, at the request of @MaPePeR, the thread, along with ServerStarting, logs how long it took to (re)map the EMC values.