### PR TITLE
Fix #635

### DIFF
--- a/src/main/java/moze_intel/projecte/events/PlayerEvents.java
+++ b/src/main/java/moze_intel/projecte/events/PlayerEvents.java
@@ -45,7 +45,7 @@ public class PlayerEvents
 	@SubscribeEvent
 	public void onHighAlchemistJoin(cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent evt)
 	{
-		if (true)//PECore.uuids.contains((evt.player.getUniqueID().toString())))
+		if (PECore.uuids.contains((evt.player.getUniqueID().toString())))
 		{
 			IChatComponent prior = ChatHelper.modifyColor(new ChatComponentTranslation("pe.server.high_alchemist"), EnumChatFormatting.BLUE);
 			IChatComponent playername = ChatHelper.modifyColor(new ChatComponentText(" " + evt.player.getCommandSenderName() + " "), EnumChatFormatting.GOLD);

--- a/src/main/java/moze_intel/projecte/events/PlayerEvents.java
+++ b/src/main/java/moze_intel/projecte/events/PlayerEvents.java
@@ -12,6 +12,7 @@ import moze_intel.projecte.network.packets.ClientSyncTableEMCPKT;
 import moze_intel.projecte.playerData.AlchemicalBags;
 import moze_intel.projecte.playerData.IOHandler;
 import moze_intel.projecte.playerData.Transmutation;
+import moze_intel.projecte.utils.ChatHelper;
 import moze_intel.projecte.utils.ItemHelper;
 import moze_intel.projecte.utils.PELogger;
 import net.minecraft.entity.player.EntityPlayer;
@@ -20,8 +21,9 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.util.StatCollector;
+import net.minecraft.util.IChatComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
@@ -43,13 +45,12 @@ public class PlayerEvents
 	@SubscribeEvent
 	public void onHighAlchemistJoin(cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent evt)
 	{
-		if (PECore.uuids.contains((evt.player.getUniqueID().toString())))
+		if (true)//PECore.uuids.contains((evt.player.getUniqueID().toString())))
 		{
-			ChatComponentText joinMsg = new ChatComponentText(String.format(
-					EnumChatFormatting.BLUE + StatCollector.translateToLocal("pe.server.high_alchemist")
-					+ EnumChatFormatting.GOLD + " %s " + EnumChatFormatting.BLUE + StatCollector.translateToLocal("pe.server.has_joined"),
-					evt.player.getDisplayName()));
-			MinecraftServer.getServer().getConfigurationManager().sendChatMsg(joinMsg); // Sends to all everywhere, not just same world like before.
+			IChatComponent prior = ChatHelper.modifyColor(new ChatComponentTranslation("pe.server.high_alchemist"), EnumChatFormatting.BLUE);
+			IChatComponent playername = ChatHelper.modifyColor(new ChatComponentText(" " + evt.player.getCommandSenderName() + " "), EnumChatFormatting.GOLD);
+			IChatComponent latter = ChatHelper.modifyColor(new ChatComponentTranslation("pe.server.has_joined"), EnumChatFormatting.BLUE);
+			MinecraftServer.getServer().getConfigurationManager().sendChatMsg(prior.appendSibling(playername).appendSibling(latter)); // Sends to all everywhere, not just same world like before.
 		}
 	}
 

--- a/src/main/java/moze_intel/projecte/gameObjs/blocks/TransmutationStone.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/blocks/TransmutationStone.java
@@ -16,9 +16,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
 import java.util.Random;
@@ -67,7 +66,7 @@ public class TransmutationStone extends Block implements ITileEntityProvider
 		{
 			if (!world.isRemote)
 			{
-				player.addChatComponentMessage(new ChatComponentText(StatCollector.translateToLocal("pe.transmutation.already_using")));
+				player.addChatComponentMessage(new ChatComponentTranslation("pe.transmutation.already_using"));
 			}
 		}
 		return true;

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/AlchBagInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/AlchBagInventory.java
@@ -81,7 +81,7 @@ public class AlchBagInventory implements IInventory
 	@Override
 	public String getInventoryName() 
 	{
-		return StatCollector.translateToLocal("item.pe_alchemical_bag_white.name");
+		return "item.pe_alchemical_bag_white.name";
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/AlchBagInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/AlchBagInventory.java
@@ -4,7 +4,6 @@ import moze_intel.projecte.playerData.AlchemicalBags;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.StatCollector;
 
 public class AlchBagInventory implements IInventory
 {

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/MercurialEyeInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/MercurialEyeInventory.java
@@ -104,7 +104,7 @@ public class MercurialEyeInventory implements IInventory
 	@Override
 	public String getInventoryName() 
 	{
-		return StatCollector.translateToLocal("item.pe_mercurial_eye.name");
+		return "item.pe_mercurial_eye.name";
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/MercurialEyeInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/MercurialEyeInventory.java
@@ -5,7 +5,6 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
-import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.Constants.NBT;
 
 public class MercurialEyeInventory implements IInventory

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
@@ -366,7 +366,7 @@ public class TransmuteTabletInventory implements IInventory
 	@Override
 	public String getInventoryName() 
 	{
-		return StatCollector.translateToLocal("item.pe_transmutation_tablet.name");
+		return "item.pe_transmutation_tablet.name";
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
@@ -15,7 +15,6 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
-import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.Constants.NBT;
 
 import java.util.Collections;

--- a/src/main/java/moze_intel/projecte/gameObjs/items/DiviningRodLow.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/DiviningRodLow.java
@@ -139,6 +139,11 @@ public class DiviningRodLow extends ItemPE implements IModeChanger
 					}
 
 
+			if (numBlocks == 0)
+			{
+				return stack;
+			}
+			
 			int[] maxValues = new int[3];
 
 			for (int i = 0; i < 3; i++)

--- a/src/main/java/moze_intel/projecte/gameObjs/items/DiviningRodLow.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/DiviningRodLow.java
@@ -19,11 +19,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.AxisAlignedBB;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.MovingObjectPosition.MovingObjectType;
-import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 

--- a/src/main/java/moze_intel/projecte/gameObjs/items/DiviningRodLow.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/DiviningRodLow.java
@@ -163,7 +163,7 @@ public class DiviningRodLow extends ItemPE implements IModeChanger
 			}
 			if (this instanceof DiviningRodHigh)
 			{
-				player.addChatComponentMessage(new ChatComponentTranslation("pe.divining.second", maxValues[1]));
+				player.addChatComponentMessage(new ChatComponentTranslation("pe.divining.secondmax", maxValues[1]));
 				player.addChatComponentMessage(new ChatComponentTranslation("pe.divining.thirdmax", maxValues[2]));
 			}
 		}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/DiviningRodLow.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/DiviningRodLow.java
@@ -20,6 +20,7 @@ import net.minecraft.item.crafting.FurnaceRecipes;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.MovingObjectPosition.MovingObjectType;
 import net.minecraft.util.StatCollector;
@@ -156,16 +157,16 @@ public class DiviningRodLow extends ItemPE implements IModeChanger
 				maxValues[i] = emcValues.get(i);
 			}
 
-			player.addChatComponentMessage(new ChatComponentText(String.format(StatCollector.translateToLocal("pe.divining.avgemc"), numBlocks, (totalEmc / numBlocks))));
+			player.addChatComponentMessage(new ChatComponentTranslation("pe.divining.avgemc", numBlocks, (totalEmc / numBlocks)));
 
 			if (this instanceof DiviningRodMedium)
 			{
-				player.addChatComponentMessage(new ChatComponentText(String.format(StatCollector.translateToLocal("pe.divining.maxemc"), maxValues[0])));
+				player.addChatComponentMessage(new ChatComponentTranslation("pe.divining.maxemc", maxValues[0]));
 			}
 			if (this instanceof DiviningRodHigh)
 			{
-				player.addChatComponentMessage(new ChatComponentText(String.format(StatCollector.translateToLocal("pe.divining.secondmax"), maxValues[1])));
-				player.addChatComponentMessage(new ChatComponentText(String.format(StatCollector.translateToLocal("pe.divining.thirdmax"), maxValues[2])));
+				player.addChatComponentMessage(new ChatComponentTranslation("pe.divining.second", maxValues[1]));
+				player.addChatComponentMessage(new ChatComponentTranslation("pe.divining.thirdmax", maxValues[2]));
 			}
 		}
 
@@ -212,7 +213,6 @@ public class DiviningRodLow extends ItemPE implements IModeChanger
 			stack.stackTagCompound.setByte("Mode", ((byte) (getMode(stack) + 1)));
 		}
 
