### PR TITLE
Miscellaneous Tweaks 2 - Updated version of PR#603

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/AlchemicalBag.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/AlchemicalBag.java
@@ -11,6 +11,7 @@ import moze_intel.projecte.playerData.AlchemicalBags;
 import moze_intel.projecte.utils.AchievementHandler;
 import moze_intel.projecte.utils.Constants;
 import moze_intel.projecte.utils.ItemHelper;
+import moze_intel.projecte.utils.WorldHelper;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
@@ -66,7 +67,7 @@ public class AlchemicalBag extends ItemPE
 	@Override
 	public void onUpdate(ItemStack stack, World world, Entity entity, int par4, boolean par5) 
 	{
-		if (world.isRemote || !(entity instanceof EntityPlayer))
+		if (!(entity instanceof EntityPlayer))
 		{
 			return;
 		}
@@ -82,35 +83,22 @@ public class AlchemicalBag extends ItemPE
 			for (EntityItem item : itemList)
 			{
 				item.delayBeforeCanPickup = 0;
-				double d1 = (player.posX - item.posX);
-				double d2 = (player.posY + (double)player.getEyeHeight() - item.posY);
-				double d3 = (player.posZ - item.posZ);
-				double d4 = Math.sqrt(d1 * d1 + d2 * d2 + d3 * d3);
-
-				item.motionX += d1 / d4 * 0.1D;
-				item.motionY += d2 / d4 * 0.1D;
-				item.motionZ += d3 / d4 * 0.1D;
-					
-				item.moveEntity(item.motionX, item.motionY, item.motionZ);
+				WorldHelper.gravitateEntityTowards(item, player.posX, player.posY, player.posZ);
 			}
 			
 			List<EntityLootBall> lootBallList = world.getEntitiesWithinAABB(EntityLootBall.class, bBox);
 			
 			for (EntityLootBall ball : lootBallList)
 			{
-				double d1 = (player.posX - ball.posX);
-				double d2 = (player.posY + (double)player.getEyeHeight() - ball.posY);
-				double d3 = (player.posZ - ball.posZ);
-				double d4 = Math.sqrt(d1 * d1 + d2 * d2 + d3 * d3);
-
-				ball.motionX += d1 / d4 * 0.1D;
-				ball.motionY += d2 / d4 * 0.1D;
-				ball.motionZ += d3 / d4 * 0.1D;
-					
-				ball.moveEntity(ball.motionX, ball.motionY, ball.motionZ);
+				WorldHelper.gravitateEntityTowards(ball, player.posX, player.posY, player.posZ);
 			}
 		}
-		
+
+		if (world.isRemote)
+		{
+			return;
+		}
+
 		ItemStack rTalisman = ItemHelper.getStackFromInv(inv, new ItemStack(ObjHandler.repairTalisman));
 		
 		if (rTalisman != null)

--- a/src/main/java/moze_intel/projecte/gameObjs/items/EvertideAmulet.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/EvertideAmulet.java
@@ -22,6 +22,7 @@ import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -104,7 +105,11 @@ public class EvertideAmulet extends ItemPE implements IProjectileShooter, IBaubl
 						default: break;
                     }
 
-					placeWater(world, i, j, k);
+					if (world.isAirBlock(i, j, k))
+					{
+						placeWater(world, i, j, k);
+					}
+					PlayerHelper.swingItem(((EntityPlayerMP) player));
 				}
 			}
 		}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/VolcaniteAmulet.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/VolcaniteAmulet.java
@@ -96,9 +96,10 @@ public class VolcaniteAmulet extends ItemPE implements IProjectileShooter, IBaub
 						default: break;
 					}
 
-					if (consumeFuel(player, stack, 32, true))
+					if (world.isAirBlock(i, j, k) && consumeFuel(player, stack, 32, true))
 					{
 						placeLava(world, i, j, k);
+						PlayerHelper.swingItem(((EntityPlayerMP) player));
 					}
 				}
 			}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/BlackHoleBand.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/BlackHoleBand.java
