### PR TITLE
A simple fix for the new tab pages

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
@@ -166,10 +166,12 @@ public class TransmuteTabletInventory implements IInventory
 				if (displayName == null)
 				{
 					iter.remove();
+                    continue;
 				}
 				else if (filter.length() > 0 && !displayName.toLowerCase().contains(filter))
 				{
 					iter.remove();
+                    continue;
 				}
 
 				if (pagecounter < (searchpage * 12))
@@ -209,10 +211,12 @@ public class TransmuteTabletInventory implements IInventory
 				if (displayName == null)
 				{
 					iter.remove();
+                    continue;
 				}
 				else if (filter.length() > 0 && !displayName.toLowerCase().contains(filter))
 				{
 					iter.remove();
+                    continue;
 				}
 
 				if (pagecounter < (searchpage * 12))

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
@@ -139,13 +139,6 @@ public class TransmuteTabletInventory implements IInventory
 			while (iter.hasNext())
 			{
 				ItemStack stack = iter.next();
-
-				if (pagecounter < (searchpage * 12))
-				{
-					pagecounter++;
-					iter.remove();
-					continue;
-				}
 				
 				if (EMCHelper.getEmcValue(stack) > reqEmc)
 				{
@@ -178,6 +171,13 @@ public class TransmuteTabletInventory implements IInventory
 				{
 					iter.remove();
 				}
+
+				if (pagecounter < (searchpage * 12))
+				{
+					pagecounter++;
+					iter.remove();
+					continue;
+				}
 			}
 		}
 		else
@@ -188,13 +188,6 @@ public class TransmuteTabletInventory implements IInventory
 			while (iter.hasNext())
 			{
 				ItemStack stack = iter.next();
-
-				if (pagecounter < (searchpage * 12))
-				{
-					pagecounter++;
-					iter.remove();
-					continue;
-				}
 				
 				if (emc < EMCHelper.getEmcValue(stack))
 				{
@@ -220,6 +213,13 @@ public class TransmuteTabletInventory implements IInventory
 				else if (filter.length() > 0 && !displayName.toLowerCase().contains(filter))
 				{
 					iter.remove();
+				}
+
+				if (pagecounter < (searchpage * 12))
+				{
+					pagecounter++;
+					iter.remove();
+					continue;
 				}
 			}
 		}

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
@@ -166,12 +166,12 @@ public class TransmuteTabletInventory implements IInventory
 				if (displayName == null)
 				{
 					iter.remove();
-                    continue;
+					continue;
 				}
 				else if (filter.length() > 0 && !displayName.toLowerCase().contains(filter))
 				{
 					iter.remove();
-                    continue;
+					continue;
 				}
 
 				if (pagecounter < (searchpage * 12))
@@ -211,12 +211,12 @@ public class TransmuteTabletInventory implements IInventory
 				if (displayName == null)
 				{
 					iter.remove();
-                    continue;
+					continue;
 				}
 				else if (filter.length() > 0 && !displayName.toLowerCase().contains(filter))
 				{
 					iter.remove();
-                    continue;
+					continue;
 				}
 
 				if (pagecounter < (searchpage * 12))


### PR DESCRIPTION
This fix makes it so the EMC and Search results get applied BEFORE removing the item from the *pages* to advance to next page.

This will prevent items counting as part of the page when they are NOT.