-		player.addChatComponentMessage(new ChatComponentText(
-				String.format(StatCollector.translateToLocal("pe.item.mode_switch"), modes[getMode(stack)])));
+		player.addChatComponentMessage(new ChatComponentTranslation("pe.item.mode_switch", modes[getMode(stack)]));
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/GemEternalDensity.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/GemEternalDensity.java
@@ -23,7 +23,6 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;

--- a/src/main/java/moze_intel/projecte/gameObjs/items/GemEternalDensity.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/GemEternalDensity.java
@@ -24,6 +24,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
@@ -154,20 +155,20 @@ public class GemEternalDensity extends ItemPE implements IModeChanger, IBauble
 		return stack;
 	}
 	
-	private String getTargetDesciption(ItemStack stack)
+	private String getTargetName(ItemStack stack)
 	{
 		switch(stack.stackTagCompound.getByte("Target"))
 		{
 			case 0:
-				return StatCollector.translateToLocal("item.ingotIron.name");
+				return "item.ingotIron.name";
 			case 1:
-				return StatCollector.translateToLocal("item.ingotGold.name");
+				return "item.ingotGold.name";
 			case 2:
-				return StatCollector.translateToLocal("item.diamond.name");
+				return "item.diamond.name";
 			case 3:
-				return StatCollector.translateToLocal("item.pe_matter_dark.name");
+				return "item.pe_matter_dark.name";
 			case 4:
-				return StatCollector.translateToLocal("item.pe_matter_red.name");
+				return "item.pe_matter_red.name";
 			default:
 				return "INVALID";
 		}
@@ -315,8 +316,8 @@ public class GemEternalDensity extends ItemPE implements IModeChanger, IBauble
 			stack.stackTagCompound.setByte("Target", (byte) (oldMode + 1));
 		}
 
-		player.addChatComponentMessage(new ChatComponentText(
-				String.format(StatCollector.translateToLocal("pe.gemdensity.mode_switch"), getTargetDesciption(stack))));
+		player.addChatComponentMessage(new ChatComponentTranslation("pe.gemdensity.mode_switch")
+				.appendText(" ").appendSibling(new ChatComponentTranslation(getTargetName(stack))));
 	}
 	
 	@Override
@@ -327,7 +328,7 @@ public class GemEternalDensity extends ItemPE implements IModeChanger, IBauble
 		
 		if (stack.hasTagCompound())
 		{
-			list.add(String.format(StatCollector.translateToLocal("pe.gemdensity.tooltip2"), getTargetDesciption(stack)));
+			list.add(String.format(StatCollector.translateToLocal("pe.gemdensity.tooltip2"), getTargetName(stack)));
 		}
 		
 		if (KeyHelper.getModeKeyCode() >= 0 && KeyHelper.getModeKeyCode() < Keyboard.getKeyCount())

