### PR TITLE
Fix the nbt whitelist mistake

### DIFF
--- a/src/main/java/moze_intel/projecte/config/NBTWhitelistParser.java
+++ b/src/main/java/moze_intel/projecte/config/NBTWhitelistParser.java
@@ -135,6 +135,7 @@ public final class NBTWhitelistParser
 			writer.println("#This file is used for items that should keep NBT data when condensed/transmuted.");
 			writer.println("#To add an item, just put it's unlocalized name on a new line. Here's some examples:");
 			writer.println("TConstruct:pickaxe");
+			writer.println("ExtraUtilities:unstableingot");
 			writer.println("ExtraUtilities:unstableIngot");
 			writer.println("Botania:specialFlower");
 		}

--- a/src/main/java/moze_intel/projecte/config/NBTWhitelistParser.java
+++ b/src/main/java/moze_intel/projecte/config/NBTWhitelistParser.java
@@ -135,7 +135,7 @@ public final class NBTWhitelistParser
 			writer.println("#This file is used for items that should keep NBT data when condensed/transmuted.");
 			writer.println("#To add an item, just put it's unlocalized name on a new line. Here's some examples:");
 			writer.println("TConstruct:pickaxe");
-			writer.println("ExtraUtilities:unstableingot");
+			writer.println("ExtraUtilities:unstableIngot");
 			writer.println("Botania:specialFlower");
 		}
 		catch (IOException e)


### PR DESCRIPTION
Put both names of the unstable ingot in the nbt whitelist by default. 
This prevents things like https://www.youtube.com/watch?v=hfuW9lH65-E&t=8m05s happening, where invalid NBT data is condensed and people get screwed over. (The ingot was missing NBT data marking it as Stable)