### PR TITLE
Fix #664 and #671

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/DarkPick.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/DarkPick.java
@@ -2,11 +2,13 @@ package moze_intel.projecte.gameObjs.items.tools;
 
 import moze_intel.projecte.gameObjs.ObjHandler;
 import moze_intel.projecte.utils.AchievementHandler;
+import moze_intel.projecte.utils.ItemHelper;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
@@ -29,6 +31,27 @@ public class DarkPick extends PEToolBase
 	protected DarkPick(String name, byte numCharges, String[] modeDesc)
 	{
 		super(name, numCharges, modeDesc);
+	}
+
+	@Override
+	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player)
+	{
+		if (world.isRemote)
+		{
+			return stack;
+		}
+
+		MovingObjectPosition mop = this.getMovingObjectPositionFromPlayer(world, player, false);
+		if (mop != null && mop.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK)
+		{
+			Block b = world.getBlock(mop.blockX, mop.blockY, mop.blockZ);
+			if (ItemHelper.isOre(b))
+			{
+				tryVeinMine(stack, player, mop);
+			}
+		}
+
+		return stack;
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/DarkShovel.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/DarkShovel.java
@@ -2,7 +2,9 @@ package moze_intel.projecte.gameObjs.items.tools;
 
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
 public class DarkShovel extends PEToolBase
@@ -28,7 +30,21 @@ public class DarkShovel extends PEToolBase
 	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player)
 	{
-		digAOE(stack, world, player, false, 16);
+		if (world.isRemote)
+		{
+			return stack;
+		}
+
+		MovingObjectPosition mop = this.getMovingObjectPositionFromPlayer(world, player, false);
+		if (mop != null && mop.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK
+				&& world.getBlock(mop.blockX, mop.blockY, mop.blockZ) == Blocks.gravel)
+		{
+			tryVeinMine(stack, player, mop);
+		}
+		else
+		{
+			digAOE(stack, world, player, false, 16);
+		}
 		return stack;
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/PEToolBase.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/PEToolBase.java
@@ -384,7 +384,7 @@ public abstract class PEToolBase extends ItemMode
 	 */
 	protected void attackWithCharge(ItemStack stack, EntityLivingBase damaged, EntityLivingBase damager, float baseDmg)
 	{
-		if (!(damager instanceof EntityPlayer))
+		if (!(damager instanceof EntityPlayer) || damager.worldObj.isRemote)
 		{
 			return;
 		}
@@ -407,6 +407,11 @@ public abstract class PEToolBase extends ItemMode
 	 */
 	protected void attackAOE(ItemStack stack, EntityPlayer player, boolean slayAll, float damage, int emcCost)
 	{
+		if (player.worldObj.isRemote)
+		{
+			return;
+		}
+
 		byte charge = getCharge(stack);
 		float factor = 2.5F * charge;
 		AxisAlignedBB aabb = player.boundingBox.expand(factor, factor, factor);
@@ -530,6 +535,11 @@ public abstract class PEToolBase extends ItemMode
 	 */
 	protected void tryVeinMine(ItemStack stack, EntityPlayer player, MovingObjectPosition mop)
 	{
+		if (player.worldObj.isRemote)
+		{
+			return;
+		}
+
 		AxisAlignedBB aabb = WorldHelper.getBroadDeepBox(new Coordinates(mop.blockX, mop.blockY, mop.blockZ), ForgeDirection.getOrientation(mop.sideHit), getCharge(stack));
 		Block target = player.worldObj.getBlock(mop.blockX, mop.blockY, mop.blockZ);
 		if (target.getBlockHardness(player.worldObj, mop.blockX, mop.blockY, mop.blockZ) <= -1 || !canHarvestBlock(target, stack))

--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/PEToolBase.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/PEToolBase.java
@@ -531,6 +531,12 @@ public abstract class PEToolBase extends ItemMode
 	protected void tryVeinMine(ItemStack stack, EntityPlayer player, MovingObjectPosition mop)
 	{
 		AxisAlignedBB aabb = WorldHelper.getBroadDeepBox(new Coordinates(mop.blockX, mop.blockY, mop.blockZ), ForgeDirection.getOrientation(mop.sideHit), getCharge(stack));
+		Block target = player.worldObj.getBlock(mop.blockX, mop.blockY, mop.blockZ);
+		if (target.getBlockHardness(player.worldObj, mop.blockX, mop.blockY, mop.blockZ) <= -1 || !canHarvestBlock(target, stack))
+		{
+			return;
+		}
+
 		List<ItemStack> drops = Lists.newArrayList();
 
 		for (int i = (int) aabb.minX; i <= aabb.maxX; i++)
@@ -540,7 +546,7 @@ public abstract class PEToolBase extends ItemMode
 				for (int k = (int) aabb.minZ; k <= aabb.maxZ; k++)
 				{
 					Block b = player.worldObj.getBlock(i, j, k);
-					if (b.getBlockHardness(player.worldObj, i, j, k) > -1 && canHarvestBlock(b, stack))
+					if (b == target)
 					{
 						WorldHelper.harvestVein(player.worldObj, player, stack, new Coordinates(i, j, k), b, drops, 0);
 					}


### PR DESCRIPTION
Resolve #664 - Fore vein-mining accidentally capturing other blocks, potentially causing infinite loops and crashes.
Resolve #671 - Pickaxe doesn't have vein mining