### PR TITLE
Modifications to bag code post-alpha test

### DIFF
--- a/src/main/java/moze_intel/projecte/events/PlayerEvents.java
+++ b/src/main/java/moze_intel/projecte/events/PlayerEvents.java
@@ -13,10 +13,12 @@ import moze_intel.projecte.playerData.Transmutation;
 import moze_intel.projecte.playerData.TransmutationProps;
 import moze_intel.projecte.utils.ChatHelper;
 import moze_intel.projecte.utils.ItemHelper;
+import moze_intel.projecte.utils.PELogger;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
@@ -26,16 +28,34 @@ import net.minecraft.world.World;
 import net.minecraftforge.event.entity.EntityEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
 
 public class PlayerEvents
 {
+	// Handles playerData props from being wiped on death
+	@SubscribeEvent
+	public void cloneEvent(PlayerEvent.Clone evt)
+	{
+		NBTTagCompound bag = new NBTTagCompound();
+		NBTTagCompound transmute = new NBTTagCompound();
+
+		AlchBagProps.getDataFor(evt.original).saveNBTData(bag); // Cache old
+		TransmutationProps.getDataFor(evt.original).saveNBTData(transmute);
+
+		AlchBagProps.getDataFor(evt.entityPlayer).loadNBTData(bag); // Reapply on new
+		TransmutationProps.getDataFor(evt.entityPlayer).loadNBTData(transmute);
+
+		PELogger.logDebug("Reapplied bag and knowledge on player respawning");
+	}
+
 	@SubscribeEvent
 	public void onEntityJoinWorld(EntityJoinWorldEvent event)
 	{
-		if (!event.entity.worldObj.isRemote && event.entity instanceof EntityPlayer)
+		if (!event.entity.worldObj.isRemote && event.entity instanceof EntityPlayerMP)
 		{
-			Transmutation.sync((EntityPlayer) event.entity);
-			AlchemicalBags.syncFull((EntityPlayer) event.entity);
+			EntityPlayerMP player = ((EntityPlayerMP) event.entity);
+			Transmutation.sync(player);
+			AlchemicalBags.syncFull(player);
 		}
 	}
 

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmuteTabletInventory.java
@@ -442,6 +442,7 @@ public class TransmuteTabletInventory implements IInventory
 			{
 				writeToNBT(player.getHeldItem().stackTagCompound);
 				Transmutation.setEmc(player, emc);
+				Transmutation.sync(player);
 			}
 		}
 		else

--- a/src/main/java/moze_intel/projecte/gameObjs/items/AlchemicalBag.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/AlchemicalBag.java
@@ -54,7 +54,6 @@ public class AlchemicalBag extends ItemPE
 	{
 		if (!world.isRemote)
 		{
-			AlchemicalBags.syncPartial(player, stack.getItemDamage());
 			player.openGui(PECore.instance, Constants.ALCH_BAG_GUI, world, (int) player.posX, (int) player.posY, (int) player.posZ);
 		}
 		

--- a/src/main/java/moze_intel/projecte/gameObjs/items/AlchemicalBag.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/AlchemicalBag.java
@@ -54,6 +54,7 @@ public class AlchemicalBag extends ItemPE
 	{
 		if (!world.isRemote)
 		{
+			AlchemicalBags.syncPartial(player, stack.getItemDamage());
 			player.openGui(PECore.instance, Constants.ALCH_BAG_GUI, world, (int) player.posX, (int) player.posY, (int) player.posZ);
 		}
 		

--- a/src/main/java/moze_intel/projecte/gameObjs/items/GemEternalDensity.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/GemEternalDensity.java
@@ -65,14 +65,18 @@ public class GemEternalDensity extends ItemPE implements IAlchBagItem, IAlchChes
 		
 		condense(stack, ((EntityPlayer) entity).inventory.mainInventory);
 	}
-	
-	public static void condense(ItemStack gem, ItemStack[] inv)
+
+	/**
+	 * @return Whether the inventory was changed
+	 */
+	public static boolean condense(ItemStack gem, ItemStack[] inv)
 	{
 		if (gem.getItemDamage() == 0 || ItemPE.getEmc(gem) >= Constants.TILE_MAX_EMC)
 		{
-			return;
+			return false;
 		}
-		
+
+		boolean hasChanged = false;
 		boolean isWhitelist = isWhitelistMode(gem);
 		List<ItemStack> whitelist = getWhitelist(gem);
 		
@@ -102,6 +106,7 @@ public class GemEternalDensity extends ItemPE implements IAlchBagItem, IAlchChes
 				}
 				
 				ItemPE.addEmc(gem, EMCHelper.getEmcValue(copy) * copy.stackSize);
+				hasChanged = true;
 				break;
 			}
 		}
@@ -110,21 +115,24 @@ public class GemEternalDensity extends ItemPE implements IAlchBagItem, IAlchChes
 
 		if (!EMCHelper.doesItemHaveEmc(target))
 		{
-			return;
+			return hasChanged;
 		}
 
 		while (getEmc(gem) >= value)
 		{
 			ItemStack remain = ItemHelper.pushStackInInv(inv, ItemStack.copyItemStack(target));
-			
+
 			if (remain != null)
 			{
-				return;
+				return false;
 			}
 			
 			ItemPE.removeEmc(gem, value);
 			setItems(gem, Lists.<ItemStack>newArrayList());
+			hasChanged = true;
 		}
