### PR TITLE
Fix another ArithmeticException

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/SimpleGraphMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/SimpleGraphMapper.java
@@ -98,7 +98,7 @@ public class SimpleGraphMapper<T, V extends Comparable<V>> extends GraphMapper<T
 					//What would the output cost be, if that conversion would be used
 					V conversionValueSingle = arithmetic.div(conversionValue, conversion.outnumber);
 					//What is the actual emc value for the conversion output
-					V resultValue = values.containsKey(entry.getKey()) ? arithmetic.mul(conversion.outnumber, values.get(entry.getKey())) : ZERO;
+					V resultValueSingle = values.containsKey(entry.getKey()) ? values.get(entry.getKey()) : ZERO;
 
 					//Find the smallest EMC value for the conversion.output
 					if (conversionValueSingle.compareTo(ZERO) > 0 || arithmetic.isFree(conversionValueSingle)) {
@@ -108,13 +108,13 @@ public class SimpleGraphMapper<T, V extends Comparable<V>> extends GraphMapper<T
 					}
 					//the cost for the ingredients is greater zero, but smaller than the value that the output has.
 					//This is a Loophole. We remove it by setting the value to 0.
-					if (ZERO.compareTo(conversionValue) < 0 && conversionValue.compareTo(resultValue) < 0) {
+					if (ZERO.compareTo(conversionValue) < 0 && conversionValueSingle.compareTo(resultValueSingle) < 0) {
 						if (canOverride(entry.getKey(), ZERO)) {
-							debugFormat("Setting %s to 0 because result (%s) > cost (%s): %s", entry.getKey(), resultValue, conversionValue, conversion);
+							debugFormat("Setting %s to 0 because result (%s) > cost (%s): %s", entry.getKey(), resultValueSingle, conversionValue, conversion);
 							newValueFor.put(conversion.output, ZERO);
 							reasonForChange.put(conversion.output, "exploit recipe");
 						} else if (logFoundExploits) {
-							PELogger.logWarn(String.format("EMC Exploit: \"%s\" ingredient cost: %s fixed value of result: %s", conversion, conversionValue, resultValue));
+							PELogger.logWarn(String.format("EMC Exploit: \"%s\" ingredient cost: %s fixed value of result: %s", conversion, conversionValue, resultValueSingle));
 						}
 					}
 				}

--- a/src/test/java/moze_intel/projecte/emc/GraphMapperTest.java
+++ b/src/test/java/moze_intel/projecte/emc/GraphMapperTest.java
@@ -563,9 +563,9 @@ public class GraphMapperTest {
 		graphMapper.setValue(gDust, 384, IMappingCollector.FixedValue.FixAndInherit);
 		graphMapper.setValue(stone, 1, IMappingCollector.FixedValue.FixAndInherit);
 		graphMapper.addConversion(8, "antiblockWhite", Arrays.asList(
-				stone,stone,stone,
-				stone,gDust,stone,
-				stone,stone,stone));
+				stone, stone, stone,
+				stone, gDust, stone,
+				stone, stone, stone));
 
 		Map<String, Integer> values = graphMapper.generateValues();
 		assertEquals((8 + 384)/8, getValue(values, "antiblockWhite"));
@@ -637,6 +637,28 @@ public class GraphMapperTest {
 		assertEquals(768, getValue(values, "waterBucket"));
 		assertEquals(0, getValue(values, "waterGroup"));
 		assertEquals(3, getValue(values, "result"));
+	}
+
+
+	@org.junit.Test
+	public void testOverflowWithIngredients() throws Exception {
+		graphMapper.setValue("a", Integer.MAX_VALUE / 2 + 1, IMappingCollector.FixedValue.FixAndInherit);
+		graphMapper.setValue("b", Integer.MAX_VALUE / 2 + 1, IMappingCollector.FixedValue.FixAndInherit);
+		graphMapper.addConversion(1, "c", Arrays.asList("a", "b"));
+
+		Map<String, Integer> values = graphMapper.generateValues();
+		assertEquals(Integer.MAX_VALUE / 2 + 1, getValue(values, "a"));
+		assertEquals(Integer.MAX_VALUE/2+1, getValue(values, "b"));
+		assertEquals(0, getValue(values, "c"));
+	}
+
+	@org.junit.Test
+	public void testOverflowWithAmount() throws Exception {
+		graphMapper.setValue("a", Integer.MAX_VALUE / 2, IMappingCollector.FixedValue.FixAndInherit);
+		graphMapper.addConversion(3, "a", Arrays.asList("something"));
+
+		Map<String, Integer> values = graphMapper.generateValues();
+		assertEquals(Integer.MAX_VALUE/2, getValue(values, "a"));
 	}
 
 	private static <T, V extends Number> int getValue(Map<T, V> map, T key) {


### PR DESCRIPTION
Fixes #841 

Instead of comparing `(cost of all ingredients)` with `x*(cost of output result)` it now compares `(cost of all ingredients)/x` with `(cost of output result)`. (`x` = number of output results)

This avoids the overflow in the multiplication.

This only works with the Fraction Arithmetic, but i could not find a way to make it work with Integers in time.