--- a/src/main/java/moze_intel/projecte/gameObjs/items/ItemMode.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/ItemMode.java
@@ -6,6 +6,7 @@ import moze_intel.projecte.api.IModeChanger;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 
@@ -47,8 +48,7 @@ public abstract class ItemMode extends ItemCharge implements IModeChanger
 			return;
 		}
 		changeMode(stack);
-		player.addChatComponentMessage(new ChatComponentText(
-				String.format(StatCollector.translateToLocal("pe.item.mode_switch"), modes[getMode(stack)])));
+		player.addChatComponentMessage(new ChatComponentTranslation("pe.item.mode_switch", modes[getMode(stack)]));
 	}
 	
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/items/ItemMode.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/ItemMode.java
@@ -5,7 +5,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 import moze_intel.projecte.api.IModeChanger;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;

--- a/src/main/java/moze_intel/projecte/gameObjs/items/TimeWatch.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/TimeWatch.java
@@ -23,7 +23,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
-import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
@@ -56,7 +56,7 @@ public class TimeWatch extends ItemCharge implements IModeChanger, IBauble, IPed
 		{
 			if (!ProjectEConfig.enableTimeWatch)
 			{
-				player.addChatComponentMessage(new ChatComponentText(StatCollector.translateToLocal("pe.timewatch.disabled")));
+				player.addChatComponentMessage(new ChatComponentTranslation("pe.timewatch.disabled"));
 				return stack;
 			}
 
@@ -69,8 +69,8 @@ public class TimeWatch extends ItemCharge implements IModeChanger, IBauble, IPed
 
 			setTimeBoost(stack, (byte) (current == 2 ? 0 : current + 1));
 
-			player.addChatComponentMessage(new ChatComponentText(
-					String.format(StatCollector.translateToLocal("pe.timewatch.mode_switch"), getTimeDescription(stack))));
+			player.addChatComponentMessage(new ChatComponentTranslation("pe.timewatch.mode_switch")
+					.appendSibling(new ChatComponentTranslation(getTimeName(stack))));
 		}
 
 		return stack;
@@ -238,26 +238,20 @@ public class TimeWatch extends ItemCharge implements IModeChanger, IBauble, IPed
 		}
 	}
 
-	private String getTimeDescription(ItemStack stack)
+	private String getTimeName(ItemStack stack)
 	{
 		byte mode = getTimeBoost(stack);
-
-		String s;
 		switch (mode)
 		{
 			case 0:
-				s = "pe.timewatch.off";
-				break;
+				return "pe.timewatch.off";
 			case 1:
-				s= "pe.timewatch.ff";
-				break;
+				return "pe.timewatch.ff";
 			case 2:
-				s = "pe.timewatch.rw";
-				break;
+				return "pe.timewatch.rw";
 			default:
-				s = "ERROR_INVALID_MODE";
+				return "ERROR_INVALID_MODE";
 		}
-		return StatCollector.translateToLocal(s);
 	}
 
 	private byte getTimeBoost(ItemStack stack)
@@ -335,7 +329,7 @@ public class TimeWatch extends ItemCharge implements IModeChanger, IBauble, IPed
 
 		if (stack.hasTagCompound())
 		{
-			list.add(String.format(StatCollector.translateToLocal("pe.timewatch.mode"), getTimeDescription(stack)));
+			list.add(String.format(StatCollector.translateToLocal("pe.timewatch.mode"), getTimeName(stack)));
 		}
 	}
 

--- a/src/main/java/moze_intel/projecte/gameObjs/items/armor/GemArmor.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/armor/GemArmor.java
@@ -22,7 +22,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumChatFormatting;

--- a/src/main/java/moze_intel/projecte/gameObjs/items/armor/GemArmor.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/armor/GemArmor.java
@@ -6,6 +6,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 import moze_intel.projecte.gameObjs.ObjHandler;
 import moze_intel.projecte.handlers.PlayerChecks;
 import moze_intel.projecte.handlers.PlayerTimers;
+import moze_intel.projecte.utils.ChatHelper;
 import moze_intel.projecte.utils.KeyHelper;
 import moze_intel.projecte.utils.PlayerHelper;
 import net.minecraft.block.Block;
@@ -22,6 +23,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
@@ -244,8 +246,8 @@ public class GemArmor extends ItemArmor implements ISpecialArmor, IRevealer, IGo
 
 		EnumChatFormatting e = value ? EnumChatFormatting.GREEN : EnumChatFormatting.RED;
 		String s = value ? "pe.gem.enabled" : "pe.gem.disabled";
-		player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("pe.gem.stepassist_tooltip") + " "
-				+ e + StatCollector.translateToLocal(s)));
+		player.addChatMessage(new ChatComponentTranslation("pe.gem.stepassist_tooltip")
+				.appendSibling(ChatHelper.modifyColor(new ChatComponentTranslation(s), e)));
 	}
 	
 	public static void toggleNightVision(ItemStack helm, EntityPlayer player)
@@ -270,8 +272,8 @@ public class GemArmor extends ItemArmor implements ISpecialArmor, IRevealer, IGo
 
 		EnumChatFormatting e = value ? EnumChatFormatting.GREEN : EnumChatFormatting.RED;
 		String s = value ? "pe.gem.enabled" : "pe.gem.disabled";
