### PR TITLE
"Fix" #629. Also log how long EMC (re)mapping takes.

### DIFF
--- a/src/main/java/moze_intel/projecte/PECore.java
+++ b/src/main/java/moze_intel/projecte/PECore.java
@@ -136,7 +136,15 @@ public class PECore
 			new ThreadCheckUUID(true).start();
 		}
 
-		ThreadReloadEMCMap.runEMCRemap(true, null);
+		long start = System.currentTimeMillis();
+
+		CustomEMCParser.readUserData();
+
+		PELogger.logInfo("Starting server-side EMC mapping.");
+
+		EMCMapper.map();
+
+		PELogger.logInfo("Registered " + EMCMapper.emc.size() + " EMC values. (took " + (System.currentTimeMillis() - start) + " ms)");
 		
 		File dir = new File(event.getServer().getEntityWorld().getSaveHandler().getWorldDirectory(), "ProjectE");
 		

--- a/src/main/java/moze_intel/projecte/emc/ThreadReloadEMCMap.java
+++ b/src/main/java/moze_intel/projecte/emc/ThreadReloadEMCMap.java
@@ -7,38 +7,29 @@ import moze_intel.projecte.utils.PELogger;
 import net.minecraft.world.World;
 
 public class ThreadReloadEMCMap extends Thread {
-	private boolean serverStarting;
 	private World world;
 
 	/**
-	 * Runs the EMC Remap. If serverStarting is true, world can safely be null.
-	 * @param serverStarting true if this is being run when the server is starting up.
-	 * @param world The world; used for checking the condensers after an EMC remap. Can be null if serverStarting is true.
+	 * Runs the EMC Remap.
+	 * @param world The world; used for checking the condensers after an EMC remap.
 	 */
-	public static void runEMCRemap(boolean serverStarting, World world) {
-		new ThreadReloadEMCMap(serverStarting, world).start();
+	public static void runEMCRemap(World world) {
+		new ThreadReloadEMCMap(world).start();
 	}
 
-	private ThreadReloadEMCMap(boolean serverStarting, World world) {
+	private ThreadReloadEMCMap(World world) {
 		super("ProjectE Reload EMC Thread");
-		this.serverStarting = serverStarting;
 		this.world = world;
 	}
 
 	@Override
 	public void run() {
-		if (serverStarting) {
-			PELogger.logInfo("Starting server-side EMC mapping.");
-		} else {
-			EMCMapper.clearMaps();
-		}
+		long start = System.currentTimeMillis();
+		EMCMapper.clearMaps();
 		CustomEMCParser.readUserData();
 		EMCMapper.map();
-		if (serverStarting) {
-			PELogger.logInfo("Registered " + EMCMapper.emc.size() + " EMC values.");
-		} else {
-			TileEntityHandler.checkAllCondensers(world);
-			PacketHandler.sendFragmentedEmcPacketToAll();
-		}
+		TileEntityHandler.checkAllCondensers(world);
+		PacketHandler.sendFragmentedEmcPacketToAll();
+		PELogger.logInfo("Thread ran for " + (System.currentTimeMillis() - start) + " ms.");
 	}
 }

--- a/src/main/java/moze_intel/projecte/network/commands/ReloadEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ReloadEmcCMD.java
@@ -23,7 +23,7 @@ public class ReloadEmcCMD extends ProjectEBaseCMD
 	public void processCommand(ICommandSender sender, String[] params) 
 	{
 		sender.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("pe.command.reload.started")));
-		ThreadReloadEMCMap.runEMCRemap(false, sender.getEntityWorld());
+		ThreadReloadEMCMap.runEMCRemap(sender.getEntityWorld());
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/network/commands/RemoveEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/RemoveEmcCMD.java
@@ -65,7 +65,7 @@ public class RemoveEmcCMD extends ProjectEBaseCMD
 
 		if (CustomEMCParser.addToFile(name, meta, 0))
 		{
-			ThreadReloadEMCMap.runEMCRemap(false, sender.getEntityWorld());
+			ThreadReloadEMCMap.runEMCRemap(sender.getEntityWorld());
 
 			sendSuccess(sender, String.format(StatCollector.translateToLocal("pe.command.remove.success"), name));
 		}

--- a/src/main/java/moze_intel/projecte/network/commands/ResetEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ResetEmcCMD.java
@@ -65,7 +65,7 @@ public class ResetEmcCMD extends ProjectEBaseCMD
 
 		if (CustomEMCParser.removeFromFile(name, meta))
 		{
-			ThreadReloadEMCMap.runEMCRemap(false, sender.getEntityWorld());
+			ThreadReloadEMCMap.runEMCRemap(sender.getEntityWorld());
 
 			sendSuccess(sender, String.format(StatCollector.translateToLocal("pe.command.reset.success"), name));
 		}

--- a/src/main/java/moze_intel/projecte/network/commands/SetEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/SetEmcCMD.java
@@ -111,7 +111,7 @@ public class SetEmcCMD extends ProjectEBaseCMD
 
 		if (CustomEMCParser.addToFile(name, meta, emc))
 		{
-			ThreadReloadEMCMap.runEMCRemap(false, sender.getEntityWorld());
+			ThreadReloadEMCMap.runEMCRemap(sender.getEntityWorld());
 
 			sendSuccess(sender, String.format(StatCollector.translateToLocal("pe.command.set.success"), name, emc));
 		}


### PR DESCRIPTION
"Fix", as in, don't thread ServerStarting. Still think others shouldn't be registering recipes during that phase, but also, users should be able to have EMC values for their stuff. So, yea.

Also, at the request of @MaPePeR, the thread, along with ServerStarting, logs how long it took to (re)map the EMC values.

Take 2.