@@ -46,7 +46,7 @@ public class BlackHoleBand extends RingToggle implements IBauble, IPedestalItem
 	@Override
 	public void onUpdate(ItemStack stack, World world, Entity entity, int par4, boolean par5) 
 	{
-		if (world.isRemote || stack.getItemDamage() != 1 || !(entity instanceof EntityPlayer)) 
+		if (stack.getItemDamage() != 1 || !(entity instanceof EntityPlayer))
 		{
 			return;
 		}
@@ -59,17 +59,7 @@ public class BlackHoleBand extends RingToggle implements IBauble, IPedestalItem
 		{
 			if (ItemHelper.hasSpace(player.inventory.mainInventory, item.getEntityItem()))
 			{
-				item.delayBeforeCanPickup = 0;
-				double d1 = (player.posX - item.posX);
-				double d2 = (player.posY + (double)player.getEyeHeight() - item.posY);
-				double d3 = (player.posZ - item.posZ);
-				double d4 = Math.sqrt(d1 * d1 + d2 * d2 + d3 * d3);
-
-				item.motionX += d1 / d4 * 0.1D;
-				item.motionY += d2 / d4 * 0.1D;
-				item.motionZ += d3 / d4 * 0.1D;
-				
-				item.moveEntity(item.motionX, item.motionY, item.motionZ);
+				WorldHelper.gravitateEntityTowards(item, player.posX, player.posY, player.posZ);
 			}
 		}
 		
@@ -77,16 +67,7 @@ public class BlackHoleBand extends RingToggle implements IBauble, IPedestalItem
 		
 		for (EntityLootBall ball : ballList)
 		{
-			double d1 = (player.posX - ball.posX);
-			double d2 = (player.posY + (double)player.getEyeHeight() - ball.posY);
-			double d3 = (player.posZ - ball.posZ);
-			double d4 = Math.sqrt(d1 * d1 + d2 * d2 + d3 * d3);
-
-			ball.motionX += d1 / d4 * 0.1D;
-			ball.motionY += d2 / d4 * 0.1D;
-			ball.motionZ += d3 / d4 * 0.1D;
-			
-			ball.moveEntity(ball.motionX, ball.motionY, ball.motionZ);
+			WorldHelper.gravitateEntityTowards(ball, player.posX, player.posY, player.posZ);
 		}
 	}
 
@@ -135,25 +116,10 @@ public class BlackHoleBand extends RingToggle implements IBauble, IPedestalItem
 			List<EntityItem> list = world.getEntitiesWithinAABB(EntityItem.class, tile.getEffectBounds());
 			for (EntityItem item : list)
 			{
-				// Adapted from openBlocks and vanilla
-				double dX = (x + 0.5 - item.posX);
-				double dY = (y + 0.5 - item.posY);
-				double dZ = (z + 0.5 - item.posZ);
-				double dist = Math.sqrt(dX * dX + dY * dY + dZ * dZ);
-
-				if (dist < 1.1 && !world.isRemote)
+				WorldHelper.gravitateEntityTowards(item, x + 0.5, y + 0.5, z + 0.5);
+				if (!world.isRemote && item.getDistanceSq(x + 0.5, y + 0.5, z + 0.5) < 1.21)
 				{
 					suckDumpItem(item, tile);
-				}
-
-				double vel = 1.0 - dist / 15.0;
-				if (vel > 0.0D)
-				{
-					vel *= vel;
-					item.motionX += dX / dist * vel * 0.05;
-					item.motionY += dY / dist * vel * 0.2;
-					item.motionZ += dZ / dist * vel * 0.05;
-					item.moveEntity(item.motionX, item.motionY, item.motionZ);
 				}
 			}
 		}
