### PR TITLE
Major Lootball Improvements

### DIFF
--- a/src/main/java/moze_intel/projecte/config/ProjectEConfig.java
+++ b/src/main/java/moze_intel/projecte/config/ProjectEConfig.java
@@ -50,6 +50,7 @@ public final class ProjectEConfig
 	public static int timePedBonus;
 	public static float timePedMobSlowness;
 	public static boolean interdictionMode;
+	public static boolean useLootBalls;
 
 	public static void init(File configFile)
 	{
@@ -66,6 +67,7 @@ public final class ProjectEConfig
 			showStatTooltip = config.getBoolean("statToolTips", "misc", true, "Show stats as tooltips for various ProjectE blocks");
 			showPedestalTooltip = config.getBoolean("pedestalToolTips", "misc", true, "Show DM pedestal functions in item tooltips");
 			showPedestalTooltipInGUI = config.getBoolean("pedestalToolTipsInGUI", "misc", false, "Show pedestal function tooltips only in pedestal GUI");
+			useLootBalls = config.getBoolean("useLootBalls", "misc", true, "Make loot balls for drops. Disabling this may potentially cause bad performance when large amounts of loot are spawned!");
 
 			enableAlcChest = config.getBoolean("enableAlcChest", "blocks", true, "Enable Alchemical Chest recipe");
 

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
@@ -114,7 +114,7 @@ public class TransmuteTabletInventory implements IInventory
 		
 		ItemStack lockCopy = null;
 
-		Collections.sort(knowledge, Comparators.ITEMSTACK_DESCENDING);
+		Collections.sort(knowledge, Comparators.ITEMSTACK_EMC_DESCENDING);
 		
 		if (inventory[LOCK_INDEX] != null)
 		{

--- a/src/main/java/moze_intel/projecte/gameObjs/entity/EntityLootBall.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/entity/EntityLootBall.java
@@ -57,6 +57,7 @@ public class EntityLootBall extends Entity
 		this.motionX = (double)((float)(Math.random() * 0.20000000298023224D - 0.10000000149011612D));
 		this.motionY = 0.20000000298023224D;
 		this.motionZ = (double)((float)(Math.random() * 0.20000000298023224D - 0.10000000149011612D));
+		ItemHelper.compactItemList(items);
 	}
 	
 	public List<ItemStack> getItemList()
@@ -106,18 +107,34 @@ public class EntityLootBall extends Entity
 		
 		if (!this.worldObj.isRemote)
 		{
-			if (age > lifespan)
+			if (age > lifespan || items.isEmpty())
 			{
 				this.setDead();
 			}
-			
-			if (this.items.isEmpty())
+			if (ticksExisted % 60 == 0 && !isDead)
 			{
-				this.setDead();
+				List<EntityLootBall> nearby = worldObj.getEntitiesWithinAABB(EntityLootBall.class, this.boundingBox.expand(1.0F, 1.0F, 1.0F));
+				for (EntityLootBall e : nearby)
+				{
+					mergeWith(e);
+				}
 			}
+
 		}
 	}
