### PR TITLE
Fixed #657: Send success chat messages after the thread is done running

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/ThreadReloadEMCMap.java
+++ b/src/main/java/moze_intel/projecte/emc/ThreadReloadEMCMap.java
@@ -4,22 +4,26 @@ import moze_intel.projecte.config.CustomEMCParser;
 import moze_intel.projecte.handlers.TileEntityHandler;
 import moze_intel.projecte.network.PacketHandler;
 import moze_intel.projecte.utils.PELogger;
-import net.minecraft.world.World;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.util.IChatComponent;
 
 public class ThreadReloadEMCMap extends Thread {
-	private World world;
+	private ICommandSender sender;
+	private IChatComponent finishedMessage;
 
 	/**
 	 * Runs the EMC Remap.
-	 * @param world The world; used for checking the condensers after an EMC remap.
+	 * @param sender The ICommandSender object that represents the one who sent the command.
+	 * @param finishedMessage The chat message to be sent upon finishing remapping.
 	 */
-	public static void runEMCRemap(World world) {
-		new ThreadReloadEMCMap(world).start();
+	public static void runEMCRemap(ICommandSender sender, IChatComponent finishedMessage) {
+		new ThreadReloadEMCMap(sender, finishedMessage).start();
 	}
 
-	private ThreadReloadEMCMap(World world) {
+	private ThreadReloadEMCMap(ICommandSender sender, IChatComponent finishedMessage) {
 		super("ProjectE Reload EMC Thread");
-		this.world = world;
+		this.sender = sender;
+		this.finishedMessage = finishedMessage;
 	}
 
 	@Override
@@ -28,8 +32,9 @@ public class ThreadReloadEMCMap extends Thread {
 		EMCMapper.clearMaps();
 		CustomEMCParser.readUserData();
 		EMCMapper.map();
-		TileEntityHandler.checkAllCondensers(world);
+		TileEntityHandler.checkAllCondensers(sender.getEntityWorld());
 		PacketHandler.sendFragmentedEmcPacketToAll();
+		sender.addChatMessage(finishedMessage);
 		PELogger.logInfo("Thread ran for " + (System.currentTimeMillis() - start) + " ms.");
 	}
 }

--- a/src/main/java/moze_intel/projecte/network/commands/ReloadEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ReloadEmcCMD.java
@@ -22,7 +22,7 @@ public class ReloadEmcCMD extends ProjectEBaseCMD
 	public void processCommand(ICommandSender sender, String[] params) 
 	{
 		sender.addChatMessage(new ChatComponentTranslation("pe.command.reload.started"));
-		ThreadReloadEMCMap.runEMCRemap(sender.getEntityWorld());
+		ThreadReloadEMCMap.runEMCRemap(sender, new ChatComponentTranslation("pe.command.reload.success"));
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/network/commands/RemoveEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/RemoveEmcCMD.java
@@ -2,11 +2,13 @@ package moze_intel.projecte.network.commands;
 
 import moze_intel.projecte.config.CustomEMCParser;
 import moze_intel.projecte.emc.ThreadReloadEMCMap;
+import moze_intel.projecte.utils.ChatHelper;
 import moze_intel.projecte.utils.MathUtils;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.EnumChatFormatting;
 
 public class RemoveEmcCMD extends ProjectEBaseCMD
 {
@@ -65,9 +67,7 @@ public class RemoveEmcCMD extends ProjectEBaseCMD
 
 		if (CustomEMCParser.addToFile(name, meta, 0))
 		{
-			ThreadReloadEMCMap.runEMCRemap(sender.getEntityWorld());
-
-			sendSuccess(sender, new ChatComponentTranslation("pe.command.remove.success", name));
+			ThreadReloadEMCMap.runEMCRemap(sender, ChatHelper.modifyColor(new ChatComponentTranslation("pe.command.remove.success", name), EnumChatFormatting.GREEN));
 		}
 		else
 		{

--- a/src/main/java/moze_intel/projecte/network/commands/ResetEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ResetEmcCMD.java
@@ -2,11 +2,13 @@ package moze_intel.projecte.network.commands;
 
 import moze_intel.projecte.config.CustomEMCParser;
 import moze_intel.projecte.emc.ThreadReloadEMCMap;
+import moze_intel.projecte.utils.ChatHelper;
 import moze_intel.projecte.utils.MathUtils;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.EnumChatFormatting;
 
 public class ResetEmcCMD extends ProjectEBaseCMD
 {
@@ -65,9 +67,7 @@ public class ResetEmcCMD extends ProjectEBaseCMD
 
 		if (CustomEMCParser.removeFromFile(name, meta))
 		{
-			ThreadReloadEMCMap.runEMCRemap(sender.getEntityWorld());
-
-			sendSuccess(sender, new ChatComponentTranslation("pe.command.reset.success", name));
+			ThreadReloadEMCMap.runEMCRemap(sender, ChatHelper.modifyColor(new ChatComponentTranslation("pe.command.reset.success", name), EnumChatFormatting.GREEN));
 		}
 		else
 		{

--- a/src/main/java/moze_intel/projecte/network/commands/SetEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/SetEmcCMD.java
@@ -2,11 +2,13 @@ package moze_intel.projecte.network.commands;
 
 import moze_intel.projecte.config.CustomEMCParser;
 import moze_intel.projecte.emc.ThreadReloadEMCMap;
+import moze_intel.projecte.utils.ChatHelper;
 import moze_intel.projecte.utils.MathUtils;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.EnumChatFormatting;
 
 public class SetEmcCMD extends ProjectEBaseCMD
 {
@@ -111,9 +113,7 @@ public class SetEmcCMD extends ProjectEBaseCMD
 
 		if (CustomEMCParser.addToFile(name, meta, emc))
 		{
-			ThreadReloadEMCMap.runEMCRemap(sender.getEntityWorld());
-
-			sendSuccess(sender, new ChatComponentTranslation("pe.command.set.success", name, emc));
+			ThreadReloadEMCMap.runEMCRemap(sender, ChatHelper.modifyColor(new ChatComponentTranslation("pe.command.set.success", name, emc), EnumChatFormatting.GREEN));
 		}
 		else
 		{


### PR DESCRIPTION
This now sends the chat messages that the operation was successful at the end of the thread, causing less confusion.