### PR TITLE
Allow to drag items in inventory when Transmutation GUI is opened

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/TransmutationContainer.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/TransmutationContainer.java
@@ -153,6 +153,7 @@ public class TransmutationContainer extends Container
 	@Override
 	public boolean canDragIntoSlot(Slot slot) 
 	{
-		return false;
+		if (slot instanceof SlotConsume || slot instanceof SlotUnlearn || slot instanceof SlotInput || slot instanceof SlotLock||slot instanceof SlotOutput) return false;
+		return true;
 	}
 }


### PR DESCRIPTION
Fixes #864 

That fix was easier than i thought.

~~Maybe we need to do that in more containers.~~
A search for `canDragIntoSlot` only shows this and the Gem of eternal density gui.

A rewrite of that item handling in that gui would probably not hurt, though.