### PR TITLE
Fix knowledge re-duping 

### DIFF
--- a/src/main/java/moze_intel/projecte/events/PlayerEvents.java
+++ b/src/main/java/moze_intel/projecte/events/PlayerEvents.java
@@ -1,6 +1,5 @@
 package moze_intel.projecte.events;
 
-import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import moze_intel.projecte.PECore;
 import moze_intel.projecte.gameObjs.ObjHandler;
@@ -36,6 +35,11 @@ public class PlayerEvents
 	@SubscribeEvent
 	public void cloneEvent(PlayerEvent.Clone evt)
 	{
+		if (!evt.wasDeath)
+		{
+			return; // Vanilla handles it for us.
+		}
+
 		NBTTagCompound bag = new NBTTagCompound();
 		NBTTagCompound transmute = new NBTTagCompound();
 
@@ -84,8 +88,6 @@ public class PlayerEvents
 	@SubscribeEvent
 	public void playerChangeDimension(cpw.mods.fml.common.gameevent.PlayerEvent.PlayerChangedDimensionEvent event)
 	{
-		System.out.println(FMLCommonHandler.instance().getEffectiveSide());
-
 		PlayerChecks.onPlayerChangeDimension((EntityPlayerMP) event.player);
 	}
 

--- a/src/main/java/moze_intel/projecte/playerData/TransmutationProps.java
+++ b/src/main/java/moze_intel/projecte/playerData/TransmutationProps.java
@@ -78,6 +78,18 @@ public class TransmutationProps implements IExtendedEntityProperties
 		return knowledge;
 	}
 
+	private void pruneDuplicateKnowledge()
+	{
+		ItemHelper.compactItemList(knowledge);
+		for (ItemStack s : knowledge)
+		{
+			if (s.stackSize > 1)
+			{
+				s.stackSize = 1;
+			}
+		}
+	}
+
 	private void pruneStaleKnowledge()
 	{
 		Iterator<ItemStack> iter = knowledge.iterator();
@@ -184,7 +196,7 @@ public class TransmutationProps implements IExtendedEntityProperties
 				knowledge.add(item);
 			}
 		}
-
+		pruneDuplicateKnowledge();
 		NBTTagList list2 = properties.getTagList("inputlock", Constants.NBT.TAG_COMPOUND);
 		inputLocks = ItemHelper.copyIndexedNBTToArray(list2, new ItemStack[9]);
 	}


### PR DESCRIPTION
Fix knowledge re-duping when exiting end (ClonePlayer firing at non-death), add patch to remove duplicated knowledge at startup.

Fixes #836, #832