### PR TITLE
Fix horribly broken TileEntityHandler

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/ThreadReloadEMCMap.java
+++ b/src/main/java/moze_intel/projecte/emc/ThreadReloadEMCMap.java
@@ -32,7 +32,7 @@ public class ThreadReloadEMCMap extends Thread {
 		EMCMapper.clearMaps();
 		CustomEMCParser.readUserData();
 		EMCMapper.map();
-		TileEntityHandler.checkAllCondensers(sender.getEntityWorld());
+		TileEntityHandler.checkAllCondensers();
 		PacketHandler.sendFragmentedEmcPacketToAll();
 		sender.addChatMessage(finishedMessage);
 		PELogger.logInfo("Thread ran for " + (System.currentTimeMillis() - start) + " ms.");

--- a/src/main/java/moze_intel/projecte/handlers/TileEntityHandler.java
+++ b/src/main/java/moze_intel/projecte/handlers/TileEntityHandler.java
@@ -1,73 +1,36 @@
 package moze_intel.projecte.handlers;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import moze_intel.projecte.gameObjs.tiles.CondenserTile;
-import moze_intel.projecte.utils.Coordinates;
 import moze_intel.projecte.utils.PELogger;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-import java.util.Iterator;
-import java.util.List;
+import java.util.Set;
 
 public class TileEntityHandler
 {
-	private static final List<Coordinates> CONDENSERS = Lists.newArrayList();
+	// The set of all (chunk)loaded condensers on the server.
+	private static final Set<CondenserTile> CONDENSERS = Sets.newHashSet();
 
 	public static void addCondenser(CondenserTile tile)
 	{
-		Coordinates coords = new Coordinates(tile);
-
-		if (!CONDENSERS.contains(coords))
-		{
-			PELogger.logDebug("Added condenser at coords: " + coords);
-			CONDENSERS.add(coords);
-		}
+		PELogger.logDebug(String.format("Added condenser at coords %s, %s, %s", Integer.toString(tile.xCoord), Integer.toString(tile.yCoord), Integer.toString(tile.zCoord)));
+		CONDENSERS.add(tile);
 	}
 
 	public static void removeCondenser(CondenserTile tile)
 	{
-		Coordinates coords = new Coordinates(tile);
-
-		if (CONDENSERS.contains(coords))
+		if (CONDENSERS.remove(tile))
 		{
-			Iterator<Coordinates> iter = CONDENSERS.iterator();
-
-			while (iter.hasNext())
-			{
-				if (iter.next().equals(coords))
-				{
-					iter.remove();
-					PELogger.logDebug("Condenser at " + coords + " has been removed.");
-					return;
-				}
-			}
-		}
-		else
-		{
-			PELogger.logFatal("Condenser at coordinates: " + coords + " hasn't been mapped!");
+			PELogger.logDebug(String.format("Removed condenser at coords %s, %s, %s", Integer.toString(tile.xCoord), Integer.toString(tile.yCoord), Integer.toString(tile.zCoord)));
 		}
 	}
 
-	public static void checkAllCondensers(World world)
+	public static void checkAllCondensers()
 	{
-		Iterator<Coordinates> iter = CONDENSERS.iterator();
-
-		while (iter.hasNext())
+		for (CondenserTile t : CONDENSERS)
 		{
-			Coordinates coords = iter.next();
-
-			TileEntity tile = world.getTileEntity(coords.x, coords.y, coords.z);
-
-			if (tile instanceof CondenserTile)
-			{
-				((CondenserTile) tile).checkLockAndUpdate();
-			}
-			else
-			{
-				PELogger.logFatal("Condenser not found at coordinates: " + coords);
-				iter.remove();
-			}
+			t.checkLockAndUpdate();
 		}
 	}
 


### PR DESCRIPTION
Fix #698 and its underlying problem.


TileEntityHandler used to maintain a list of coordinates (!!!!!) of all condensers so it could check the lock slot to make sure it has a valid emc target whenever the EMC mapping shifts. Already you can see the problem. What if you have multiple condensers in different dims at the same coords?
Next, on to the actual issue, which describes only condensers in the command sender's world being rechecked. *If the condenser is not found in the world given, the coordinates are plucked off the handler.* BAD. This handler is trans-dimensional. We just ruined the recheck for some condenser in some other dimension. If this handler ever does more than just recheck lock slots this would be so bad.

What I did was 
1. TileEntityHandler holds hard references to TileEntity objects instead of silly coordinates. Memory leaks should not be a concern as objects are added and removed automatically as they are chunkloaded/unloaded. 
2. When ThreadEMCRemap runs, it just tells the server to recheck all condensers everywhere and stop trying to be smart doing just the command sender's world, etc.