-		player.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("pe.gem.nightvision_tooltip") + " "
-				+ e + StatCollector.translateToLocal(s)));
+		player.addChatMessage(new ChatComponentTranslation("pe.gem.nightvision_tooltip")
+				.appendSibling(ChatHelper.modifyColor(new ChatComponentTranslation(s), e)));
 	}
 	
 	public static boolean isStepAssistEnabled(ItemStack boots)

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/AlchChestTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/AlchChestTile.java
@@ -12,7 +12,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.AxisAlignedBB;
-import net.minecraft.util.StatCollector;
 
 import java.util.Iterator;
 import java.util.List;

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/AlchChestTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/AlchChestTile.java
@@ -129,7 +129,7 @@ public class AlchChestTile extends TileEmcDirection implements IInventory
 	@Override
 	public String getInventoryName() 
 	{
-		return StatCollector.translateToLocal("tile.pe_alchemy_chest.name");
+		return "tile.pe_alchemy_chest.name";
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK1Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK1Tile.java
@@ -446,7 +446,7 @@ public class CollectorMK1Tile extends TileEmcProducer implements IInventory, ISi
 	@Override
 	public String getInventoryName() 
 	{
-		return StatCollector.translateToLocal("tile.pe_collector_MK1.name");
+		return "tile.pe_collector_MK1.name";
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK1Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK1Tile.java
@@ -15,7 +15,6 @@ import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
-import net.minecraft.util.StatCollector;
 
 public class CollectorMK1Tile extends TileEmcProducer implements IInventory, ISidedInventory
 {

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK2Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK2Tile.java
@@ -13,6 +13,6 @@ public class CollectorMK2Tile extends CollectorMK1Tile
 	@Override
 	public String getInventoryName()
 	{
-		return StatCollector.translateToLocal("tile.pe_collector_MK2.name");
+		return "tile.pe_collector_MK2.name";
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK2Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK2Tile.java
@@ -1,7 +1,6 @@
 package moze_intel.projecte.gameObjs.tiles;
 
 import moze_intel.projecte.utils.Constants;
-import net.minecraft.util.StatCollector;
 
 public class CollectorMK2Tile extends CollectorMK1Tile
 {

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK3Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK3Tile.java
@@ -1,7 +1,6 @@
 package moze_intel.projecte.gameObjs.tiles;
 
 import moze_intel.projecte.utils.Constants;
-import net.minecraft.util.StatCollector;
 
 public class CollectorMK3Tile extends CollectorMK1Tile
 {

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK3Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK3Tile.java
@@ -13,6 +13,6 @@ public class CollectorMK3Tile extends CollectorMK1Tile
 	@Override
 	public String getInventoryName()
 	{
-		return StatCollector.translateToLocal("tile.pe_collector_MK3.name");
+		return "tile.pe_collector_MK3.name";
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserMK2Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserMK2Tile.java
@@ -95,6 +95,6 @@ public class CondenserMK2Tile extends CondenserTile
 	@Override
 	public String getInventoryName()
 	{
-		return StatCollector.translateToLocal("tile.pe_condenser_mk2.name");
+		return "tile.pe_condenser_mk2.name";
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserMK2Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserMK2Tile.java
@@ -2,7 +2,6 @@ package moze_intel.projecte.gameObjs.tiles;
 
 import moze_intel.projecte.utils.EMCHelper;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.StatCollector;
 
 public class CondenserMK2Tile extends CondenserTile
 {

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserTile.java
@@ -356,7 +356,7 @@ public class CondenserTile extends TileEmcDirection implements IInventory, ISide
 	@Override
 	public String getInventoryName() 
 	{
-		return StatCollector.translateToLocal("tile.pe_condenser.name");
+		return "tile.pe_condenser.name";
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserTile.java
@@ -15,7 +15,6 @@ import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
-import net.minecraft.util.StatCollector;
 
 public class CondenserTile extends TileEmcDirection implements IInventory, ISidedInventory
 {

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/DMFurnaceTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/DMFurnaceTile.java
@@ -72,6 +72,6 @@ public class DMFurnaceTile extends RMFurnaceTile implements IInventory, ISidedIn
 	@Override
 	public String getInventoryName()
 	{
-		return StatCollector.translateToLocal("pe.dmfurnace.shortname");
+		return "pe.dmfurnace.shortname";
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/DMFurnaceTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/DMFurnaceTile.java
@@ -8,7 +8,6 @@ import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
 import net.minecraft.tileentity.TileEntityFurnace;
-import net.minecraft.util.StatCollector;
 
 public class DMFurnaceTile extends RMFurnaceTile implements IInventory, ISidedInventory
 {

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/DMPedestalTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/DMPedestalTile.java
@@ -12,7 +12,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.network.Packet;
 import net.minecraft.util.AxisAlignedBB;
-import net.minecraft.util.StatCollector;
 
 public class DMPedestalTile extends TileEmc implements IInventory
 {

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/DMPedestalTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/DMPedestalTile.java
@@ -202,7 +202,7 @@ public class DMPedestalTile extends TileEmc implements IInventory
 	@Override
 	public String getInventoryName()
 	{
-		return StatCollector.translateToLocal("pe.pedestal.shortname");
+		return "pe.pedestal.shortname";
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/RMFurnaceTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/RMFurnaceTile.java
@@ -17,7 +17,6 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraft.util.Facing;
-import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 
 public class RMFurnaceTile extends TileEmc implements IInventory, ISidedInventory

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/RMFurnaceTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/RMFurnaceTile.java
@@ -647,7 +647,7 @@ public class RMFurnaceTile extends TileEmc implements IInventory, ISidedInventor
 	@Override
 	public String getInventoryName() 
 	{
-		return StatCollector.translateToLocal("pe.rmfurnace.shortname");
+		return "pe.rmfurnace.shortname";
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/RelayMK1Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/RelayMK1Tile.java
@@ -14,7 +14,6 @@ import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
-import net.minecraft.util.StatCollector;
 
 public class RelayMK1Tile extends TileEmcProducer implements IInventory, ISidedInventory
 {

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/RelayMK1Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/RelayMK1Tile.java
@@ -326,7 +326,7 @@ public class RelayMK1Tile extends TileEmcProducer implements IInventory, ISidedI
 	@Override
 	public String getInventoryName() 
 	{
-		return StatCollector.translateToLocal("pe.relay.mk1");
+		return "pe.relay.mk1";
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/RelayMK2Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/RelayMK2Tile.java
@@ -1,7 +1,6 @@
 package moze_intel.projecte.gameObjs.tiles;
 
 import moze_intel.projecte.utils.Constants;
-import net.minecraft.util.StatCollector;
 
 public class RelayMK2Tile extends RelayMK1Tile
 {

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/RelayMK2Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/RelayMK2Tile.java
@@ -13,6 +13,6 @@ public class RelayMK2Tile extends RelayMK1Tile
 	@Override
 	public String getInventoryName()
 	{
-		return StatCollector.translateToLocal("pe.relay.mk2");
+		return "pe.relay.mk2";
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/RelayMK3Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/RelayMK3Tile.java
@@ -13,6 +13,6 @@ public class RelayMK3Tile extends RelayMK1Tile
 	@Override
 	public String getInventoryName()
 	{
-		return StatCollector.translateToLocal("pe.relay.mk3");
+		return "pe.relay.mk3";
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/RelayMK3Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/RelayMK3Tile.java
@@ -1,7 +1,6 @@
 package moze_intel.projecte.gameObjs.tiles;
 
 import moze_intel.projecte.utils.Constants;
-import net.minecraft.util.StatCollector;
 
 public class RelayMK3Tile extends RelayMK1Tile
 {

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/TransmuteTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/TransmuteTile.java
@@ -400,7 +400,7 @@ public class TransmuteTile extends TileEmc implements IInventory
 	@Override
 	public String getInventoryName() 
 	{
-		return StatCollector.translateToLocal("tile.pe_transmutation_stone.name");
+		return "tile.pe_transmutation_stone.name";
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/TransmuteTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/TransmuteTile.java
@@ -19,7 +19,6 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
-import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.Constants.NBT;
 
 import java.util.Collections;

--- a/src/main/java/moze_intel/projecte/network/commands/ChangelogCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ChangelogCMD.java
@@ -3,6 +3,7 @@ package moze_intel.projecte.network.commands;
 import com.google.common.collect.Lists;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.StatCollector;
 
 import java.util.List;
@@ -28,7 +29,7 @@ public class ChangelogCMD extends ProjectEBaseCMD
 	{
 		if (ChangelogCMD.changelog.isEmpty())
 		{
-			sender.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("pe.command.changelog.uptodate")));
+			sender.addChatMessage(new ChatComponentTranslation("pe.command.changelog.uptodate"));
 		}
 		else
 		{

--- a/src/main/java/moze_intel/projecte/network/commands/ChangelogCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ChangelogCMD.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Lists;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
-import net.minecraft.util.StatCollector;
 
 import java.util.List;
 

--- a/src/main/java/moze_intel/projecte/network/commands/ClearKnowledgeCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ClearKnowledgeCMD.java
@@ -3,10 +3,12 @@ package moze_intel.projecte.network.commands;
 import moze_intel.projecte.network.PacketHandler;
 import moze_intel.projecte.network.packets.ClientKnowledgeClearPKT;
 import moze_intel.projecte.playerData.Transmutation;
+import moze_intel.projecte.utils.ChatHelper;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 
@@ -21,7 +23,7 @@ public class ClearKnowledgeCMD extends ProjectEBaseCMD
 	@Override
 	public String getCommandUsage(ICommandSender sender)
 	{
-		return StatCollector.translateToLocal("pe.command.clearknowledge.usage");
+		return "pe.command.clearknowledge.usage";
 	}
 
 	@Override
@@ -33,11 +35,11 @@ public class ClearKnowledgeCMD extends ProjectEBaseCMD
 			{
 				Transmutation.clearKnowledge(sender.getCommandSenderName());
 				PacketHandler.sendTo(new ClientKnowledgeClearPKT(sender.getCommandSenderName()), (EntityPlayerMP) sender);
-				sendSuccess(sender, String.format(StatCollector.translateToLocal("pe.command.clearknowledge.success"), sender.getCommandSenderName()));
+				sendSuccess(sender, new ChatComponentTranslation("pe.command.clearknowledge.success", sender.getCommandSenderName()));
 			}
 			else
 			{
-				sendError(sender, String.format(StatCollector.translateToLocal("pe.command.clearknowledge.error"), sender.getCommandSenderName()));
+				sendError(sender, new ChatComponentTranslation("pe.command.clearknowledge.error", sender.getCommandSenderName()));
 			}
 		}
 		else
@@ -50,18 +52,18 @@ public class ClearKnowledgeCMD extends ProjectEBaseCMD
 				{
 					Transmutation.clearKnowledge(player.getCommandSenderName());
 					PacketHandler.sendTo(new ClientKnowledgeClearPKT(player.getCommandSenderName()), (EntityPlayerMP) player);
-					sendSuccess(sender, String.format(StatCollector.translateToLocal("pe.command.clearknowledge.success"), player.getCommandSenderName()));
+					sendSuccess(sender, new ChatComponentTranslation("pe.command.clearknowledge.success", player.getCommandSenderName()));
 					
 					if (!player.getCommandSenderName().equals(sender.getCommandSenderName()))
 					{
-						player.addChatComponentMessage(new ChatComponentText(EnumChatFormatting.RED + String.format(StatCollector.translateToLocal("pe.command.clearknowledge.notify"), sender.getCommandSenderName())));
+						player.addChatComponentMessage(ChatHelper.modifyColor(new ChatComponentTranslation("pe.command.clearknowledge.notify", sender.getCommandSenderName()), EnumChatFormatting.RED));
 					}
 					
 					return;
 				}
 			}
-			
-			sendError(sender, String.format(StatCollector.translateToLocal("pe.command.clearknowledge.playernotfound"), params[0]));
+
+			sendError(sender, new ChatComponentTranslation("pe.command.clearknowledge.playernotfound", params[0]));
 		}
 	}
 

--- a/src/main/java/moze_intel/projecte/network/commands/ClearKnowledgeCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ClearKnowledgeCMD.java
@@ -7,10 +7,8 @@ import moze_intel.projecte.utils.ChatHelper;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.util.StatCollector;
 
 public class ClearKnowledgeCMD extends ProjectEBaseCMD
 {

--- a/src/main/java/moze_intel/projecte/network/commands/ProjectEBaseCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ProjectEBaseCMD.java
@@ -3,7 +3,6 @@ package moze_intel.projecte.network.commands;
 import moze_intel.projecte.utils.ChatHelper;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
 

--- a/src/main/java/moze_intel/projecte/network/commands/ProjectEBaseCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ProjectEBaseCMD.java
@@ -1,9 +1,11 @@
 package moze_intel.projecte.network.commands;
 
+import moze_intel.projecte.utils.ChatHelper;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.IChatComponent;
 
 public abstract class ProjectEBaseCMD extends CommandBase
 {
@@ -19,18 +21,18 @@ public abstract class ProjectEBaseCMD extends CommandBase
 	@Override
 	public abstract void processCommand(ICommandSender sender, String[] params);
 	
-	protected void sendSuccess(ICommandSender sender, String message)
+	protected void sendSuccess(ICommandSender sender, IChatComponent message)
 	{
-		sendMessage(sender, EnumChatFormatting.GREEN + message);
+		sendMessage(sender, ChatHelper.modifyColor(message, EnumChatFormatting.GREEN));
 	}
 	
-	protected void sendError(ICommandSender sender, String message)
+	protected void sendError(ICommandSender sender, IChatComponent message)
 	{
-		sendMessage(sender, EnumChatFormatting.RED + message);
+		sendMessage(sender, ChatHelper.modifyColor(message, EnumChatFormatting.RED));
 	}
 	
-	protected void sendMessage(ICommandSender sender, String message)
+	protected void sendMessage(ICommandSender sender, IChatComponent message)
 	{
-		sender.addChatMessage(new ChatComponentText(message));
+		sender.addChatMessage(message);
 	}
 }

--- a/src/main/java/moze_intel/projecte/network/commands/ReloadEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ReloadEmcCMD.java
@@ -3,6 +3,7 @@ package moze_intel.projecte.network.commands;
 import moze_intel.projecte.emc.ThreadReloadEMCMap;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.StatCollector;
 
 public class ReloadEmcCMD extends ProjectEBaseCMD
@@ -22,7 +23,7 @@ public class ReloadEmcCMD extends ProjectEBaseCMD
 	@Override
 	public void processCommand(ICommandSender sender, String[] params) 
 	{
-		sender.addChatMessage(new ChatComponentText(StatCollector.translateToLocal("pe.command.reload.started")));
+		sender.addChatMessage(new ChatComponentTranslation("pe.command.reload.started"));
 		ThreadReloadEMCMap.runEMCRemap(false, sender.getEntityWorld());
 	}
 

--- a/src/main/java/moze_intel/projecte/network/commands/ReloadEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ReloadEmcCMD.java
@@ -2,9 +2,7 @@ package moze_intel.projecte.network.commands;
 
 import moze_intel.projecte.emc.ThreadReloadEMCMap;
 import net.minecraft.command.ICommandSender;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
-import net.minecraft.util.StatCollector;
 
 public class ReloadEmcCMD extends ProjectEBaseCMD
 {

--- a/src/main/java/moze_intel/projecte/network/commands/RemoveEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/RemoveEmcCMD.java
@@ -6,6 +6,7 @@ import moze_intel.projecte.utils.MathUtils;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.StatCollector;
 
 public class RemoveEmcCMD extends ProjectEBaseCMD
@@ -19,7 +20,7 @@ public class RemoveEmcCMD extends ProjectEBaseCMD
 	@Override
 	public String getCommandUsage(ICommandSender sender) 
 	{
-		return StatCollector.translateToLocal("pe.command.remove.usage");
+		return "pe.command.remove.usage";
 	}
 	
 	@Override
@@ -40,7 +41,7 @@ public class RemoveEmcCMD extends ProjectEBaseCMD
 
 			if (heldItem == null)
 			{
-				sendError(sender, StatCollector.translateToLocal("pe.command.remove.notholding"));
+				sendError(sender, new ChatComponentTranslation("pe.command.remove.notholding"));
 				return;
 			}
 
@@ -57,7 +58,7 @@ public class RemoveEmcCMD extends ProjectEBaseCMD
 
 				if (meta < 0)
 				{
-					sendError(sender, String.format(StatCollector.translateToLocal("pe.command.remove.invalidmeta"), params[1]));
+					sendError(sender, new ChatComponentTranslation("pe.command.remove.invalidmeta", params[1]));
 					return;
 				}
 			}
@@ -67,11 +68,11 @@ public class RemoveEmcCMD extends ProjectEBaseCMD
 		{
 			ThreadReloadEMCMap.runEMCRemap(false, sender.getEntityWorld());
 
-			sendSuccess(sender, String.format(StatCollector.translateToLocal("pe.command.remove.success"), name));
+			sendSuccess(sender, new ChatComponentTranslation("pe.command.remove.success", name));
 		}
 		else
 		{
-			sendError(sender, String.format(StatCollector.translateToLocal("pe.command.remove.invaliditem"), name));
+			sendError(sender, new ChatComponentTranslation("pe.command.remove.invaliditem", name));
 		}
 	}
 }

--- a/src/main/java/moze_intel/projecte/network/commands/RemoveEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/RemoveEmcCMD.java
@@ -7,7 +7,6 @@ import net.minecraft.command.ICommandSender;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentTranslation;
-import net.minecraft.util.StatCollector;
 
 public class RemoveEmcCMD extends ProjectEBaseCMD
 {

--- a/src/main/java/moze_intel/projecte/network/commands/ResetEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ResetEmcCMD.java
@@ -6,6 +6,7 @@ import moze_intel.projecte.utils.MathUtils;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.StatCollector;
 
 public class ResetEmcCMD extends ProjectEBaseCMD
@@ -19,7 +20,7 @@ public class ResetEmcCMD extends ProjectEBaseCMD
 	@Override
 	public String getCommandUsage(ICommandSender sender) 
 	{
-		return StatCollector.translateToLocal("pe.command.reset.usage");
+		return "pe.command.reset.usage";
 	}
 	
 	@Override
@@ -40,7 +41,7 @@ public class ResetEmcCMD extends ProjectEBaseCMD
 
 			if (heldItem == null)
 			{
-				sendError(sender, StatCollector.translateToLocal("pe.command.reset.notholding"));
+				sendError(sender, new ChatComponentTranslation("pe.command.reset.notholding"));
 				return;
 			}
 
@@ -57,7 +58,7 @@ public class ResetEmcCMD extends ProjectEBaseCMD
 
 				if (meta < 0)
 				{
-					sendError(sender, String.format(StatCollector.translateToLocal("pe.command.reset.invalidmeta"), params[1]));
+					sendError(sender, new ChatComponentTranslation("pe.command.reset.invalidmeta", params[1]));
 					return;
 				}
 			}
@@ -67,11 +68,11 @@ public class ResetEmcCMD extends ProjectEBaseCMD
 		{
 			ThreadReloadEMCMap.runEMCRemap(false, sender.getEntityWorld());
 
-			sendSuccess(sender, String.format(StatCollector.translateToLocal("pe.command.reset.success"), name));
+			sendSuccess(sender, new ChatComponentTranslation("pe.command.reset.success", name));
 		}
 		else
 		{
-			sendError(sender, String.format(StatCollector.translateToLocal("pe.command.reset.nochange"), name, meta));
+			sendError(sender, new ChatComponentTranslation("pe.command.reset.nochange", name, meta));
 		}
 	}
 }

--- a/src/main/java/moze_intel/projecte/network/commands/ResetEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ResetEmcCMD.java
@@ -7,7 +7,6 @@ import net.minecraft.command.ICommandSender;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentTranslation;
-import net.minecraft.util.StatCollector;
 
 public class ResetEmcCMD extends ProjectEBaseCMD
 {

--- a/src/main/java/moze_intel/projecte/network/commands/SetEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/SetEmcCMD.java
@@ -6,6 +6,7 @@ import moze_intel.projecte.utils.MathUtils;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.StatCollector;
 
 public class SetEmcCMD extends ProjectEBaseCMD
@@ -19,7 +20,7 @@ public class SetEmcCMD extends ProjectEBaseCMD
 	@Override
 	public String getCommandUsage(ICommandSender sender) 
 	{
-		return StatCollector.translateToLocal("pe.command.set.usage");
+		return "pe.command.set.usage";
 	}
 	
 	@Override
@@ -33,7 +34,7 @@ public class SetEmcCMD extends ProjectEBaseCMD
 	{
 		if (params.length < 1)
 		{
-			sendError(sender, StatCollector.translateToLocal("pe.command.set.invalidparams"));
+			sendError(sender, new ChatComponentTranslation("pe.command.set.invalidparams"));
 			return;
 		}
 
@@ -47,7 +48,7 @@ public class SetEmcCMD extends ProjectEBaseCMD
 
 			if (heldItem == null)
 			{
-				sendError(sender, StatCollector.translateToLocal("pe.command.set.notholding"));
+				sendError(sender, new ChatComponentTranslation("pe.command.set.notholding"));
 				return;
 			}
 
@@ -57,7 +58,7 @@ public class SetEmcCMD extends ProjectEBaseCMD
 
 			if (emc < 0)
 			{
-				sendError(sender, String.format(StatCollector.translateToLocal("pe.command.set.invalidemc"), params[0]));
+				sendError(sender, new ChatComponentTranslation("pe.command.set.invalidemc", params[0]));
 			}
 		}
 		else
@@ -74,7 +75,7 @@ public class SetEmcCMD extends ProjectEBaseCMD
 
 					if (meta < 0)
 					{
-						sendError(sender, String.format(StatCollector.translateToLocal("pe.command.set.invalidmeta"), params[1]));
+						sendError(sender, new ChatComponentTranslation("pe.command.set.invalidmeta", params[1]));
 						return;
 					}
 
@@ -82,7 +83,7 @@ public class SetEmcCMD extends ProjectEBaseCMD
 
 					if (emc < 0)
 					{
-						sendError(sender, String.format(StatCollector.translateToLocal("pe.command.set.invalidemc"), params[0]));
+						sendError(sender, new ChatComponentTranslation("pe.command.set.invalidemc", params[0]));
 						return;
 					}
 				}
@@ -92,7 +93,7 @@ public class SetEmcCMD extends ProjectEBaseCMD
 
 					if (emc < 0)
 					{
-						sendError(sender, String.format(StatCollector.translateToLocal("pe.command.set.invalidemc"), params[0]));
+						sendError(sender, new ChatComponentTranslation("pe.command.set.invalidemc", params[0]));
 						return;
 					}
 				}
@@ -103,7 +104,7 @@ public class SetEmcCMD extends ProjectEBaseCMD
 
 				if (emc < 0)
 				{
-					sendError(sender, String.format(StatCollector.translateToLocal("pe.command.set.invalidemc"), params[0]));
+					sendError(sender, new ChatComponentTranslation("pe.command.set.invalidemc", params[0]));
 					return;
 				}
 			}
@@ -113,11 +114,11 @@ public class SetEmcCMD extends ProjectEBaseCMD
 		{
 			ThreadReloadEMCMap.runEMCRemap(false, sender.getEntityWorld());
 
-			sendSuccess(sender, String.format(StatCollector.translateToLocal("pe.command.set.success"), name, emc));
+			sendSuccess(sender, new ChatComponentTranslation("pe.command.set.success", name, emc));
 		}
 		else
 		{
-			sendError(sender, String.format(StatCollector.translateToLocal("pe.command.set.invaliditem"), name));
+			sendError(sender, new ChatComponentTranslation("pe.command.set.invaliditem", name));
 		}
 	}
 }

--- a/src/main/java/moze_intel/projecte/network/commands/SetEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/SetEmcCMD.java
@@ -7,7 +7,6 @@ import net.minecraft.command.ICommandSender;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentTranslation;
-import net.minecraft.util.StatCollector;
 
 public class SetEmcCMD extends ProjectEBaseCMD
 {

--- a/src/main/java/moze_intel/projecte/utils/ChatHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/ChatHelper.java
@@ -1,0 +1,24 @@
+package moze_intel.projecte.utils;
+
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.IChatComponent;
+
+/**
+ * Helper class for chat messages and formatting
+ * Notice: Please try to keep methods tidy and alphabetically ordered. Thanks!
+ */
+public class ChatHelper
+{
+	/**
+	 * Alters color of a IChatComponent and returns it.
+	 * Returning the param allows for a chat message to be constructed and colored in one line.
+	 */
+	public static IChatComponent modifyColor(IChatComponent chat, EnumChatFormatting format)
+	{
+		if (format.isColor())
+		{
+			chat.getChatStyle().setColor(format);
+		}
+		return chat;
+	}
+}

--- a/src/main/java/moze_intel/projecte/utils/MathUtils.java
+++ b/src/main/java/moze_intel/projecte/utils/MathUtils.java
@@ -38,6 +38,10 @@ public final class MathUtils
 		return ticks / 20.0D;
 	}
 
+	/**
+	 * Converts ticks to seconds, and adds the string unit on. If result is 0, then "every tick" is appended
+	 * Take care when calling this serverside, the units will be in the Locale of the server.
+	 */
 	public static String tickToSecFormatted(int ticks)
 	{
 		double result = tickToSec(ticks);

--- a/src/main/resources/assets/projecte/lang/en_US.lang
+++ b/src/main/resources/assets/projecte/lang/en_US.lang
@@ -195,10 +195,10 @@ pe.darkpick.mode2=3x Tallshot
 pe.darkpick.mode3=3x Wideshot
 pe.darkpick.mode4=3x Longshot
 
-pe.divining.avgemc=Average EMC for %d blocks: %,d
-pe.divining.maxemc=Max EMC: %,d
-pe.divining.secondmax=Second Max EMC: %,d
-pe.divining.thirdmax=Third Max EMC: %,d
+pe.divining.avgemc=Average EMC for %s blocks: %s
+pe.divining.maxemc=Max EMC: %s
+pe.divining.secondmax=Second Max EMC: %s
+pe.divining.thirdmax=Third Max EMC: %s
 
 pe.dmfurnace.shortname=DM Furnace
 pe.rmfurnace.shortname=RM Furnace

--- a/src/main/resources/assets/projecte/lang/ru_RU.lang
+++ b/src/main/resources/assets/projecte/lang/ru_RU.lang
@@ -164,10 +164,10 @@ pe.darkpick.mode2=3x блока в высоту
 pe.darkpick.mode3=3x блока в ширину
 pe.darkpick.mode4=3x блока в длину
 
-pe.divining.avgemc=Средний EMC для %d блоков: %,d
-pe.divining.maxemc=Макс. EMC: %,d
-pe.divining.secondmax=Второй макс. EMC: %,d
-pe.divining.thirdmax=Третий макс. EMC: %,d
+pe.divining.avgemc=Средний EMC для %s блоков: %s
+pe.divining.maxemc=Макс. EMC: %s
+pe.divining.secondmax=Второй макс. EMC: %s
+pe.divining.thirdmax=Третий макс. EMC: %s
 
 pe.dmfurnace.shortname=Печь из ТМ
 pe.rmfurnace.shortname=Печь из КМ

--- a/src/main/resources/assets/projecte/lang/zh_CN.lang
+++ b/src/main/resources/assets/projecte/lang/zh_CN.lang
@@ -164,10 +164,10 @@ pe.darkpick.mode2=3x 竖直模式
 pe.darkpick.mode3=3x 横向模式
 pe.darkpick.mode4=3x 直线模式
 
-pe.divining.avgemc=平均EMC: %,d (共%d个方块)
-pe.divining.maxemc=最高EMC: %,d
-pe.divining.secondmax=第二高EMC: %,d
-pe.divining.thirdmax=第三高EMC: %,d
+pe.divining.avgemc=平均EMC: %s (共%s个方块)
+pe.divining.maxemc=最高EMC: %s
+pe.divining.secondmax=第二高EMC: %s
+pe.divining.thirdmax=第三高EMC: %s
 
 pe.dmfurnace.shortname=暗物质熔炉
 pe.rmfurnace.shortname=红物质熔炉


### PR DESCRIPTION
Fix #635 
Localized messages were being translated before being sent to players, causing them to always appear in the server's locale.
Use chatcomponenttranslation instead, which makes the server send the unlocalized string with a command for the client to translate when received.

Have not tested extensively yet, but hopefully can later today.