+
+		return hasChanged;
 	}
 	
 	@Override
@@ -240,13 +248,13 @@ public class GemEternalDensity extends ItemPE implements IAlchBagItem, IAlchChes
 	private static void addToList(List<ItemStack> list, ItemStack stack)
 	{
 		boolean hasFound = false;
-		
+
 		for (ItemStack s : list)
 		{
 			if (s.stackSize < s.getMaxStackSize() && ItemHelper.areItemStacksEqual(s, stack))
 			{
 				int remain = s.getMaxStackSize() - s.stackSize;
-				
+
 				if (stack.stackSize <= remain)
 				{
 					s.stackSize += stack.stackSize;
@@ -260,7 +268,7 @@ public class GemEternalDensity extends ItemPE implements IAlchBagItem, IAlchChes
 				}
 			}
 		}
-		
+
 		if (!hasFound)
 		{
 			list.add(stack);
@@ -405,11 +413,6 @@ public class GemEternalDensity extends ItemPE implements IAlchBagItem, IAlchChes
 	@Override
 	public boolean updateInAlchBag(ItemStack[] inv, EntityPlayer player, ItemStack stack)
 	{
-		if (!player.worldObj.isRemote)
-		{
-			condense(stack, inv);
-			return true;
-		}
-		return false;
+		return !player.worldObj.isRemote && condense(stack, inv);
 	}
 }

--- a/src/main/java/moze_intel/projecte/network/packets/ClientKnowledgeSyncPKT.java
+++ b/src/main/java/moze_intel/projecte/network/packets/ClientKnowledgeSyncPKT.java
@@ -24,7 +24,7 @@ public class ClientKnowledgeSyncPKT implements IMessage, IMessageHandler<ClientK
 	public IMessage onMessage(ClientKnowledgeSyncPKT message, MessageContext ctx) 
 	{
 		PECore.proxy.getClientTransmutationProps().readFromPacket(message.nbt);
-		PELogger.logInfo("** RECEIVED TRANSMUTATION DATA CLIENTSIDE **");
+		PELogger.logDebug("** RECEIVED TRANSMUTATION DATA CLIENTSIDE **");
 		return null;
 	}
 

--- a/src/main/java/moze_intel/projecte/network/packets/ClientSyncBagDataPKT.java
+++ b/src/main/java/moze_intel/projecte/network/packets/ClientSyncBagDataPKT.java
@@ -24,7 +24,7 @@ public class ClientSyncBagDataPKT implements IMessage, IMessageHandler<ClientSyn
 	public IMessage onMessage(ClientSyncBagDataPKT message, MessageContext ctx)
 	{
 		PECore.proxy.getClientBagProps().readFromPacket(message.nbt);
-		PELogger.logInfo("** RECEIVED BAGS CLIENTSIDE **");
+		PELogger.logDebug("** RECEIVED BAGS CLIENTSIDE **");
 		return null;
 	}
 

--- a/src/main/java/moze_intel/projecte/playerData/AlchemicalBags.java
+++ b/src/main/java/moze_intel/projecte/playerData/AlchemicalBags.java
@@ -31,13 +31,13 @@ public final class AlchemicalBags
 	public static void syncFull(EntityPlayer player)
 	{
 		PacketHandler.sendTo(new ClientSyncBagDataPKT(AlchBagProps.getDataFor(player).saveForPacket()), (EntityPlayerMP) player);
-		PELogger.logInfo("** SENT FULL BAG DATA **");
+		PELogger.logDebug("** SENT FULL BAG DATA **");
 	}
 
 	public static void syncPartial(EntityPlayer player, int color)
 	{
 		PacketHandler.sendTo(new ClientSyncBagDataPKT(AlchBagProps.getDataFor(player).saveForPartialPacket(color)), (EntityPlayerMP) player);
-		PELogger.logInfo("** SENT PARTIAL BAG DATA **");
+		PELogger.logDebug("** SENT PARTIAL BAG DATA **");
 	}
 
 	/**

--- a/src/main/java/moze_intel/projecte/playerData/IOHandler.java
+++ b/src/main/java/moze_intel/projecte/playerData/IOHandler.java
@@ -13,37 +13,13 @@ import java.util.LinkedList;
 
 public final class IOHandler
 {
-	public static boolean markedDirty;
 	private static File knowledgeFile;
 	private static File bagDataFile;
 	
 	public static void init(File knowledge, File bagData)
 	{
-		if (!knowledge.exists())
+		if (!knowledge.exists() || !bagData.exists())
 		{
-//			try
-//			{
-//				knowledge.createNewFile();
-//			}
-//			catch (IOException e)
-//			{
-//				PELogger.logFatal("Couldn't create transmutation knowledge file!");
-//				e.printStackTrace();
-//			}
-			return;
-		}
-		
-		if (!bagData.exists())
-		{
-//			try
-//			{
-//				bagData.createNewFile();
-//			}
-//			catch (IOException e)
-//			{
-//				PELogger.logFatal("Couldn't create alchemical bag data file!");
-//				e.printStackTrace();
-//			}
 			return;
 		}
 		
@@ -64,7 +40,6 @@ public final class IOHandler
 		catch (IOException e)
 		{
 			PELogger.logFatal("Error loading legacy knowledge file");
-			e.printStackTrace();
 		}
 
 		if (knowledge != null)
@@ -114,7 +89,7 @@ public final class IOHandler
 
 				Transmutation.legacySetStoredEmc(tag.getString("player"), tag.getDouble("emc"));
 			}
-			PELogger.logInfo("** LOADED LEGACY TRANSMUTATION DATA **");
+			PELogger.logDebug("** LOADED LEGACY TRANSMUTATION DATA **");
 		}
 
 		NBTTagCompound bagData = null;
@@ -126,7 +101,6 @@ public final class IOHandler
 		catch (Exception e)
 		{
 			PELogger.logFatal("Error loading legacy bag file");
-			e.printStackTrace();
 		}
 
 		if (bagData != null)
@@ -155,14 +129,9 @@ public final class IOHandler
 					}
 
 					AlchemicalBags.legacySet(nbt.getString("player"), subNbt.getByte("color"), inv);
-					PELogger.logInfo("** LOADED LEGACY BAG DATA **");
 				}
 			}
+			PELogger.logDebug("** LOADED LEGACY BAG DATA **");
 		}
-	}
-
-	public static void markDirty()
-	{
-		// NO-OP - Remove in future
 	}
 }

--- a/src/main/java/moze_intel/projecte/playerData/Transmutation.java
+++ b/src/main/java/moze_intel/projecte/playerData/Transmutation.java
@@ -102,7 +102,7 @@ public final class Transmutation
 		TransmutationProps data = TransmutationProps.getDataFor(player);
 		for (ItemStack s : data.getKnowledge())
 		{
-			if (ItemStack.areItemStacksEqual(s, stack))
+			if (ItemHelper.basicAreStacksEqual(s, stack))
 			{
 				return true;
 			}

--- a/src/main/java/moze_intel/projecte/playerData/Transmutation.java
+++ b/src/main/java/moze_intel/projecte/playerData/Transmutation.java
@@ -28,7 +28,7 @@ public final class Transmutation
 	@Deprecated
 	private static final LinkedList<String> TOME_KNOWLEDGE = new LinkedList<String>();
 
-	private static final LinkedList<ItemStack> CACHED_TOME_KNOWLEDGE = Lists.newLinkedList();
+	private static final List<ItemStack> CACHED_TOME_KNOWLEDGE = Lists.newArrayList();
 	
 	public static void cacheFullKnowledge()
 	{
@@ -178,7 +178,7 @@ public final class Transmutation
 	}
 
 	@Deprecated
-	public static LinkedList<ItemStack> legacyGetKnowledge(String username)
+	public static List<ItemStack> legacyGetKnowledge(String username)
 	{
 		if (TOME_KNOWLEDGE.contains(username))
 		{

--- a/src/main/java/moze_intel/projecte/playerData/Transmutation.java
+++ b/src/main/java/moze_intel/projecte/playerData/Transmutation.java
@@ -140,7 +140,7 @@ public final class Transmutation
 	public static void sync(EntityPlayer player)
 	{
 		PacketHandler.sendTo(new ClientKnowledgeSyncPKT(TransmutationProps.getDataFor(player).saveForPacket()), (EntityPlayerMP) player);
-		PELogger.logInfo("** SENT TRANSMUTATION DATA **");
+		PELogger.logDebug("** SENT TRANSMUTATION DATA **");
 	}
 
 	public static void clearCache()

--- a/src/main/java/moze_intel/projecte/utils/PELogger.java
+++ b/src/main/java/moze_intel/projecte/utils/PELogger.java
@@ -32,10 +32,10 @@ public final class PELogger
 
 	public static void logDebug(String msg)
 	{
-		if (ProjectEConfig.enableDebugLog)
+		if (ProjectEConfig.enableDebugLog) // visible in main console
 		{
-			//logger.debug() doesn't seem to work
 			logger.info(msg);
 		}
+		logger.debug(msg); // fml log
 	}
 }

--- a/src/main/java/moze_intel/projecte/utils/PELogger.java
+++ b/src/main/java/moze_intel/projecte/utils/PELogger.java
@@ -36,6 +36,9 @@ public final class PELogger
 		{
 			logger.info(msg);
 		}
-		logger.debug(msg); // fml log
+		else
+		{
+			logger.debug(msg); // fml log
+		}
 	}
 }


### PR DESCRIPTION
So far:
* Made Gem of Eternal Density spam bag packets a lot less often - bag data as a whole is sent immensely less than the old save code did (once every tick, every player, versus only when it changes, per player). The bandwidth we're saving is awesome.
* Data no longer wipes after dying (design limitation of IEEP's, easy workaround)
* Transmutation Tablet no longer desyncs after you close it
* Fix transmutation sometimes creating duplicate entries
* Fix crash with Tome