### PR TITLE
Fix #655, #656 and #663

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/TimeWatch.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/TimeWatch.java
@@ -190,7 +190,7 @@ public class TimeWatch extends ItemCharge implements IModeChanger, IBauble, IPed
 
 	private void speedUpTileEntities(World world, int bonusTicks, AxisAlignedBB bBox)
 	{
-		if (bBox == null) // Sanity check for chunk unload weirdness
+		if (bBox == null || bonusTicks == 0) // Sanity check the box for chunk unload weirdness
 		{
 			return;
 		}
@@ -215,7 +215,7 @@ public class TimeWatch extends ItemCharge implements IModeChanger, IBauble, IPed
 
 	private void speedUpRandomTicks(World world, int bonusTicks, AxisAlignedBB bBox)
 	{
-		if (bBox == null) // Sanity check for chunk unload weirdness
+		if (bBox == null || bonusTicks == 0) // Sanity check the box for chunk unload weirdness
 		{
 			return;
 		}
@@ -388,8 +388,8 @@ public class TimeWatch extends ItemCharge implements IModeChanger, IBauble, IPed
 		{
 			AxisAlignedBB bBox = ((DMPedestalTile) world.getTileEntity(x, y, z)).getEffectBounds();
 			if (ProjectEConfig.timePedBonus > 0) {
-				speedUpTileEntities(world, 18, bBox);
-				speedUpRandomTicks(world, 18, bBox);
+				speedUpTileEntities(world, ProjectEConfig.timePedBonus, bBox);
+				speedUpRandomTicks(world, ProjectEConfig.timePedBonus, bBox);
 			}
 
 			if (ProjectEConfig.timePedMobSlowness < 1.0F) {

--- a/src/main/java/moze_intel/projecte/gameObjs/items/TimeWatch.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/TimeWatch.java
@@ -77,8 +77,7 @@ public class TimeWatch extends ItemCharge implements IModeChanger, IBauble, IPed
 
 			setTimeBoost(stack, (byte) (current == 2 ? 0 : current + 1));
 
-			player.addChatComponentMessage(new ChatComponentTranslation("pe.timewatch.mode_switch")
-					.appendSibling(new ChatComponentTranslation(getTimeName(stack))));
+			player.addChatComponentMessage(new ChatComponentTranslation("pe.timewatch.mode_switch", new ChatComponentTranslation(getTimeName(stack)).getUnformattedTextForChat()));
 		}
 
 		return stack;
@@ -92,7 +91,7 @@ public class TimeWatch extends ItemCharge implements IModeChanger, IBauble, IPed
 			stack.setTagCompound(new NBTTagCompound());
 		}
 		
-		if (world.isRemote || !(entity instanceof EntityPlayer) || invSlot > 8)
+		if (!(entity instanceof EntityPlayer) || invSlot > 8)
 		{
 			return;
 		}
@@ -127,7 +126,7 @@ public class TimeWatch extends ItemCharge implements IModeChanger, IBauble, IPed
 			}
 		}
 
-		if (stack.getItemDamage() == 0)
+		if (world.isRemote || stack.getItemDamage() == 0)
 		{
 			return;
 		}
@@ -337,7 +336,8 @@ public class TimeWatch extends ItemCharge implements IModeChanger, IBauble, IPed
 
 		if (stack.hasTagCompound())
 		{
-			list.add(String.format(StatCollector.translateToLocal("pe.timewatch.mode"), getTimeName(stack)));
+			list.add(String.format(StatCollector.translateToLocal("pe.timewatch.mode"),
+					StatCollector.translateToLocal(getTimeName(stack))));
 		}
 	}
 

--- a/src/main/java/moze_intel/projecte/gameObjs/items/TimeWatch.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/TimeWatch.java
@@ -103,27 +103,29 @@ public class TimeWatch extends ItemCharge implements IModeChanger, IBauble, IPed
 
 		byte timeControl = getTimeBoost(stack);
 
-		if (timeControl == 1)
-		{
-			if (world.getWorldTime() + ((getCharge(stack) + 1) * 4) > Long.MAX_VALUE)
-			{
-				world.setWorldTime(Long.MAX_VALUE);
-			}
-			else
-			{
-				world.setWorldTime((world.getWorldTime() + ((getCharge(stack) + 1) * 4)));
-			}
-		}
-		else if (timeControl == 2)
-		{
-			if (world.getWorldTime() - ((getCharge(stack) + 1) * 4) < 0)
-			{
-				world.setWorldTime(0);
-			}
-			else
-			{
-				world.setWorldTime((world.getWorldTime() - ((getCharge(stack) + 1) * 4)));
-			}
+		if (world.getGameRules().getGameRuleBooleanValue("doDaylightCycle")) {
+			if (timeControl == 1)
+            {
+                if (world.getWorldTime() + ((getCharge(stack) + 1) * 4) > Long.MAX_VALUE)
+                {
+                    world.setWorldTime(Long.MAX_VALUE);
+                }
+                else
+                {
+                    world.setWorldTime((world.getWorldTime() + ((getCharge(stack) + 1) * 4)));
+                }
+            }
+            else if (timeControl == 2)
+            {
+                if (world.getWorldTime() - ((getCharge(stack) + 1) * 4) < 0)
+                {
+                    world.setWorldTime(0);
+                }
+                else
+                {
+                    world.setWorldTime((world.getWorldTime() - ((getCharge(stack) + 1) * 4)));
+                }
+            }
 		}
 
 		if (world.isRemote || stack.getItemDamage() == 0)

--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/SWRG.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/SWRG.java
@@ -345,6 +345,11 @@ public class SWRG extends ItemPE implements IBauble, IPedestalItem
 			WorldHelper.repelEntitiesInAABBFromPoint(player.worldObj, player.boundingBox.expand(5.0, 5.0, 5.0), player.posX, player.posY, player.posZ, true);
 		}
 
+		if (player.worldObj.isRemote)
+		{
+			return;
+		}
+
 		EntityPlayerMP playerMP = (EntityPlayerMP) player;
 
 		if (!stack.hasTagCompound())


### PR DESCRIPTION
Fix #655 SWRG missing a remote check in bauble mode
Fix #656 TimeWatch missing localized messages because of derp and because of Minecraft
Fix #663 TimeWatch ignored vanilla permaday gamerules.

Also made TimeWatch apply its time speedup effect both client and serverside so it looks smooth like it used to in EE2 instead of the sun jumping around. Desyncs should not happen as the server constantly resends the time to the client every 2 seconds or so.

Also - don't know how nobody caught this - the Time Watch on the pedestal didn't respect the config, made it do so.