@@ -183,10 +149,10 @@ public class BlackHoleBand extends RingToggle implements IBauble, IPedestalItem
 	@Override
 	public List<String> getPedestalDescription()
 	{
-		List<String> list = Lists.newArrayList();
-		list.add(EnumChatFormatting.BLUE + StatCollector.translateToLocal("pe.bhb.pedestal1"));
-		list.add(EnumChatFormatting.BLUE + StatCollector.translateToLocal("pe.bhb.pedestal2"));
-		return list;
+		return Lists.newArrayList(
+				EnumChatFormatting.BLUE + StatCollector.translateToLocal("pe.bhb.pedestal1"),
+				EnumChatFormatting.BLUE + StatCollector.translateToLocal("pe.bhb.pedestal2")
+		);
 	}
 
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/Ignition.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/Ignition.java
@@ -8,6 +8,7 @@ import moze_intel.projecte.api.IPedestalItem;
 import moze_intel.projecte.config.ProjectEConfig;
 import moze_intel.projecte.gameObjs.tiles.DMPedestalTile;
 import moze_intel.projecte.utils.MathUtils;
+import net.minecraft.block.BlockTNT;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
@@ -16,6 +17,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
@@ -96,7 +98,26 @@ public class Ignition extends RingToggle implements IBauble, IPedestalItem
 			stack.setItemDamage(0);
 		}
 	}
-	
+
+	@Override
+	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player)
+	{
+		if (!world.isRemote)
+		{
+			MovingObjectPosition mop = getMovingObjectPositionFromPlayer(world, player, false);
+			if (mop != null && mop.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK)
+			{
+				if (world.getBlock(mop.blockX, mop.blockY, mop.blockZ) instanceof BlockTNT)
+				{
+					// Ignite TNT or derivatives
+					((BlockTNT) world.getBlock(mop.blockX, mop.blockY, mop.blockZ)).func_150114_a(world, mop.blockX, mop.blockY, mop.blockZ, 1, player);
+					world.setBlockToAir(mop.blockX, mop.blockY, mop.blockZ);
+				}
+			}
+		}
+		return stack;
+	}
+
 	@Override
 	@Optional.Method(modid = "Baubles")
 	public baubles.api.BaubleType getBaubleType(ItemStack itemstack)

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/AlchChestTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/AlchChestTile.java
@@ -5,6 +5,7 @@ import moze_intel.projecte.gameObjs.entity.EntityLootBall;
 import moze_intel.projecte.gameObjs.items.GemEternalDensity;
 import moze_intel.projecte.gameObjs.items.rings.RingToggle;
 import moze_intel.projecte.utils.ItemHelper;
