### PR TITLE
Fix sword digspeed

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/DarkSword.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/DarkSword.java
@@ -39,7 +39,7 @@ public class DarkSword extends PEToolBase implements IExtraFunction
 	}
 
 	@Override
-	public float func_150893_a(ItemStack p_150893_1_, Block p_150893_2_)
+	public float getDigSpeed(ItemStack p_150893_1_, Block p_150893_2_, int meta)
 	{
 		if (p_150893_2_ == Blocks.web)
 		{
@@ -72,7 +72,7 @@ public class DarkSword extends PEToolBase implements IExtraFunction
 	}
 
 	@Override
-	public boolean func_150897_b(Block p_150897_1_)
+	public boolean canHarvestBlock(Block p_150897_1_, ItemStack stack)
 	{
 		return p_150897_1_ == Blocks.web;
 	}


### PR DESCRIPTION
Closes #741
The two methods shown override vanilla methods, which are called through a Forge hook/reroute. However, in PEToolBase the Forge hook was overriden so the vanilla method would never be called.

Changes it to override the Forge hook instead of the vanilla method so it actually works now.