### PR TITLE
Fix for the other method

### DIFF
--- a/src/main/java/moze_intel/projecte/network/PacketHandler.java
+++ b/src/main/java/moze_intel/projecte/network/PacketHandler.java
@@ -72,7 +72,7 @@ public final class PacketHandler
 		ArrayList<Integer[]> list = Lists.newArrayList();
 		int counter = 0;
 
-		for (Map.Entry<SimpleStack, Integer> entry : EMCMapper.emc.entrySet())
+		for (Map.Entry<SimpleStack, Integer> entry : Maps.newLinkedHashMap(EMCMapper.emc).entrySet()) // Copy constructor to prevent race condition CME in SP
 		{
 			SimpleStack stack = entry.getKey();
 


### PR DESCRIPTION
I missed the other sendFragmentedEmc method in the CME bugfix. Oops. Fixes #856