### PR TITLE
Remove items from creative tab that shouldn't be there

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/blocks/MatterFurnace.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/blocks/MatterFurnace.java
@@ -115,13 +115,15 @@ public class MatterFurnace extends BlockDirection implements ITileEntityProvider
 		{
 			if (isHighTier)
 				world.setBlock(x, y, z, ObjHandler.rmFurnaceOn);
-			else world.setBlock(x, y, z, ObjHandler.dmFurnaceOn);
+			else
+				world.setBlock(x, y, z, ObjHandler.dmFurnaceOn);
 		}
 		else
 		{
 			if (isHighTier)
 				world.setBlock(x, y, z, ObjHandler.rmFurnaceOff);
-			else world.setBlock(x, y, z, ObjHandler.dmFurnaceOff);
+			else
+				world.setBlock(x, y, z, ObjHandler.dmFurnaceOff);
 		}
 
 		isUpdating = false;

--- a/src/main/java/moze_intel/projecte/gameObjs/blocks/MatterFurnace.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/blocks/MatterFurnace.java
@@ -45,6 +45,7 @@ public class MatterFurnace extends BlockDirection implements ITileEntityProvider
 		
 		if (isActive) 
 		{
+			this.setCreativeTab(null);
 			this.setLightLevel(0.875F);
 		}
 	}
@@ -191,8 +192,8 @@ public class MatterFurnace extends BlockDirection implements ITileEntityProvider
 	@SideOnly(Side.CLIENT)
 	public void registerBlockIcons(IIconRegister register)
 	{
-		this.blockIcon = register.registerIcon("projecte:"+textureName);
-		front = register.registerIcon("projecte:matter_furnace/"+(isActive ? (textureName+"_on") : (textureName + "_off")));
+		this.blockIcon = register.registerIcon("projecte:" + textureName);
+		front = register.registerIcon("projecte:matter_furnace/" + (isActive ? (textureName + "_on") : (textureName + "_off")));
 	}
 	
 	@SideOnly(Side.CLIENT)
@@ -209,7 +210,7 @@ public class MatterFurnace extends BlockDirection implements ITileEntityProvider
 	@SideOnly(Side.CLIENT)
 	public Item getItem(World world, int x, int y, int z)
 	{
-		return isHighTier ? isActive ? Item.getItemFromBlock(ObjHandler.rmFurnaceOn) : Item.getItemFromBlock(ObjHandler.rmFurnaceOff) : Item.getItemFromBlock(ObjHandler.dmFurnaceOff);
+		return isHighTier ? Item.getItemFromBlock(ObjHandler.rmFurnaceOff) : Item.getItemFromBlock(ObjHandler.dmFurnaceOff);
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/items/itemEntities/LavaOrb.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/itemEntities/LavaOrb.java
@@ -9,6 +9,7 @@ public class LavaOrb extends ItemPE
 {
 	public LavaOrb()
 	{
+		this.setCreativeTab(null);
 		this.setUnlocalizedName("lava_orb");
 		this.setMaxStackSize(1);
 	}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/itemEntities/LensExplosive.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/itemEntities/LensExplosive.java
@@ -9,6 +9,7 @@ public class LensExplosive extends ItemPE
 {
 	public LensExplosive()
 	{
+		this.setCreativeTab(null);
 		this.setUnlocalizedName("lens_explosive");
 		this.setMaxStackSize(1);
 	}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/itemEntities/LootBallItem.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/itemEntities/LootBallItem.java
@@ -9,6 +9,7 @@ public class LootBallItem extends ItemPE
 {
 	public LootBallItem()
 	{
+		this.setCreativeTab(null);
 		this.setUnlocalizedName("loot_ball");
 		this.setMaxStackSize(1);
 	}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/itemEntities/RandomizerProjectile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/itemEntities/RandomizerProjectile.java
@@ -9,6 +9,7 @@ public class RandomizerProjectile extends ItemPE
 {
 	public RandomizerProjectile()
 	{
+		this.setCreativeTab(null);
 		this.setUnlocalizedName("randomizer");
 		this.setMaxStackSize(1);
 	}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/itemEntities/WaterOrb.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/itemEntities/WaterOrb.java
@@ -9,6 +9,7 @@ public class WaterOrb extends ItemPE
 {
 	public WaterOrb()
 	{
+		this.setCreativeTab(null);
 		this.setUnlocalizedName("water_orb");
 		this.setMaxStackSize(1);
 	}

--- a/src/main/resources/assets/projecte/lang/de_DE.lang
+++ b/src/main/resources/assets/projecte/lang/de_DE.lang
@@ -268,7 +268,7 @@ pe.pedestal.item_disabled=Podestfunktion wurde deaktiviert!
 pe.pedestal.on_pedestal=Auf Podest:
 pe.pedestal.shortname=DM-Podest
 pe.pedestal.tooltip1=Shift + Rechtsklick um GUI zu öffnen
-pe.pedestal.tooltip2=Rechtsklick zum aktivieren!
+pe.pedestal.tooltip2=Rechtsklick zum Aktivieren!
 
 pe.philstone.mode1=Würfel
 pe.philstone.mode2=Panel


### PR DESCRIPTION
I removed the lava orb, the water orb, the explosive lens, the loot ball, the randomizer orb and the active versions of the matter furnaces from the creative tab because they are useless in the inventory. I also fixed a typo in de_DE.lang and I cleaned up the <code>MatterFurnace</code> class a little bit.