### PR TITLE
Actually fix GoED localizations and buff speed to match ee2

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/GemEternalDensity.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/GemEternalDensity.java
@@ -317,8 +317,7 @@ public class GemEternalDensity extends ItemPE implements IAlchChestItem, IModeCh
 			stack.stackTagCompound.setByte("Target", (byte) (oldMode + 1));
 		}
 
-		player.addChatComponentMessage(new ChatComponentTranslation("pe.gemdensity.mode_switch")
-				.appendText(" ").appendSibling(new ChatComponentTranslation(getTargetName(stack))));
+		player.addChatComponentMessage(new ChatComponentTranslation("pe.gemdensity.mode_switch").appendText(" ").appendSibling(new ChatComponentTranslation(getTargetName(stack))));
 	}
 	
 	@Override
@@ -329,7 +328,7 @@ public class GemEternalDensity extends ItemPE implements IAlchChestItem, IModeCh
 		
 		if (stack.hasTagCompound())
 		{
-			list.add(String.format(StatCollector.translateToLocal("pe.gemdensity.tooltip2"), getTargetName(stack)));
+			list.add(String.format(StatCollector.translateToLocal("pe.gemdensity.tooltip2"), StatCollector.translateToLocal(getTargetName(stack))));
 		}
 		
 		if (KeyHelper.getModeKeyCode() >= 0 && KeyHelper.getModeKeyCode() < Keyboard.getKeyCount())

--- a/src/main/java/moze_intel/projecte/gameObjs/items/GemEternalDensity.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/GemEternalDensity.java
@@ -89,18 +89,18 @@ public class GemEternalDensity extends ItemPE implements IAlchChestItem, IModeCh
 			if ((isWhitelist && listContains(whitelist, s)) || (!isWhitelist && !listContains(whitelist, s)))
 			{
 				ItemStack copy = s.copy();
-				copy.stackSize = 1;
-				
+				copy.stackSize = s.stackSize == 1 ? 1 : s.stackSize / 2;
+
 				addToList(gem, copy);
 				
-				inv[i].stackSize--;
+				s.stackSize -= copy.stackSize;
 				
-				if (inv[i].stackSize <= 0)
+				if (s.stackSize <= 0)
 				{
 					inv[i] = null;
 				}
 				
-				ItemPE.addEmc(gem, EMCHelper.getEmcValue(copy));
+				ItemPE.addEmc(gem, EMCHelper.getEmcValue(copy) * copy.stackSize);
 				break;
 			}
 		}

--- a/src/main/java/moze_intel/projecte/utils/EMCHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/EMCHelper.java
@@ -165,6 +165,9 @@ public final class EMCHelper
 		return 0;
 	}
 
+	/**
+	 * Does not consider stack size
+	 */
 	public static int getEmcValue(ItemStack stack)
 	{
 		if (stack == null)

--- a/src/main/resources/assets/projecte/lang/en_US.lang
+++ b/src/main/resources/assets/projecte/lang/en_US.lang
@@ -228,7 +228,7 @@ pe.gem.stepassist_tooltip=Step Assist:
 pe.gem.stepassist.prompt=Press %s to toggle Step Assist
 
 pe.gemdensity.blacklist=Blacklist
-pe.gemdensity.mode_switch=Set target to %s
+pe.gemdensity.mode_switch=Set target to
 pe.gemdensity.tooltip1=Condenses items on the go
 pe.gemdensity.tooltip2=Current target: %s
 pe.gemdensity.tooltip3=Press %s to change target


### PR DESCRIPTION
I thought i fixed these in the serverlang pull but guess not.
Also considerably buffed the consumption rate of the gem to match what it was in ee2. Instead of 1 item per tick (ProjectE), halve the stack size each tick (EE2)