### PR TITLE
Fix all the numerous transmutation tablet writeToNBT crashes

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
@@ -436,8 +436,11 @@ public class TransmuteTabletInventory implements IInventory
 	{
 		if (player != null && player.getHeldItem() != null)
 		{
-			writeToNBT(player.getHeldItem().stackTagCompound);
-			Transmutation.setStoredEmc(player.getCommandSenderName(), emc);
+			if (!player.worldObj.isRemote)
+			{
+				writeToNBT(player.getHeldItem().stackTagCompound);
+				Transmutation.setStoredEmc(player.getCommandSenderName(), emc);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Fixes for #531 and similar.

Cause, according to #531 log:
GUITransmuteTablet.onGuiClose() -> GuiContainer.onGuiClose() -> TransmuteTabletContainer.onContainerClosed() -> TransmuteTablet.closeInventory() -> no remote check => try to write nbt on the client side => crash if the client managed to switch to another item that doesn't have nbt data