### PR TITLE
Simple fix for the search pages

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
@@ -139,13 +139,6 @@ public class TransmuteTabletInventory implements IInventory
 			while (iter.hasNext())
 			{
 				ItemStack stack = iter.next();
-
-				if (pagecounter < (searchpage * 12))
-				{
-					pagecounter++;
-					iter.remove();
-					continue;
-				}
 				
 				if (EMCHelper.getEmcValue(stack) > reqEmc)
 				{
@@ -178,6 +171,13 @@ public class TransmuteTabletInventory implements IInventory
 				{
 					iter.remove();
 				}
+
+				if (pagecounter < (searchpage * 12))
+				{
+					pagecounter++;
+					iter.remove();
+					continue;
+				}
 			}
 		}
 		else
@@ -188,13 +188,6 @@ public class TransmuteTabletInventory implements IInventory
 			while (iter.hasNext())
 			{
 				ItemStack stack = iter.next();
-
-				if (pagecounter < (searchpage * 12))
-				{
-					pagecounter++;
-					iter.remove();
-					continue;
-				}
 				
 				if (emc < EMCHelper.getEmcValue(stack))
 				{
@@ -220,6 +213,13 @@ public class TransmuteTabletInventory implements IInventory
 				else if (filter.length() > 0 && !displayName.toLowerCase().contains(filter))
 				{
 					iter.remove();
+				}
+
+				if (pagecounter < (searchpage * 12))
+				{
+					pagecounter++;
+					iter.remove();
+					continue;
 				}
 			}
 		}


### PR DESCRIPTION
The search page was filtering out items before they could even be
checked for the proper EMC/search requirement resulting in incorrect
items appearing for the pages