+import moze_intel.projecte.utils.WorldHelper;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
@@ -265,15 +266,15 @@ public class AlchChestTile extends TileEmcDirection implements IInventory
 			
 			for (EntityItem item : itemList)
 			{
-				if (getDistance(item.posX, item.posY, item.posZ) <= 0.5f)
+				if (item.getDistanceSq(xCoord + 0.5, yCoord + 0.5, zCoord + 0.5) < 1.21)
 				{
 					if (!this.worldObj.isRemote)
 					{
-					
+
 						if (ItemHelper.hasSpace(this, item.getEntityItem()))
 						{
 							ItemStack remain = ItemHelper.pushStackInInv(this, item.getEntityItem());
-							
+
 							if (remain == null)
 							{
 								item.setDead();
@@ -283,36 +284,27 @@ public class AlchChestTile extends TileEmcDirection implements IInventory
 				}
 				else
 				{
-					double d1 = (this.xCoord - item.posX);
-					double d2 = (this.yCoord - item.posY);
-					double d3 = (this.zCoord - item.posZ);
-					double d4 = Math.sqrt(d1 * d1 + d2 * d2 + d3 * d3);
-
-					item.motionX += d1 / d4 * 0.1D;
-					item.motionY += d2 / d4 * 0.1D;
-					item.motionZ += d3 / d4 * 0.1D;
-						
-					item.moveEntity(item.motionX, item.motionY, item.motionZ);
+					WorldHelper.gravitateEntityTowards(item, xCoord + 0.5, yCoord + 0.5, zCoord + 0.5);
 				}
 			}
 			
 			for (EntityLootBall loot : lootList)
 			{
-				if (getDistance(loot.posX, loot.posY, loot.posZ) <= 0.5f)
+				if (loot.getDistanceSq(xCoord + 0.5, yCoord + 0.5, zCoord + 0.5) < 1.21)
 				{
 					if (!this.worldObj.isRemote)
 					{
 						//Avoids concurrent modification exception
 						Iterator<ItemStack> iter = loot.getItemList().iterator();
-						
+
 						while (iter.hasNext())
 						{
 							ItemStack current = iter.next();
-							
+
 							if (ItemHelper.hasSpace(this, current))
 							{
 								ItemStack remain = ItemHelper.pushStackInInv(this, current);
-								
+
 								if (remain == null)
 								{
 									iter.remove();
@@ -323,24 +315,10 @@ public class AlchChestTile extends TileEmcDirection implements IInventory
 				}
 				else
 				{
-					double d1 = (this.xCoord - loot.posX);
-					double d2 = (this.yCoord - loot.posY);
-					double d3 = (this.zCoord - loot.posZ);
-					double d4 = Math.sqrt(d1 * d1 + d2 * d2 + d3 * d3);
-
-					loot.motionX += d1 / d4 * 0.1D;
-					loot.motionY += d2 / d4 * 0.1D;
-					loot.motionZ += d3 / d4 * 0.1D;
-						
-					loot.moveEntity(loot.motionX, loot.motionY, loot.motionZ);
+					WorldHelper.gravitateEntityTowards(loot, xCoord + 0.5, yCoord + 0.5, zCoord + 0.5);
 				}
 			}
 		}
-	}
-	
-	private double getDistance(double x, double y, double z)
-	{
-		return Math.sqrt((Math.pow((this.xCoord - x), 2) + Math.pow((this.yCoord - y), 2) + Math.pow((this.zCoord - z), 2)));
 	}
 	
 	@Override

--- a/src/main/java/moze_intel/projecte/utils/WorldHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/WorldHelper.java
@@ -271,6 +271,28 @@ public final class WorldHelper
 	}
 
 	/**
+	 * Gravitates an entity, vanilla xp orb style, towards a position
+	 * Code adapted from EntityXPOrb and OpenBlocks Vacuum Hopper, mostly the former
+	 */
+	public static void gravitateEntityTowards(Entity ent, double x, double y, double z)
+	{
+		double dX = x - ent.posX;
+		double dY = y - ent.posY;
+		double dZ = z - ent.posZ;
+		double dist = Math.sqrt(dX * dX + dY * dY + dZ * dZ);
+
+		double vel = 1.0 - dist / 15.0;
+		if (vel > 0.0D)
+		{
+			vel *= vel;
+			ent.motionX += dX / dist * vel * 0.05;
+			ent.motionY += dY / dist * vel * 0.1;
+			ent.motionZ += dZ / dist * vel * 0.05;
+			ent.moveEntity(ent.motionX, ent.motionY, ent.motionZ);
+		}
+	}
+
+	/**
 	 * Recursively mines out a vein of the given Block, starting from the provided coordinates
 	 */
 	public static void harvestVein(World world, EntityPlayer player, ItemStack stack, Coordinates coords, Block target, List<ItemStack> currentDrops, int numMined)

--- a/src/main/resources/assets/projecte/lang/en_US.lang
+++ b/src/main/resources/assets/projecte/lang/en_US.lang
@@ -252,6 +252,8 @@ pe.katar.mode2=Slay All
 pe.life.pedestal1=Restores both hunger and hearts
 pe.life.pedestal2=Half a heart and shank every %s
 
+pe.mind.pedestal1=Sucks nearby XP orbs into the Mind Stone
+
 pe.misc.every_tick=every tick
 pe.misc.seconds=seconds
 pe.misc.storedxp_tooltip=Stored XP:


### PR DESCRIPTION
The refactor broke merge compatibility in quite a bit of https://github.com/sinkillerj/ProjectE/pull/603
so here's another pr that does the same that did.

Changes:
* Mind Stone has a pedestal function - draws nearby xp orbs in and stores them on the stone
* Unified all "make entity fly towards this point" code areas (duplicated about 7x) into a WorldHelper method, and move some remote checks to be later so the client sees a smooth animation instead of jumpiness.
* Fix potential block deletion exploit with Volcanite/Evertide, and make the arm swing when placing a liquid
* Ignition Ring ignites TNT (and all derivatives) on right click
* Remove a redundant method and compare square distances instead of real distance, save a Math.sqrt() call every tick.