### PR TITLE
Use fractions internally for items with 0< EMC < 1

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/EMCMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/EMCMapper.java
@@ -1,7 +1,7 @@
 package moze_intel.projecte.emc;
 
 import moze_intel.projecte.PECore;
-import moze_intel.projecte.emc.arithmetics.IntArithmetic;
+import moze_intel.projecte.emc.arithmetics.HiddenFractionArithmetic;
 import moze_intel.projecte.emc.mappers.APICustomEMCMapper;
 import moze_intel.projecte.emc.mappers.CraftingMapper;
 import moze_intel.projecte.emc.mappers.CustomEMCMapper;
@@ -10,6 +10,7 @@ import moze_intel.projecte.emc.mappers.LazyMapper;
 import moze_intel.projecte.emc.mappers.OreDictionaryMapper;
 import moze_intel.projecte.emc.mappers.SmeltingMapper;
 import moze_intel.projecte.emc.pregenerated.PregeneratedEMC;
+import moze_intel.projecte.emc.valuetranslators.FractionToIntegerTranslator;
 import moze_intel.projecte.playerData.Transmutation;
 import moze_intel.projecte.utils.PELogger;
 import moze_intel.projecte.utils.PrefixConfiguration;
@@ -17,6 +18,7 @@ import moze_intel.projecte.utils.PrefixConfiguration;
 import com.google.common.collect.Maps;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.oredict.OreDictionary;
+import org.apache.commons.lang3.math.Fraction;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,7 +45,7 @@ public final class EMCMapper
 				new moze_intel.projecte.emc.mappers.FluidMapper(),
 				new SmeltingMapper()
 		);
-		SimpleGraphMapper<NormalizedSimpleStack, Integer> graphMapper = new SimpleGraphMapper<NormalizedSimpleStack, Integer>(new IntArithmetic());
+		IValueGenerator<NormalizedSimpleStack, Integer> graphMapper = new FractionToIntegerTranslator<NormalizedSimpleStack>(new SimpleGraphMapper<NormalizedSimpleStack, Fraction>(new HiddenFractionArithmetic()));
 
 		Configuration config = new Configuration(new File(PECore.CONFIG_DIR, "mapping.cfg"));
 		config.load();
