### PR TITLE
Fraction emc propagation

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenFractionArithmetic.java
+++ b/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenFractionArithmetic.java
@@ -38,13 +38,18 @@ public class HiddenFractionArithmetic implements IValueArithmetic<Fraction>
 	@Override
 	public Fraction div(Fraction a, int b)
 	{
-		if (this.isFree(a)) return getFree();
-		Fraction result = a.divideBy(Fraction.getFraction(b, 1));
-		if (Fraction.ZERO.compareTo(result) <= 0 && result.compareTo(Fraction.ONE) < 0)
+		try
 		{
-			return result;
+			if (this.isFree(a)) return getFree();
+			Fraction result = a.divideBy(Fraction.getFraction(b, 1));
+			if (Fraction.ZERO.compareTo(result) <= 0 && result.compareTo(Fraction.ONE) < 0)
+			{
+				return result;
+			}
+			return Fraction.getFraction(result.intValue(), 1);
+		} catch (ArithmeticException e) {
+			return Fraction.ZERO;
 		}
-		return Fraction.getFraction(result.intValue(), 1);
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenFractionArithmetic.java
+++ b/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenFractionArithmetic.java
@@ -32,7 +32,7 @@ public class HiddenFractionArithmetic implements IValueArithmetic<Fraction>
 	public Fraction mul(int a, Fraction b)
 	{
 		if (this.isFree(b)) return getFree();
-		return zeroOrInt(b.multiplyBy(Fraction.getFraction(a, 1)));
+		return b.multiplyBy(Fraction.getFraction(a, 1));
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenFractionArithmetic.java
+++ b/src/main/java/moze_intel/projecte/emc/arithmetics/HiddenFractionArithmetic.java
@@ -48,6 +48,11 @@ public class HiddenFractionArithmetic implements IValueArithmetic<Fraction>
 			}
 			return Fraction.getFraction(result.intValue(), 1);
 		} catch (ArithmeticException e) {
+			//The documentation for Fraction.divideBy states, that this Exception is only thrown if
+			// * you try to divide by `null` (We are not doing this)
+			// * the numerator or denumerator exceeds Integer.MAX_VALUE.
+			// Because we only divide by values > 1 it means the denumerator overflowed.
+			// This means we reached something/infinity, which is basically 0.
 			return Fraction.ZERO;
 		}
 	}

--- a/src/test/java/moze_intel/projecte/emc/GraphMapperTest.java
+++ b/src/test/java/moze_intel/projecte/emc/GraphMapperTest.java
@@ -447,6 +447,20 @@ public class GraphMapperTest {
 	}
 
 	@org.junit.Test
+	public void testGenerateValuesDelayedCycleRecipeExploit() throws Exception {
+		graphMapper.setValue("a1", 1, GraphMapper.FixedValue.FixAndInherit);
+		//Exploitable Cycle Recype
+		graphMapper.addConversion(1, "exploitable1", Arrays.asList("a1"));
+		graphMapper.addConversion(2, "exploitable2", Arrays.asList("exploitable1"));
+		graphMapper.addConversion(1, "exploitable1", Arrays.asList("exploitable2"));
+
+		Map<String, Integer> values = graphMapper.generateValues();
+		assertEquals(1, getValue(values, "a1"));
+		assertEquals(0, getValue(values, "exploitable1"));
+		assertEquals(0, getValue(values, "exploitable2"));
+	}
+
+	@org.junit.Test
 	public void testGenerateValuesCycleRecipeExploit2() throws Exception {
 		graphMapper.setValue("a1", 1, GraphMapper.FixedValue.FixAndInherit);
 		//Exploitable Cycle Recype

--- a/src/test/java/moze_intel/projecte/emc/HiddenFractionSpecificTest.java
+++ b/src/test/java/moze_intel/projecte/emc/HiddenFractionSpecificTest.java
@@ -82,7 +82,7 @@ public class HiddenFractionSpecificTest
 
 
 	@Test
-	public void fractionPropagation()
+	public void reliquaryVials()
 	{
 		graphMapper.setValue("glass", 1, IMappingCollector.FixedValue.FixAndInherit);
 
@@ -99,6 +99,23 @@ public class HiddenFractionSpecificTest
 		assertEquals(0, getValue(values, "vial"));
 		assertEquals(1, getValue(values, "testItem1"));
 		assertEquals(1, getValue(values, "testItem2"));
+	}
+
+	@Test
+	public void propagation()
+	{
+		graphMapper.setValue("a", 1, IMappingCollector.FixedValue.FixAndInherit);
+
+		graphMapper.addConversionMultiple(2, "ahalf", ImmutableMap.of("a", 1));
+		graphMapper.addConversionMultiple(1, "ahalf2", ImmutableMap.of("ahalf", 1));
+		graphMapper.addConversionMultiple(1, "2ahalf2", ImmutableMap.of("ahalf2", 2));
+
+		Map<String, Integer> values = graphMapper.generateValues();
+		assertEquals(1, getValue(values, "a"));
+		assertEquals(0, getValue(values, "ahalf"));
+		assertEquals(0, getValue(values, "ahalf2"));
+		assertEquals(1, getValue(values, "2ahalf2"));
+
 	}
 
 	private static <T, V extends Number> int getValue(Map<T, V> map, T key) {

--- a/src/test/java/moze_intel/projecte/emc/HiddenFractionSpecificTest.java
+++ b/src/test/java/moze_intel/projecte/emc/HiddenFractionSpecificTest.java
@@ -80,6 +80,27 @@ public class HiddenFractionSpecificTest
 
 	}
 
+
+	@Test
+	public void fractionPropagation()
+	{
+		graphMapper.setValue("glass", 1, IMappingCollector.FixedValue.FixAndInherit);
+
+		graphMapper.addConversionMultiple(16, "pane", ImmutableMap.of("glass", 6));
+		graphMapper.addConversionMultiple(5, "vial", ImmutableMap.of("pane", 5));
+		//Internal EMC of pane and vial: 3/8 = 0.375
+		//So 8 * vial should have an emc of 3 => testItem should have emc of 1
+		graphMapper.addConversionMultiple(3, "testItem1", ImmutableMap.of("pane", 8));
+		graphMapper.addConversionMultiple(3, "testItem2", ImmutableMap.of("vial", 8));
+
+		Map<String, Integer> values = graphMapper.generateValues();
+		assertEquals(1, getValue(values, "glass"));
+		assertEquals(0, getValue(values, "pane"));
+		assertEquals(0, getValue(values, "vial"));
+		assertEquals(1, getValue(values, "testItem1"));
+		assertEquals(1, getValue(values, "testItem2"));
+	}
+
 	private static <T, V extends Number> int getValue(Map<T, V> map, T key) {
 		V val = map.get(key);
 		if (val == null) return 0;


### PR DESCRIPTION
This fixes some emc propagation for fractions:

* Stone slab has internal emc of 1/2
* Something that is made from a single stone slab did not have an internal emc of 1/2. With this fix it has.

~~Don't merge yet: It crashes the [exploit1](https://github.com/sinkillerj/ProjectE/blob/master/src/test/java/moze_intel/projecte/emc/GraphMapperTest.java#L433) and [exploit2](https://github.com/sinkillerj/ProjectE/blob/master/src/test/java/moze_intel/projecte/emc/GraphMapperTest.java#L450) testcases. (Recipes with 1 cobble->2 cobble)~~

I fixed the testcases with a try/catch that should never trigger unless someone really made such a cheaty recipe. I did not notice the testcase running longer than the others, so i think it converges to 0 very fast so it *should not be problem* (thats how problems always start, right?).