-	
+
+	public void mergeWith(EntityLootBall other)
+	{
+		if (other == this)
+		{
+			return;
+		}
+		other.setDead();
+		items.addAll(Lists.newArrayList(other.getItemList()));
+		other.getItemList().clear();
+		ItemHelper.compactItemList(items);
+	}
+
 	@Override
 	public void onCollideWithPlayer(EntityPlayer player)
 	{

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/TransmuteTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/TransmuteTile.java
@@ -105,7 +105,7 @@ public class TransmuteTile extends TileEmc implements IInventory
 		
 		ItemStack lockCopy = null;
 
-		Collections.sort(knowledge, Comparators.ITEMSTACK_DESCENDING);
+		Collections.sort(knowledge, Comparators.ITEMSTACK_EMC_DESCENDING);
 
 		if (inventory[LOCK_INDEX] != null)
 		{

--- a/src/main/java/moze_intel/projecte/utils/Comparators.java
+++ b/src/main/java/moze_intel/projecte/utils/Comparators.java
@@ -2,13 +2,14 @@ package moze_intel.projecte.utils;
 
 import moze_intel.projecte.emc.EMCMapper;
 import moze_intel.projecte.emc.SimpleStack;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 import java.util.Comparator;
 
 public final class Comparators
 {
-	public static final Comparator<ItemStack> ITEMSTACK_DESCENDING = new Comparator<ItemStack>()
+	public static final Comparator<ItemStack> ITEMSTACK_EMC_DESCENDING = new Comparator<ItemStack>()
 	{
 		@Override
 		public int compare(ItemStack s1, ItemStack s2) 
@@ -29,7 +30,38 @@ public final class Comparators
 			return 0;
 		}
 	};
-	
+
+	public static final Comparator<ItemStack> ITEMSTACK_ASCENDING = new Comparator<ItemStack>() {
+		@Override
+		public int compare(ItemStack o1, ItemStack o2)
+		{
+			if ((o1 == null && o2 == null))
+			{
+				return 0;
+			}
+			if (o1 == null)
+			{
+				return Integer.MAX_VALUE;
+			}
+			if (o2 == null)
+			{
+				return Integer.MIN_VALUE;
+			}
+			if (ItemHelper.areItemStacksEqualIgnoreNBT(o1, o2))
+			{
+				return 0;
+			}
+			if (o1.getItem() == o2.getItem())
+			{
+				return o1.stackSize - o2.stackSize;
+			}
+			else
+			{
+				return Item.getIdFromItem(o1.getItem()) - Item.getIdFromItem(o2.getItem());
+			}
+		}
+	};
+
 	public static final Comparator<SimpleStack> SIMPLESTACK_ASCENDING = new Comparator<SimpleStack>()
 	{
 		@Override

--- a/src/main/java/moze_intel/projecte/utils/ItemHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/ItemHelper.java
@@ -9,6 +9,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -18,6 +19,9 @@ import java.util.List;
  */
 public final class ItemHelper
 {
+	/**
+	 * @return True if the only aspect these stacks differ by is stack size, false if item, meta, or nbt differ.
+	 */
 	public static boolean areItemStacksEqual(ItemStack stack1, ItemStack stack2)
 	{
 		return ItemStack.areItemStacksEqual(getNormalizedStack(stack1), getNormalizedStack(stack2));
@@ -42,6 +46,34 @@ public final class ItemHelper
 	public static boolean basicAreStacksEqual(ItemStack stack1, ItemStack stack2)
 	{
 		return (stack1.getItem() == stack2.getItem()) && (stack1.getMetadata() == stack2.getMetadata());
+	}
+
+	public static void compactItemList(List<ItemStack> list)
+	{
+		for (int i = 0; i < list.size(); i++)
+		{
+			ItemStack s = list.get(i);
+			for (int j = i + 1; j < list.size(); j++)
+			{
+				ItemStack s1 = list.get(j);
+				if (areItemStacksEqual(s, s1))
+				{
+					if (s.stackSize + s1.stackSize <= s.getMaxStackSize())
+					{
+						s.stackSize += s1.stackSize;
+						s1.stackSize = 0;
+					}
+					else
+					{
+						s1.stackSize = (s1.stackSize + s.stackSize) - s.getMaxStackSize();
+						s.stackSize = s.getMaxStackSize();
+					}
+				}
+			}
+		}
+
+		Collections.sort(list, Comparators.ITEMSTACK_ASCENDING);
+		trimItemList(list);
 	}
 
 	public static boolean containsItemStack(List<ItemStack> list, ItemStack toSearch)
@@ -394,5 +426,18 @@ public final class ItemHelper
 		}
 
 		return stack.copy();
+	}
+
+	public static void trimItemList(List<ItemStack> list)
+	{
+		Iterator<ItemStack> iter = list.iterator();
+		while (iter.hasNext())
+		{
+			ItemStack s = iter.next();
+			if (s.stackSize <= 0)
+			{
+				iter.remove();
+			}
+		}
 	}
 }

--- a/src/main/java/moze_intel/projecte/utils/WorldHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/WorldHelper.java
@@ -88,7 +88,21 @@ public final class WorldHelper
 		{
 			return;
 		}
-		world.spawnEntityInWorld(new EntityLootBall(world, drops, x, y, z));
+
+		ItemHelper.compactItemList(drops);
+
+		if (ProjectEConfig.useLootBalls)
+		{
+			world.spawnEntityInWorld(new EntityLootBall(world, drops, x, y, z));
+		}
+		else
+		{
+			for (ItemStack drop : drops)
+			{
+				spawnEntityItem(world, drop, x, y, z);
+			}
+		}
+
 	}
 
 	public static List<TileEntity> getAdjacentTileEntities(World world, TileEntity tile)
@@ -364,7 +378,7 @@ public final class WorldHelper
 		}
 	}
 
-	public static void spawnEntityItem(World world, ItemStack stack, int x, int y, int z)
+	public static void spawnEntityItem(World world, ItemStack stack, double x, double y, double z)
 	{
 		float f = world.rand.nextFloat() * 0.8F + 0.1F;
 		float f1 = world.rand.nextFloat() * 0.8F + 0.1F;


### PR DESCRIPTION
- Lootballs now compact / sort their item list instead of holding a list full of millions of 1-big itemstacks
- Lootballs now seek other lootballs every 3 seconds within 1 block of themselves and merge.
- Added config option to not use lootballs at all (lootballs remain enabled by default). WorldHelper.createLoopDrop will instead compact / sort the item list and then spawn the items one by one (Tests with nova cataclysm show that there really is no performance impact from this on high end computers thanks to the sorting and compacting, low end untested)

- Renamed a comparator to make it clear that it's sorting based on EMC value.