@@ -59,7 +61,7 @@ public final class EMCMapper
 		{
 
 
-			graphMapper.setLogFoundExploits(config.getBoolean("logEMCExploits", "general", true,
+			SimpleGraphMapper.setLogFoundExploits(config.getBoolean("logEMCExploits", "general", true,
 					"Log known EMC Exploits. This can not and will not find all possible exploits. " +
 							"This will only find exploits that result in fixed/custom emc values that the algorithm did not overwrite. " +
 							"Exploits that derive from conversions that are unknown to ProjectE will not be found."

--- a/src/main/java/moze_intel/projecte/emc/GraphMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/GraphMapper.java
@@ -10,7 +10,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-public abstract class GraphMapper<T, V extends Comparable<V>> implements IMappingCollector<T, V> {
+public abstract class GraphMapper<T, V extends Comparable<V>> implements IValueGenerator<T, V> {
 	protected static final boolean DEBUG_GRAPHMAPPER = false;
 
 	protected static void debugFormat(String format, Object... args) {

--- a/src/main/java/moze_intel/projecte/emc/IValueGenerator.java
+++ b/src/main/java/moze_intel/projecte/emc/IValueGenerator.java
@@ -1,0 +1,8 @@
+package moze_intel.projecte.emc;
+
+import java.util.Map;
+
+public interface IValueGenerator<T, V extends Comparable<V>> extends IMappingCollector<T, V>
+{
+	public Map<T, V> generateValues();
+}

--- a/src/main/java/moze_intel/projecte/emc/SimpleGraphMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/SimpleGraphMapper.java
@@ -11,7 +11,7 @@ public class SimpleGraphMapper<T, V extends Comparable<V>> extends GraphMapper<T
 	static boolean OVERWRITE_FIXED_VALUES = false;
 	protected V ZERO;
 
-	private boolean logFoundExploits = true;
+	private static boolean logFoundExploits = true;
 	public SimpleGraphMapper(IValueArithmetic<V> arithmetic) {
 		super(arithmetic);
 		ZERO = arithmetic.getZero();
@@ -21,7 +21,7 @@ public class SimpleGraphMapper<T, V extends Comparable<V>> extends GraphMapper<T
 		return (m.containsKey(key) && value.compareTo(m.get(key)) >= 0);
 	}
 
-	public void setLogFoundExploits(boolean log) {
+	public static void setLogFoundExploits(boolean log) {
 		logFoundExploits = log;
 	}
 

--- a/src/main/java/moze_intel/projecte/emc/SimpleGraphMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/SimpleGraphMapper.java
@@ -155,6 +155,12 @@ public class SimpleGraphMapper<T, V extends Comparable<V>> extends GraphMapper<T
 		boolean hasPositiveIngredientValues = false;
 		for (Map.Entry<T, Integer> entry:conversion.ingredientsWithAmount.entrySet()) {
 			if (values.containsKey(entry.getKey())) {
+				//The ingredient has a value
+				if (entry.getValue() == 0)
+				{
+					//Ingredients with an amount of 'zero' do not need to be handled.
+					continue;
+				}
 				//value = value + amount * ingredientcost
 				V ingredientValue = arithmetic.mul(entry.getValue(),values.get(entry.getKey()));
 				if (ingredientValue.compareTo(ZERO) != 0) {

--- a/src/main/java/moze_intel/projecte/emc/SimpleGraphMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/SimpleGraphMapper.java
@@ -156,10 +156,10 @@ public class SimpleGraphMapper<T, V extends Comparable<V>> extends GraphMapper<T
 		for (Map.Entry<T, Integer> entry:conversion.ingredientsWithAmount.entrySet()) {
 			if (values.containsKey(entry.getKey())) {
 				//value = value + amount * ingredientcost
-				V ingredientValue = values.get(entry.getKey());
+				V ingredientValue = arithmetic.mul(entry.getValue(),values.get(entry.getKey()));
 				if (ingredientValue.compareTo(ZERO) != 0) {
 					if (!arithmetic.isFree(ingredientValue)) {
-						value = arithmetic.add(value, arithmetic.mul(entry.getValue(), ingredientValue));
+						value = arithmetic.add(value, ingredientValue);
 						if (ingredientValue.compareTo(ZERO) > 0 && entry.getValue() > 0) hasPositiveIngredientValues = true;
 						allIngredientsAreFree = false;
 					}

--- a/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenFractionArithmetic.java
+++ b/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenFractionArithmetic.java
@@ -38,7 +38,7 @@ public class HiddenFractionArithmetic implements IValueArithmetic<Fraction>
 	public Fraction div(Fraction a, int b)
 	{
 		if (this.isFree(a)) return getFree();
-		return zeroOrInt(a.divideBy(Fraction.getFraction(b, 1)));
+		return a.divideBy(Fraction.getFraction(b, 1));
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenFractionArithmetic.java
+++ b/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenFractionArithmetic.java
@@ -22,6 +22,8 @@ public class HiddenFractionArithmetic implements IValueArithmetic<Fraction>
 	@Override
 	public Fraction add(Fraction a, Fraction b)
 	{
+		if (isFree(a)) return b;
+		if (isFree(b)) return a;
 		return a.add(b);
 	}
 
@@ -48,12 +50,12 @@ public class HiddenFractionArithmetic implements IValueArithmetic<Fraction>
 	@Override
 	public boolean isFree(Fraction value)
 	{
-		return value.getNumerator() < 0;
+		return value.getNumerator() == Integer.MIN_VALUE;
 	}
 
 	protected Fraction zeroOrInt(Fraction value)
 	{
-		if (value.compareTo(Fraction.ONE) < 0) return Fraction.ZERO;
+		if (Fraction.ZERO.compareTo(value) <= 0 && value.compareTo(Fraction.ONE) < 0) return Fraction.ZERO;
 		return Fraction.getFraction(value.intValue(), 1);
 	}
 }

--- a/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenFractionArithmetic.java
+++ b/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenFractionArithmetic.java
@@ -24,6 +24,7 @@ public class HiddenFractionArithmetic implements IValueArithmetic<Fraction>
 	{
 		if (isFree(a)) return b;
 		if (isFree(b)) return a;
+
 		return a.add(b);
 	}
 
@@ -38,7 +39,12 @@ public class HiddenFractionArithmetic implements IValueArithmetic<Fraction>
 	public Fraction div(Fraction a, int b)
 	{
 		if (this.isFree(a)) return getFree();
-		return a.divideBy(Fraction.getFraction(b, 1));
+		Fraction result = a.divideBy(Fraction.getFraction(b, 1));
+		if (Fraction.ZERO.compareTo(result) <= 0 && result.compareTo(Fraction.ONE) < 0)
+		{
+			return result;
+		}
+		return Fraction.getFraction(result.intValue(), 1);
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenFractionArithmetic.java
+++ b/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenFractionArithmetic.java
@@ -4,7 +4,7 @@ import moze_intel.projecte.emc.IValueArithmetic;
 
 import org.apache.commons.lang3.math.Fraction;
 
-public class HiddenRationalArithmetic implements IValueArithmetic<Fraction>
+public class HiddenFractionArithmetic implements IValueArithmetic<Fraction>
 {
 
 	@Override

--- a/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenRationalArithmetic.java
+++ b/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenRationalArithmetic.java
@@ -1,0 +1,59 @@
+package moze_intel.projecte.emc.arithmetics;
+
+import moze_intel.projecte.emc.IValueArithmetic;
+
+import org.apache.commons.lang3.math.Fraction;
+
+public class HiddenRationalArithmetic implements IValueArithmetic<Fraction>
+{
+
+	@Override
+	public boolean isZero(Fraction value)
+	{
+		return value.getNumerator() == 0;
+	}
+
+	@Override
+	public Fraction getZero()
+	{
+		return Fraction.ZERO;
+	}
+
+	@Override
+	public Fraction add(Fraction a, Fraction b)
+	{
+		return a.add(b);
+	}
+
+	@Override
+	public Fraction mul(int a, Fraction b)
+	{
+		if (this.isFree(b)) return getFree();
+		return zeroOrInt(b.multiplyBy(Fraction.getFraction(a, 1)));
+	}
+
+	@Override
+	public Fraction div(Fraction a, int b)
+	{
+		if (this.isFree(a)) return getFree();
+		return zeroOrInt(a.divideBy(Fraction.getFraction(b, 1)));
+	}
+
+	@Override
+	public Fraction getFree()
+	{
+		return Fraction.getFraction(Integer.MIN_VALUE, 1);
+	}
+
+	@Override
+	public boolean isFree(Fraction value)
+	{
+		return value.getNumerator() < 0;
+	}
+
+	protected Fraction zeroOrInt(Fraction value)
+	{
+		if (value.compareTo(Fraction.ONE) < 0) return Fraction.ZERO;
+		return Fraction.getFraction(value.intValue(), 1);
+	}
+}

--- a/src/main/java/moze_intel/projecte/emc/valuetranslators/AbstractTranslator.java
+++ b/src/main/java/moze_intel/projecte/emc/valuetranslators/AbstractTranslator.java
@@ -1,0 +1,49 @@
+package moze_intel.projecte.emc.valuetranslators;
+
+import moze_intel.projecte.emc.IValueGenerator;
+
+import org.apache.commons.lang3.math.Fraction;
+
+import java.util.Map;
+
+public abstract class AbstractTranslator<T, IN extends Comparable<IN>, OUT extends Comparable<OUT>> implements IValueGenerator<T, OUT>
+{
+
+	protected IValueGenerator<T, IN> inner;
+	public AbstractTranslator(IValueGenerator<T, IN> inner)
+	{
+		this.inner = inner;
+	}
+
+	public abstract IN translateValue(OUT v);
+
+	@Override
+	public void addConversionMultiple(int outnumber, T output, Map<T, Integer> ingredientsWithAmount)
+	{
+		inner.addConversionMultiple(outnumber, output, ingredientsWithAmount);
+	}
+
+	@Override
+	public void addConversionMultiple(int outnumber, T output, Map<T, Integer> ingredientsWithAmount, OUT baseValueForConversion)
+	{
+		inner.addConversionMultiple(outnumber, output, ingredientsWithAmount, translateValue(baseValueForConversion));
+	}
+
+	@Override
+	public void addConversion(int outnumber, T output, Iterable<T> ingredients)
+	{
+		inner.addConversion(outnumber, output, ingredients);
+	}
+
+	@Override
+	public void addConversion(int outnumber, T output, Iterable<T> ingredients, OUT baseValueForConversion)
+	{
+		inner.addConversion(outnumber,output, ingredients, translateValue(baseValueForConversion));
+	}
+
+	@Override
+	public void setValue(T something, OUT value, FixedValue type)
+	{
+		inner.setValue(something, translateValue(value), type);
+	}
+}

--- a/src/main/java/moze_intel/projecte/emc/valuetranslators/FractionToIntegerTranslator.java
+++ b/src/main/java/moze_intel/projecte/emc/valuetranslators/FractionToIntegerTranslator.java
@@ -1,0 +1,40 @@
+package moze_intel.projecte.emc.valuetranslators;
+
+import moze_intel.projecte.emc.IMappingCollector;
+import moze_intel.projecte.emc.IValueGenerator;
+
+import com.google.common.collect.Maps;
+import org.apache.commons.lang3.math.Fraction;
+
+import java.util.Map;
+
+public class FractionToIntegerTranslator<T> extends AbstractTranslator<T, Fraction, Integer>
+{
+	public FractionToIntegerTranslator(IValueGenerator<T, Fraction> inner)
+	{
+		super(inner);
+	}
+
+	@Override
+	public Map<T, Integer> generateValues()
+	{
+		Map<T, Fraction> innerReslt = inner.generateValues();
+		Map<T, Integer> myResult = Maps.newHashMap();
+		for (Map.Entry<T, Fraction> entry: innerReslt.entrySet())
+		{
+			Fraction value = entry.getValue();
+			if (value.intValue() > 0)
+			{
+				myResult.put(entry.getKey(), value.intValue());
+			}
+		}
+		return myResult;
+	}
+
+
+	@Override
+	public Fraction translateValue(Integer v)
+	{
+		return Fraction.getFraction(v, 1);
+	}
+}

--- a/src/test/java/moze_intel/projecte/emc/GraphMapperTest.java
+++ b/src/test/java/moze_intel/projecte/emc/GraphMapperTest.java
@@ -1,44 +1,37 @@
 package moze_intel.projecte.emc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-
 import moze_intel.projecte.emc.arithmetics.IntArithmetic;
-
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-@RunWith(value = Parameterized.class)
+import static org.junit.Assert.*;
+
+//@RunWith(value = Parameterized.class)
 public class GraphMapperTest {
 
-	@Parameters
+/*	@Parameterized.Parameters
 	public static Collection  parameters() {
-		Object[][] data = new Object[][] {
-				{ new SimpleGraphMapper<String, Integer>(new IntArithmetic())  },
-		};
+		Object[][] data = new Object[][] { { new ComplexGraphMapper<String, Integer>(new IntArithmetic())  }};
 		return Arrays.asList(data);
 	}
 
-	public GraphMapperTest(IValueGenerator<String, Integer> graphMapper) {
+	public GraphMapperTest(GraphMapper<String, Integer> graphMapper) {
 		this.graphMapper = graphMapper;
+	}*/
+	@Before
+	public void setup() {
+		graphMapper = new SimpleGraphMapper<String, Integer>(new IntArithmetic());
 	}
 
 	@Rule
 	public Timeout timeout = new Timeout(3000);
 
-	public IValueGenerator<String, Integer> graphMapper;
+	public GraphMapper<String, Integer> graphMapper;
 
 	@org.junit.Test
 	public void testGetOrCreateList() throws Exception {

--- a/src/test/java/moze_intel/projecte/emc/GraphMapperTest.java
+++ b/src/test/java/moze_intel/projecte/emc/GraphMapperTest.java
@@ -1,11 +1,12 @@
 package moze_intel.projecte.emc;
 
-import moze_intel.projecte.emc.arithmetics.IntArithmetic;
+import moze_intel.projecte.emc.arithmetics.HiddenFractionArithmetic;
+import moze_intel.projecte.emc.valuetranslators.FractionToIntegerTranslator;
+
+import org.apache.commons.lang3.math.Fraction;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.*;
 
@@ -25,13 +26,14 @@ public class GraphMapperTest {
 	}*/
 	@Before
 	public void setup() {
-		graphMapper = new SimpleGraphMapper<String, Integer>(new IntArithmetic());
+		//graphMapper = new SimpleGraphMapper<String, Integer>(new IntArithmetic());
+		graphMapper = new FractionToIntegerTranslator<String>(new SimpleGraphMapper<String, Fraction>(new HiddenFractionArithmetic()));
 	}
 
 	@Rule
 	public Timeout timeout = new Timeout(3000);
 
-	public GraphMapper<String, Integer> graphMapper;
+	public IValueGenerator<String, Integer> graphMapper;
 
 	@org.junit.Test
 	public void testGetOrCreateList() throws Exception {

--- a/src/test/java/moze_intel/projecte/emc/GraphMapperTest.java
+++ b/src/test/java/moze_intel/projecte/emc/GraphMapperTest.java
@@ -1,37 +1,44 @@
 package moze_intel.projecte.emc;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import moze_intel.projecte.emc.arithmetics.IntArithmetic;
-import org.junit.Before;
+
 import org.junit.Rule;
 import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
-import static org.junit.Assert.*;
-
-//@RunWith(value = Parameterized.class)
+@RunWith(value = Parameterized.class)
 public class GraphMapperTest {
 
-/*	@Parameterized.Parameters
+	@Parameters
 	public static Collection  parameters() {
-		Object[][] data = new Object[][] { { new ComplexGraphMapper<String, Integer>(new IntArithmetic())  }};
+		Object[][] data = new Object[][] {
+				{ new SimpleGraphMapper<String, Integer>(new IntArithmetic())  },
+		};
 		return Arrays.asList(data);
 	}
 
-	public GraphMapperTest(GraphMapper<String, Integer> graphMapper) {
+	public GraphMapperTest(IValueGenerator<String, Integer> graphMapper) {
 		this.graphMapper = graphMapper;
-	}*/
-	@Before
-	public void setup() {
-		graphMapper = new SimpleGraphMapper<String, Integer>(new IntArithmetic());
 	}
 
 	@Rule
 	public Timeout timeout = new Timeout(3000);
 
-	public GraphMapper<String, Integer> graphMapper;
+	public IValueGenerator<String, Integer> graphMapper;
 
 	@org.junit.Test
 	public void testGetOrCreateList() throws Exception {

--- a/src/test/java/moze_intel/projecte/emc/HiddenFractionSpecificTest.java
+++ b/src/test/java/moze_intel/projecte/emc/HiddenFractionSpecificTest.java
@@ -42,6 +42,26 @@ public class HiddenFractionSpecificTest
 
 	}
 
+	@Test
+	public void nuggetExploits()
+	{
+		graphMapper.setValue("ingot", 2048, IMappingCollector.FixedValue.FixAndInherit);
+		graphMapper.setValue("melon", 16, IMappingCollector.FixedValue.FixAndInherit);
+		graphMapper.addConversion(9, "nugget", Arrays.asList("ingot"));
+		graphMapper.addConversion(1, "goldmelon", Arrays.asList(
+				"nugget", "nugget", "nugget",
+				"nugget", "melon", "nugget",
+				"nugget", "nugget", "nugget"
+		));
+
+
+		Map<String, Integer> values = graphMapper.generateValues();
+		assertEquals(2048, getValue(values, "ingot"));
+		assertEquals(16, getValue(values, "melon"));
+		assertEquals(227, getValue(values, "nugget"));
+		assertEquals(8*227+16, getValue(values, "goldmelon"));
+	}
+
 	private static <T, V extends Number> int getValue(Map<T, V> map, T key) {
 		V val = map.get(key);
 		if (val == null) return 0;

--- a/src/test/java/moze_intel/projecte/emc/HiddenFractionSpecificTest.java
+++ b/src/test/java/moze_intel/projecte/emc/HiddenFractionSpecificTest.java
@@ -1,0 +1,51 @@
+package moze_intel.projecte.emc;
+
+import static org.junit.Assert.assertEquals;
+
+import moze_intel.projecte.emc.arithmetics.HiddenFractionArithmetic;
+import moze_intel.projecte.emc.valuetranslators.FractionToIntegerTranslator;
+
+import org.apache.commons.lang3.math.Fraction;
+import org.junit.Before;
+import org.junit.Test;
+import scala.Int;
+
+import java.util.Arrays;
+import java.util.Map;
+
+public class HiddenFractionSpecificTest
+{
+	public IValueGenerator<String, Integer> graphMapper;
+
+	@Before
+	public void setup()
+	{
+		graphMapper = new FractionToIntegerTranslator<String>(new SimpleGraphMapper<String, Fraction>(new HiddenFractionArithmetic()));
+	}
+
+	@Test
+	public void slabRecipe()
+	{
+		graphMapper.setValue("s", 1, IMappingCollector.FixedValue.FixAndInherit);
+		graphMapper.setValue("redstone", 64, IMappingCollector.FixedValue.FixAndInherit);
+		graphMapper.setValue("glass", 1, IMappingCollector.FixedValue.FixAndInherit);
+		graphMapper.addConversion(6, "slab", Arrays.asList("s", "s", "s"));
+		graphMapper.addConversion(1, "doubleslab", Arrays.asList("slab", "slab"));
+		graphMapper.addConversion(1, "transferpipe", Arrays.asList("slab", "slab", "slab", "glass", "redstone", "glass", "slab", "slab", "slab"));
+		Map<String, Integer> values = graphMapper.generateValues();
+		assertEquals(1, getValue(values, "s"));
+		assertEquals(64, getValue(values, "redstone"));
+		assertEquals(1, getValue(values, "glass"));
+		assertEquals(0, getValue(values, "slab"));
+		assertEquals(3 + 64 + 2, getValue(values, "transferpipe"));
+		assertEquals(1, getValue(values, "doubleslab"));
+
+	}
+
+	private static <T, V extends Number> int getValue(Map<T, V> map, T key) {
+		V val = map.get(key);
+		if (val == null) return 0;
+		return val.intValue();
+	}
+
+}

--- a/src/test/java/moze_intel/projecte/emc/HiddenFractionSpecificTest.java
+++ b/src/test/java/moze_intel/projecte/emc/HiddenFractionSpecificTest.java
@@ -5,10 +5,10 @@ import static org.junit.Assert.assertEquals;
 import moze_intel.projecte.emc.arithmetics.HiddenFractionArithmetic;
 import moze_intel.projecte.emc.valuetranslators.FractionToIntegerTranslator;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.math.Fraction;
 import org.junit.Before;
 import org.junit.Test;
-import scala.Int;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -60,6 +60,24 @@ public class HiddenFractionSpecificTest
 		assertEquals(16, getValue(values, "melon"));
 		assertEquals(227, getValue(values, "nugget"));
 		assertEquals(8*227+16, getValue(values, "goldmelon"));
+	}
+
+	@Test
+	public void moltenEnderpearl()
+	{
+		graphMapper.setValue("enderpearl", 1024, IMappingCollector.FixedValue.FixAndInherit);
+		graphMapper.setValue("bucket", 768, IMappingCollector.FixedValue.FixAndInherit);
+
+		//Conversion using mili-milibuckets to make the 'emc per milibucket' smaller than 1
+		graphMapper.addConversion(250*1000, "moltenEnder", Arrays.asList("enderpearl"));
+		graphMapper.addConversionMultiple(1, "moltenEnderBucket", ImmutableMap.of("moltenEnder", 1000*1000, "bucket", 1));
+
+		Map<String, Integer> values = graphMapper.generateValues();
+		assertEquals(1024, getValue(values, "enderpearl"));
+		assertEquals(0, getValue(values, "moltenEnder"));
+		assertEquals(768, getValue(values, "bucket"));
+		assertEquals(4*1024+768, getValue(values, "moltenEnderBucket"));
+
 	}
 
 	private static <T, V extends Number> int getValue(Map<T, V> map, T key) {


### PR DESCRIPTION
For example: stone and cobblestone slabs will not cause a recipe to not result in an emc value.