### PR TITLE
Adds clay to tools

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/DarkShovel.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/DarkShovel.java
@@ -22,6 +22,7 @@ public class DarkShovel extends PEToolBase
 		this.harvestMaterials.add(Material.ground);
 		this.harvestMaterials.add(Material.sand);
 		this.harvestMaterials.add(Material.snow);
+		this.harvestMaterials.add(Material.clay);
 	}
 
 	// Only for RedShovel

--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/RedShovel.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/RedShovel.java
@@ -14,5 +14,6 @@ public class RedShovel extends DarkShovel
 		this.harvestMaterials.add(Material.ground);
 		this.harvestMaterials.add(Material.sand);
 		this.harvestMaterials.add(Material.snow);
+		this.harvestMaterials.add(Material.clay);
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/RedStar.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/RedStar.java
@@ -8,6 +8,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockDirt;
 import net.minecraft.block.BlockGrass;
 import net.minecraft.block.BlockGravel;
+import net.minecraft.block.BlockClay;
 import net.minecraft.block.BlockSand;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
@@ -36,7 +37,8 @@ public class RedStar extends PEToolBase
 		this.harvestMaterials.add(Material.ground);
 		this.harvestMaterials.add(Material.sand);
 		this.harvestMaterials.add(Material.snow);
-
+		this.harvestMaterials.add(Material.clay);
+		
 		this.harvestMaterials.add(Material.iron);
 		this.harvestMaterials.add(Material.anvil);
 		this.harvestMaterials.add(Material.rock);
@@ -86,7 +88,7 @@ public class RedStar extends PEToolBase
 			{
 				Block block = world.getBlock(mop.blockX, mop.blockY, mop.blockZ);
 
-				if (block instanceof BlockGravel)
+				if (block instanceof BlockGravel || block instanceof BlockClay)
 				{
 					if (ProjectEConfig.pickaxeAoeVeinMining)
 					{


### PR DESCRIPTION
Simple PR, makes it so that the morningstar and shovel consider clay a valid material to harvest.

I don't have a local copy of the repository, so this is untested. I am also not sure this is all that needs to be done to ensure that they harvest clay properly. The goal was to make the morningstar harvest clay on its 9x9 mode.

In most situations this is slightly convenient but not very important, but when using Pam's Clay where clay worldgens.. everywhere.. well..

Let's just say my enormous underground caverns has a ton of clay floating around, as the morningstar ignores it.