### PR TITLE
Make the 'isOre' check for OreDictionary name not ignore block metadata

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/DarkPick.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/DarkPick.java
@@ -55,7 +55,7 @@ public class DarkPick extends PEToolBase
 			if (mop != null && mop.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK)
 			{
 				Block b = world.getBlock(mop.blockX, mop.blockY, mop.blockZ);
-				if (ItemHelper.isOre(b))
+				if (ItemHelper.isOre(b, world.getBlockMetadata(mop.blockX, mop.blockY, mop.blockZ)))
 				{
 					tryVeinMine(stack, player, mop);
 				}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/PEToolBase.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/PEToolBase.java
@@ -602,7 +602,7 @@ public abstract class PEToolBase extends ItemMode
 				{
 					Block block = world.getBlock(x, y, z);
 
-					if (ItemHelper.isOre(block) && block.getBlockHardness(player.worldObj, x, y, z) != -1 && (canHarvestBlock(block, stack) || ForgeHooks.canToolHarvestBlock(block, world.getBlockMetadata(x, y, z), stack)))
+					if (ItemHelper.isOre(block, world.getBlockMetadata(x, y, z)) && block.getBlockHardness(player.worldObj, x, y, z) != -1 && (canHarvestBlock(block, stack) || ForgeHooks.canToolHarvestBlock(block, world.getBlockMetadata(x, y, z), stack)))
 					{
 						WorldHelper.harvestVein(world, player, stack, new Coordinates(x, y, z), block, drops, 0);
 					}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/RedStar.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/RedStar.java
@@ -99,7 +99,7 @@ public class RedStar extends PEToolBase
 						tryVeinMine(stack, player, mop);
 					}
 				}
-				else if (ItemHelper.isOre(block))
+				else if (ItemHelper.isOre(block, world.getBlockMetadata(mop.blockX, mop.blockY, mop.blockZ)))
 				{
 					if (!ProjectEConfig.pickaxeAoeVeinMining)
 					{

--- a/src/main/java/moze_intel/projecte/utils/ItemHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/ItemHelper.java
@@ -376,14 +376,13 @@ public final class ItemHelper
 		return false;
 	}
 
-	public static boolean isOre(Block block)
+	public static boolean isOre(Block block, int meta)
 	{
 		if (block.equals(Blocks.lit_redstone_ore))
 		{
 			return true;
 		}
-
-		String oreDictName = getOreDictionaryName(new ItemStack(block));
+		String oreDictName = getOreDictionaryName(new ItemStack(block, 1, meta));
 		return oreDictName.startsWith("ore") || oreDictName.startsWith("denseore");
 	}
 


### PR DESCRIPTION
Fixes #867 