### PR TITLE
FIX: Life Stone might consume up to 128 EMC, but only requested 64

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/LifeStone.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/LifeStone.java
@@ -46,7 +46,7 @@ public class LifeStone extends RingToggle implements IBauble, IPedestalItem
 		{
 			double itemEmc = getEmc(stack);
 			
-			if (itemEmc < 64 && !consumeFuel(player, stack, 64, false))
+			if (itemEmc < 2*64 && !consumeFuel(player, stack, 2*64, false))
 			{
 				stack.setItemDamage(0);
 			}


### PR DESCRIPTION
Not sure if that would ever cause any issues - but now that i stumbled across it i can as well fix it.