### PR TITLE
Config option to log known emc exploits and fix dye-exploits

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/EMCMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/EMCMapper.java
@@ -29,10 +29,16 @@ public final class EMCMapper
 	public static void map()
 	{
 		List<IEMCMapper<NormalizedSimpleStack, Integer>> emcMappers = Arrays.asList(new OreDictionaryMapper(), new LazyMapper(), new CustomEMCMapper(), new CraftingMapper(), new moze_intel.projecte.emc.mappers.FluidMapper(), new SmeltingMapper());
-		GraphMapper<NormalizedSimpleStack, Integer> graphMapper = new SimpleGraphMapper<NormalizedSimpleStack, Integer>(new IntArithmetic());
+		SimpleGraphMapper<NormalizedSimpleStack, Integer> graphMapper = new SimpleGraphMapper<NormalizedSimpleStack, Integer>(new IntArithmetic());
 
 		Configuration config = new Configuration(new File(PECore.CONFIG_DIR, "mapping.cfg"));
 		config.load();
+
+		graphMapper.setLogFoundExploits(config.getBoolean("logEMCExploits", "general", true,
+				"Log known EMC Exploits. This can and will NOT find all the exploits! " +
+						"This will only find exploits that result in fixed/custom emc values that the algorithm did not overwrite. " +
+						"Exploits that derive from conversions, that are unknown to ProjectE will not be found!"
+		));
 
 		PELogger.logInfo("Starting to collect Mappings...");
 		for (IEMCMapper<NormalizedSimpleStack, Integer> emcMapper: emcMappers) {

--- a/src/main/java/moze_intel/projecte/emc/GraphMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/GraphMapper.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Maps;
 import moze_intel.projecte.utils.PELogger;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -167,7 +168,25 @@ public abstract class GraphMapper<T, V extends Comparable<V>> implements IMappin
 		}
 
 		public String toString() {
-			return "" + value + " + " + this.ingredientsWithAmount + " => " + outnumber + "x" + output;
+			return "" + value + " + " + ingredientsToString() + " => " + outnumber + "*" + output;
+		}
+
+		public String ingredientsToString() {
+			if (ingredientsWithAmount == null || ingredientsWithAmount.size() == 0) return "nothing";
+			StringBuilder sb = new StringBuilder();
+			boolean first = true;
+			Iterator<Map.Entry<T,Integer>> iter = ingredientsWithAmount.entrySet().iterator();
+			if (iter.hasNext()) {
+				Map.Entry<T, Integer> entry = iter.next();
+				sb.append(entry.getValue()).append("*").append(entry.getKey().toString());
+				while(iter.hasNext()) {
+					entry = iter.next();
+					sb.append(" + ").append(entry.getValue()).append("*").append(entry.getKey().toString());
+				}
+			}
+
+
+			return sb.toString();
 		}
 
 		public boolean equals(Conversion other) {

--- a/src/main/java/moze_intel/projecte/emc/NormalizedSimpleStack.java
+++ b/src/main/java/moze_intel/projecte/emc/NormalizedSimpleStack.java
@@ -111,7 +111,7 @@ public abstract class NormalizedSimpleStack {
 			Object obj = Item.itemRegistry.getObjectById(id);
 
 			if (obj != null) {
-				return "" + Item.itemRegistry.getNameForObject(obj) + "(" + id + ") " + (damage == OreDictionary.WILDCARD_VALUE ? "*" : damage);
+				return String.format("%s(%s:%s)", Item.itemRegistry.getNameForObject(obj), id, damage == OreDictionary.WILDCARD_VALUE ? "*" : damage);
 			}
 
 			return "id:" + id + " damage:" + (damage == OreDictionary.WILDCARD_VALUE ? "*" : damage);

--- a/src/main/java/moze_intel/projecte/emc/SimpleGraphMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/SimpleGraphMapper.java
@@ -1,6 +1,7 @@
 package moze_intel.projecte.emc;
 
 import com.google.common.collect.Maps;
+import moze_intel.projecte.utils.PELogger;
 
 import java.util.Iterator;
 import java.util.List;
@@ -9,6 +10,8 @@ import java.util.Map;
 public class SimpleGraphMapper<T, V extends Comparable<V>> extends GraphMapper<T, V> {
 	static boolean OVERWRITE_FIXED_VALUES = false;
 	protected V ZERO;
+
+	private boolean logFoundExploits = true;
 	public SimpleGraphMapper(IValueArithmetic<V> arithmetic) {
 		super(arithmetic);
 		ZERO = arithmetic.getZero();
@@ -16,6 +19,10 @@ public class SimpleGraphMapper<T, V extends Comparable<V>> extends GraphMapper<T
 
 	protected static<K,V extends Comparable<V>> boolean hasSmaller(Map<K,V> m, K key, V value) {
 		return (m.containsKey(key) && value.compareTo(m.get(key)) >= 0);
+	}
+
+	public void setLogFoundExploits(boolean log) {
+		logFoundExploits = log;
 	}
 
 	protected static<K, V extends Comparable<V>> boolean updateMapWithMinimum(Map<K,V> m, K key, V value) {
@@ -101,10 +108,14 @@ public class SimpleGraphMapper<T, V extends Comparable<V>> extends GraphMapper<T
 					}
 					//the cost for the ingredients is greater zero, but smaller than the value that the output has.
 					//This is a Loophole. We remove it by setting the value to 0.
-					if (canOverride(entry.getKey(),ZERO) && ZERO.compareTo(conversionValue) < 0 && conversionValue.compareTo(resultValue) < 0) {
-						debugFormat("Setting %s to 0 because result (%s) > cost (%s): %s", entry.getKey(), resultValue, conversionValue, conversion);
-						newValueFor.put(conversion.output, ZERO);
-						reasonForChange.put(conversion.output, "exploit recipe");
+					if (ZERO.compareTo(conversionValue) < 0 && conversionValue.compareTo(resultValue) < 0) {
+						if (canOverride(entry.getKey(), ZERO)) {
+							debugFormat("Setting %s to 0 because result (%s) > cost (%s): %s", entry.getKey(), resultValue, conversionValue, conversion);
+							newValueFor.put(conversion.output, ZERO);
+							reasonForChange.put(conversion.output, "exploit recipe");
+						} else if (logFoundExploits) {
+							PELogger.logWarn(String.format("EMC Exploit: \"%s\" ingredient cost: %s fixed value of result: %s", conversion, conversionValue, resultValue));
+						}
 					}
 				}
 				if (minConversionValue == null || minConversionValue.equals(ZERO)) {

--- a/src/main/java/moze_intel/projecte/emc/mappers/LazyMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/LazyMapper.java
@@ -49,7 +49,7 @@ public class LazyMapper implements IEMCMapper<NormalizedSimpleStack, Integer> {
 				continue;
 			}
 
-			addMapping(new ItemStack(Blocks.double_plant, 1, i), 16);
+			addMapping(new ItemStack(Blocks.double_plant, 1, i), 32);
 		}
 
 		addMapping(new ItemStack(Blocks.yellow_flower), 16);

--- a/src/main/java/moze_intel/projecte/emc/mappers/LazyMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/LazyMapper.java
@@ -120,13 +120,8 @@ public class LazyMapper implements IEMCMapper<NormalizedSimpleStack, Integer> {
 		addMapping(new ItemStack(Items.quartz), 256);
 		addMapping(new ItemStack(Items.dye, 1, 4), 864);
 
-		for (int i = 0; i < 15; i++) {
-			if (i == 3 || i == 4) {
-				continue;
-			}
-
-			addMapping(new ItemStack(Items.dye, 1, i), 16);
-		}
+		//ink sac
+		addMapping(new ItemStack(Items.dye, 1, 0), 16);
 
 		addMapping(new ItemStack(Items.enchanted_book), 2048);
 		addMapping(new ItemStack(Items.emerald), 16384);


### PR DESCRIPTION
Log output for vanilla MC + PE: (Removed the `[HH:MM:SS] [ProjectE Reload EMC Thread/WARN] [ProjectE]: `)

```
EMC Exploit: "0 + 9*minecraft:gold_nugget(371:0) => 1*minecraft:gold_ingot(266:0)" ingredient cost: 2043 fixed value of result: 2048
EMC Exploit: "0 + 1*minecraft:double_plant(175:1) => 2*minecraft:dye(351:13)" ingredient cost: 16 fixed value of result: 32
EMC Exploit: "0 + 0*ProjectE:item.pe_philosophers_stone(4096:0) + 7*minecraft:cactus(81:*) + 1*minecraft:coal(263:*) => 7*minecraft:dye(351:2)" ingredient cost: 88 fixed value of result: 112
EMC Exploit: "0 + 1*minecraft:cactus(81:*) => 1*minecraft:dye(351:2)" ingredient cost: 8 fixed value of result: 16
EMC Exploit: "0 + 1*minecraft:double_plant(175:5) => 2*minecraft:dye(351:9)" ingredient cost: 16 fixed value of result: 32
EMC Exploit: "0 + 1*minecraft:double_plant(175:0) => 2*minecraft:dye(351:11)" ingredient cost: 16 fixed value of result: 32
EMC Exploit: "0 + 1*minecraft:double_plant(175:4) => 2*minecraft:dye(351:1)" ingredient cost: 16 fixed value of result: 32
```

This is: `rose red` (using `rose bush`), `cactus green`, `pink dye` (using `peony`), `dandelion yellow` (using `sunflower`), `magenta dye` (using `lilac`)