### PR TITLE
Internal rename with remapping!

### DIFF
--- a/src/main/java/moze_intel/projecte/PECore.java
+++ b/src/main/java/moze_intel/projecte/PECore.java
@@ -43,6 +43,7 @@ import moze_intel.projecte.playerData.IOHandler;
 import moze_intel.projecte.playerData.Transmutation;
 import moze_intel.projecte.proxies.CommonProxy;
 import moze_intel.projecte.utils.AchievementHandler;
+import moze_intel.projecte.utils.Constants;
 import moze_intel.projecte.utils.GuiHandler;
 import moze_intel.projecte.utils.IMCHandler;
 import moze_intel.projecte.utils.PELogger;
@@ -210,19 +211,9 @@ public class PECore
 					}
 					else
 					{
-						String newSubName;
-						if (subName.contains("Realy"))
-						{
-							// Realy MK2 typo and strip space remap for ItemBlock
-							newSubName = subName.replace("Realy", "Relay").toLowerCase().replaceAll("\\s", "_");
-							remappedItem = GameRegistry.findItem(PECore.MODID, newSubName);
-						}
-						else
-						{
-							// strip space remap for ItemBlocks
-							newSubName = subName.toLowerCase().replaceAll("\\s", "_");
-							remappedItem = GameRegistry.findItem(PECore.MODID, newSubName);
-						}
+						// Space strip remap - ItemBlocks
+						String newSubName = Constants.SPACE_STRIP_NAME_MAP.get(subName);
+						remappedItem = GameRegistry.findItem(PECore.MODID, newSubName);
 
 						if (remappedItem != null)
 						{
@@ -237,20 +228,10 @@ public class PECore
 				}
 				if (mapping.type == GameRegistry.Type.BLOCK)
 				{
-					Block remappedBlock;
-					String newSubName;
-					if (subName.contains("Realy"))
-					{
-						// Realy MK2 typo remap
-						newSubName = subName.replace("Realy", "Relay").toLowerCase().replaceAll("\\s", "_");
-						remappedBlock = GameRegistry.findBlock(PECore.MODID, newSubName);
-					}
-					else
-					{
-						// strip space remap for blocks
-						newSubName = subName.toLowerCase().replaceAll("\\s", "_");
-						remappedBlock = GameRegistry.findBlock(PECore.MODID, newSubName);
-					}
+					// Space strip remap - Blocks
+					String newSubName = Constants.SPACE_STRIP_NAME_MAP.get(subName);
+					Block remappedBlock = GameRegistry.findBlock(PECore.MODID, newSubName);
+
 					if (remappedBlock != null)
 					{
 						mapping.remap(remappedBlock);

--- a/src/main/java/moze_intel/projecte/gameObjs/ObjHandler.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/ObjHandler.java
@@ -237,8 +237,8 @@ public class ObjHandler
 
 		// Blocks with ItemBlock
 		GameRegistry.registerBlock(alchChest, ItemAlchemyChestBlock.class, "alchemical_chest");
-		GameRegistry.registerBlock(transmuteStone, ItemTransmutationBlock.class, "transmutation_stone");
-		GameRegistry.registerBlock(condenser, ItemCondenserBlock.class, "condenser");
+		GameRegistry.registerBlock(transmuteStone, ItemTransmutationBlock.class, "transmutation_table");
+		GameRegistry.registerBlock(condenser, ItemCondenserBlock.class, "condenser_mk1");
 		GameRegistry.registerBlock(rmFurnaceOff, ItemRMFurnaceBlock.class, "rm_furnace");
 		GameRegistry.registerBlock(dmFurnaceOff, ItemDMFurnaceBlock.class, "dm_furnace");
 		GameRegistry.registerBlock(matterBlock, ItemMatterBlock.class, "matter_block");

--- a/src/main/java/moze_intel/projecte/gameObjs/ObjHandler.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/ObjHandler.java
@@ -226,28 +226,30 @@ public class ObjHandler
 	
 	public static void register()
 	{
-		//Blocks
-		GameRegistry.registerBlock(alchChest, ItemAlchemyChestBlock.class, "Alchemical Chest");
-		GameRegistry.registerBlock(confuseTorch, "Interdiction Torch");
-		GameRegistry.registerBlock(transmuteStone, ItemTransmutationBlock.class, "Transmutation Stone");
-		GameRegistry.registerBlock(condenser, ItemCondenserBlock.class, "Condenser");
-		GameRegistry.registerBlock(condenserMk2, "Condenser MK2");
-		GameRegistry.registerBlock(rmFurnaceOff, ItemRMFurnaceBlock.class, "RM Furnace");
-		GameRegistry.registerBlock(rmFurnaceOn, "RM Furnace Lit");
-		GameRegistry.registerBlock(dmFurnaceOff, ItemDMFurnaceBlock.class, "DM Furnace");
-		GameRegistry.registerBlock(dmFurnaceOn, "DM Furnace Lit");
-		GameRegistry.registerBlock(dmPedestal, "DM Pedestal");
-		GameRegistry.registerBlock(matterBlock, ItemMatterBlock.class, "Matter Block");
-		GameRegistry.registerBlock(fuelBlock, ItemFuelBlock.class, "Fuel Block");
-		GameRegistry.registerBlock(energyCollector, ItemCollectorBlock.class, "Collector MK1");
-		GameRegistry.registerBlock(collectorMK2, ItemRelayBlock.class, "Collector MK2");
-		GameRegistry.registerBlock(collectorMK3, ItemRelayBlock.class, "Collector MK3");
-		GameRegistry.registerBlock(relay, ItemRelayBlock.class, "Relay MK1");
-		GameRegistry.registerBlock(relayMK2, ItemRelayBlock.class, "Realy MK2");
-		GameRegistry.registerBlock(relayMK3, ItemRelayBlock.class, "Relay MK3");
-		GameRegistry.registerBlock(novaCatalyst, "Nova Catalyst");
-		GameRegistry.registerBlock(novaCataclysm, "Nova Cataclysm");
-		
+		// Blocks without ItemBlock
+		GameRegistry.registerBlock(confuseTorch, "interdiction_torch");
+		GameRegistry.registerBlock(condenserMk2, "condenser_mk2");
+		GameRegistry.registerBlock(rmFurnaceOn, "rm_furnace_lit");
+		GameRegistry.registerBlock(dmFurnaceOn, "dm_furnace_lit");
+		GameRegistry.registerBlock(dmPedestal, "dm_pedestal");
+		GameRegistry.registerBlock(novaCatalyst, "nova_catalyst");
+		GameRegistry.registerBlock(novaCataclysm, "nova_cataclysm");
+
+		// Blocks with ItemBlock
+		GameRegistry.registerBlock(alchChest, ItemAlchemyChestBlock.class, "alchemical_chest");
+		GameRegistry.registerBlock(transmuteStone, ItemTransmutationBlock.class, "transmutation_stone");
+		GameRegistry.registerBlock(condenser, ItemCondenserBlock.class, "condenser");
+		GameRegistry.registerBlock(rmFurnaceOff, ItemRMFurnaceBlock.class, "rm_furnace");
+		GameRegistry.registerBlock(dmFurnaceOff, ItemDMFurnaceBlock.class, "dm_furnace");
+		GameRegistry.registerBlock(matterBlock, ItemMatterBlock.class, "matter_block");
+		GameRegistry.registerBlock(fuelBlock, ItemFuelBlock.class, "fuel_block");
+		GameRegistry.registerBlock(energyCollector, ItemCollectorBlock.class, "collector_mk1");
+		GameRegistry.registerBlock(collectorMK2, ItemCollectorBlock.class, "collector_mk2");
+		GameRegistry.registerBlock(collectorMK3, ItemCollectorBlock.class, "collector_mk3");
+		GameRegistry.registerBlock(relay, ItemRelayBlock.class, "relay_mk1");
+		GameRegistry.registerBlock(relayMK2, ItemRelayBlock.class, "relay_mk2");
+		GameRegistry.registerBlock(relayMK3, ItemRelayBlock.class, "relay_mk3");
+
 		//Items
 		GameRegistry.registerItem(philosStone, philosStone.getUnlocalizedName());
 		GameRegistry.registerItem(alchBag, alchBag.getUnlocalizedName());
@@ -327,30 +329,30 @@ public class ObjHandler
 		GameRegistry.registerItem(transmutationTablet, transmutationTablet.getUnlocalizedName());
 		
 		//Tile Entities
-		GameRegistry.registerTileEntity(AlchChestTile.class, "Alchemical Chest Tile");
-		GameRegistry.registerTileEntity(InterdictionTile.class, "Interdiction Torch Tile");
-		GameRegistry.registerTileEntity(CondenserTile.class, "Condenser Tile");
-		GameRegistry.registerTileEntity(CondenserMK2Tile.class, "Condenser MK2 Tile");
-		GameRegistry.registerTileEntity(RMFurnaceTile.class, "RM Furnace Tile");
-		GameRegistry.registerTileEntity(DMFurnaceTile.class, "DM Furnace Tile");
-		GameRegistry.registerTileEntity(CollectorMK1Tile.class, "Energy Collector MK1 Tile");
-		GameRegistry.registerTileEntity(CollectorMK2Tile.class, "Energy Collector MK2 Tile");
-		GameRegistry.registerTileEntity(CollectorMK3Tile.class, "Energy Collector MK3 Tile");
-		GameRegistry.registerTileEntity(RelayMK1Tile.class, "AM Relay MK1 Tile");
-		GameRegistry.registerTileEntity(RelayMK2Tile.class, "AM Relay MK2 Tile");
-		GameRegistry.registerTileEntity(RelayMK3Tile.class, "AM Relay MK3 Tile");
-		GameRegistry.registerTileEntity(TransmuteTile.class, "Transmutation Tablet Tile");
-		GameRegistry.registerTileEntity(DMPedestalTile.class, "DM Pedestal Tile");
+		GameRegistry.registerTileEntityWithAlternatives(AlchChestTile.class, "AlchChestTile", "Alchemical Chest Tile");
+		GameRegistry.registerTileEntityWithAlternatives(InterdictionTile.class, "InterdictionTile", "Interdiction Torch Tile");
+		GameRegistry.registerTileEntityWithAlternatives(CondenserTile.class, "CondenserTile", "Condenser Tile");
+		GameRegistry.registerTileEntityWithAlternatives(CondenserMK2Tile.class, "CondenserMK2Tile", "Condenser MK2 Tile");
+		GameRegistry.registerTileEntityWithAlternatives(RMFurnaceTile.class, "RMFurnaceTile", "RM Furnace Tile");
+		GameRegistry.registerTileEntityWithAlternatives(DMFurnaceTile.class, "DMFurnaceTile", "DM Furnace Tile");
+		GameRegistry.registerTileEntityWithAlternatives(CollectorMK1Tile.class, "CollectorMK1Tile", "Energy Collector MK1 Tile");
+		GameRegistry.registerTileEntityWithAlternatives(CollectorMK2Tile.class, "CollectorMK2Tile", "Energy Collector MK2 Tile");
+		GameRegistry.registerTileEntityWithAlternatives(CollectorMK3Tile.class, "CollectorMK3Tile", "Energy Collector MK3 Tile");
+		GameRegistry.registerTileEntityWithAlternatives(RelayMK1Tile.class, "RelayMK1Tile", "AM Relay MK1 Tile");
+		GameRegistry.registerTileEntityWithAlternatives(RelayMK2Tile.class, "RelayMK2Tile", "AM Relay MK2 Tile");
+		GameRegistry.registerTileEntityWithAlternatives(RelayMK3Tile.class, "RelayMK3Tile", "AM Relay MK3 Tile");
+		GameRegistry.registerTileEntityWithAlternatives(TransmuteTile.class, "TransmuteTile", "Transmutation Tablet Tile");
+		GameRegistry.registerTileEntityWithAlternatives(DMPedestalTile.class, "DMPedestalTile", "DM Pedestal Tile");
 		
 		//Entities
-		EntityRegistry.registerModEntity(EntityWaterProjectile.class, "Water Water", 1, PECore.instance, 256, 10, true);
-		EntityRegistry.registerModEntity(EntityLavaProjectile.class, "Lava Orb", 2, PECore.instance, 256, 10, true);
-		EntityRegistry.registerModEntity(EntityLootBall.class, "Loot Ball", 3, PECore.instance, 64, 10, true);
-		EntityRegistry.registerModEntity(EntityMobRandomizer.class, "Mob Randomizer", 4, PECore.instance, 256, 10, true);
-		EntityRegistry.registerModEntity(EntityLensProjectile.class, "Explosive Lens Projectile", 5, PECore.instance, 256, 10, true);
-		EntityRegistry.registerModEntity(EntityNovaCatalystPrimed.class, "Nova Catalyst", 6, PECore.instance, 256, 10, true);
-		EntityRegistry.registerModEntity(EntityNovaCataclysmPrimed.class, "Nova Cataclysm", 7, PECore.instance, 256, 10, true);
-		EntityRegistry.registerModEntity(EntityHomingArrow.class, "Homing Arrow", 8, PECore.instance, 256, 10, true);
+		EntityRegistry.registerModEntity(EntityWaterProjectile.class, "WaterProjectile", 1, PECore.instance, 256, 10, true);
+		EntityRegistry.registerModEntity(EntityLavaProjectile.class, "LavaProjectile", 2, PECore.instance, 256, 10, true);
+		EntityRegistry.registerModEntity(EntityLootBall.class, "LootBall", 3, PECore.instance, 64, 10, true);
+		EntityRegistry.registerModEntity(EntityMobRandomizer.class, "MobRandomizer", 4, PECore.instance, 256, 10, true);
+		EntityRegistry.registerModEntity(EntityLensProjectile.class, "LensProjectile", 5, PECore.instance, 256, 10, true);
+		EntityRegistry.registerModEntity(EntityNovaCatalystPrimed.class, "NovaCatalystPrimed", 6, PECore.instance, 256, 10, true);
+		EntityRegistry.registerModEntity(EntityNovaCataclysmPrimed.class, "NovaCataclysmPrimed", 7, PECore.instance, 256, 10, true);
+		EntityRegistry.registerModEntity(EntityHomingArrow.class, "HomingArrow", 8, PECore.instance, 256, 10, true);
 	}
 	
 	public static void addRecipes()

--- a/src/main/java/moze_intel/projecte/utils/Constants.java
+++ b/src/main/java/moze_intel/projecte/utils/Constants.java
@@ -1,5 +1,6 @@
 package moze_intel.projecte.utils;
 
+import com.google.common.collect.ImmutableMap;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import moze_intel.projecte.PECore;
 import net.minecraft.util.ResourceLocation;
@@ -67,4 +68,31 @@ public final class Constants
 	public static final int MAX_VEIN_SIZE = 250;
 	
 	public static final int ENCH_EMC_BONUS = 5000;
+
+	public static final ImmutableMap<String, String> SPACE_STRIP_NAME_MAP;
+
+	static {
+		ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+		builder.put("Alchemical Chest", "alchemical_chest");
+		builder.put("Interdiction Torch", "interdiction_torch");
+		builder.put("Transmutation Stone", "transmutation_table");
+		builder.put("Condenser", "condenser_mk1");
+		builder.put("Condenser MK2", "condenser_mk2");
+		builder.put("RM Furnace", "rm_furnace");
+		builder.put("RM Furnace Lit", "rm_furnace_lit");
+		builder.put("DM Furnace", "dm_furnace");
+		builder.put("DM Furnace Lit", "dm_furnace_lit");
+		builder.put("DM Pedestal", "dm_pedestal");
+		builder.put("Matter Block", "matter_block");
+		builder.put("Fuel Block", "fuel_block");
+		builder.put("Collector MK1", "collector_mk1");
+		builder.put("Collector MK2", "collector_mk2");
+		builder.put("Collector MK3", "collector_mk3");
+		builder.put("Relay MK1", "relay_mk1");
+		builder.put("Realy MK2", "relay_mk2");
+		builder.put("Relay MK3", "relay_mk3");
+		builder.put("Nova Catalyst", "nova_catalyst");
+		builder.put("Nova Cataclysm", "nova_cataclysm");
+		SPACE_STRIP_NAME_MAP = builder.build();
+	}
 }


### PR DESCRIPTION
Supersedes #719, sry Kolatra :p

Remove spaces from itemblock, block, TileEntity, and entity names. Fixed relay MK2 being "Realy MK2"

Technical deets -
- ItemBlocks and Blocks share names, simply replace spaces and lowercase all. See code.
- Entities: The entities we have are all transient in nature (lootballs, projectiles, and explosive) - they rarely last longer than 5 minutes at max. Thus I simply renamed them.  They will be lost but unless someone stores valuables in lootballs in 5 minute intervals no one will care :p
- Tile Entities: There is a built in system for renaming where one simply registers multiple names, but specifies a single one that will be saved. Forge will read the old names, but then resave them as the primary name you specify. Easy peasy.