### PR TITLE
Preliminary protection support

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/entity/EntityFireProjectile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/entity/EntityFireProjectile.java
@@ -1,7 +1,9 @@
 package moze_intel.projecte.gameObjs.entity;
 
+import moze_intel.projecte.utils.PlayerHelper;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
@@ -43,7 +45,7 @@ public class EntityFireProjectile extends PEProjectile
 				for(int x1 = x - 2; x1 <= x + 2; x1++)
 					for(int y1 = y - 2; y1 <= y + 2; y1++)
 						for(int z1 = z - 2; z1 <= z + 2; z1++)
-							if(worldObj.getBlock(x1, y1, z1) == Blocks.sand)
+							if(PlayerHelper.hasEditPermission(worldObj, ((EntityPlayerMP) getThrower()), x1, y1, z1) && worldObj.getBlock(x1, y1, z1) == Blocks.sand)
 								worldObj.setBlock(x1, y1, z1, Blocks.glass);
 			}
 			else
@@ -51,7 +53,7 @@ public class EntityFireProjectile extends PEProjectile
 				for(int x1 = x - 1; x1 <= x + 1; x1++)
 					for(int y1 = y - 1; y1 <= y + 1; y1++)
 						for(int z1 = z - 1; z1 <= z + 1; z1++)
-							if(worldObj.getBlock(x1, y1, z1) == Blocks.air)
+							if(PlayerHelper.hasEditPermission(worldObj, ((EntityPlayerMP) getThrower()), x1, y1, z1) && worldObj.getBlock(x1, y1, z1) == Blocks.air)
 								worldObj.setBlock(x1, y1, z1, Blocks.fire);
 			}
 		}

--- a/src/main/java/moze_intel/projecte/gameObjs/entity/EntityLavaProjectile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/entity/EntityLavaProjectile.java
@@ -2,9 +2,11 @@ package moze_intel.projecte.gameObjs.entity;
 
 import moze_intel.projecte.gameObjs.ObjHandler;
 import moze_intel.projecte.gameObjs.items.ItemPE;
+import moze_intel.projecte.utils.PlayerHelper;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.MovingObjectPosition;
@@ -85,7 +87,13 @@ public class EntityLavaProjectile extends PEProjectile
 			{
 				case BLOCK:
 					ForgeDirection dir = ForgeDirection.getOrientation(mop.sideHit);
-					this.worldObj.setBlock(mop.blockX + dir.offsetX, mop.blockY + dir.offsetY, mop.blockZ + dir.offsetZ, Blocks.flowing_lava);
+					int x = mop.blockX + dir.offsetX;
+					int y = mop.blockY + dir.offsetY;
+					int z = mop.blockZ + dir.offsetZ;
+					if (worldObj.isAirBlock(x, y, z) && PlayerHelper.hasEditPermission(worldObj, ((EntityPlayerMP) getThrower()), x, y, z))
+					{
+						this.worldObj.setBlock(x, y, z, Blocks.flowing_lava);
+					}
 					break;
 				case ENTITY:
 					Entity ent = mop.entityHit;

--- a/src/main/java/moze_intel/projecte/gameObjs/entity/EntityWaterProjectile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/entity/EntityWaterProjectile.java
@@ -1,8 +1,10 @@
 package moze_intel.projecte.gameObjs.entity;
 
+import moze_intel.projecte.utils.PlayerHelper;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.MovingObjectPosition.MovingObjectType;
@@ -45,8 +47,7 @@ public class EntityWaterProjectile extends PEProjectile
 					for (int z = (int) (this.posZ - 3); z <= this.posZ + 3; z++)
 					{
 						Block block = this.worldObj.getBlock(x, y, z);
-						boolean flag = false;
-						
+
 						if (block == Blocks.lava)
 						{
 							this.worldObj.setBlock(x, y, z, Blocks.obsidian);
@@ -88,9 +89,12 @@ public class EntityWaterProjectile extends PEProjectile
 		if (mop.typeOfHit == MovingObjectType.BLOCK)
 		{
 			ForgeDirection dir = ForgeDirection.getOrientation(mop.sideHit);
-			if (worldObj.isAirBlock(mop.blockX + dir.offsetX, mop.blockY + dir.offsetY, mop.blockZ + dir.offsetZ))
+			int x = mop.blockX + dir.offsetX;
+			int y = mop.blockY + dir.offsetY;
+			int z = mop.blockZ + dir.offsetZ;
+			if (worldObj.isAirBlock(x, y, z) && PlayerHelper.hasEditPermission(worldObj, ((EntityPlayerMP) getThrower()), x, y, z))
 			{
-				this.worldObj.setBlock(mop.blockX + dir.offsetX, mop.blockY + dir.offsetY, mop.blockZ + dir.offsetZ, Blocks.flowing_water);
+				this.worldObj.setBlock(x, y, z, Blocks.flowing_water);
 			}
 		}
 		else if (mop.typeOfHit == MovingObjectType.ENTITY)

--- a/src/main/java/moze_intel/projecte/gameObjs/items/DestructionCatalyst.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/DestructionCatalyst.java
@@ -12,6 +12,7 @@ import moze_intel.projecte.utils.WorldHelper;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.AxisAlignedBB;
@@ -63,7 +64,7 @@ public class DestructionCatalyst extends ItemCharge
 						Block block = world.getBlock(x, y, z);
 						float hardness = block.getBlockHardness(world, x, y, z);
 						
-						if (block == Blocks.air || hardness >= 50.0F || hardness == -1.0F)
+						if (block == Blocks.air || hardness >= 50.0F || hardness == -1.0F || !PlayerHelper.hasBreakPermission(world, ((EntityPlayerMP) player), x, y, z))
 						{
 							continue;
 						}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/EvertideAmulet.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/EvertideAmulet.java
@@ -24,6 +24,7 @@ import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -104,7 +105,7 @@ public class EvertideAmulet extends ItemPE implements IProjectileShooter, IBaubl
 						default: break;
                     }
 
-					if (world.isAirBlock(i, j, k))
+					if (world.isAirBlock(i, j, k) && PlayerHelper.hasEditPermission(world, ((EntityPlayerMP) player), i, j, k))
 					{
 						world.playSoundAtEntity(player, "projecte:item.pewatermagic", 1.0F, 1.0F);
 						placeWater(world, i, j, k);

--- a/src/main/java/moze_intel/projecte/gameObjs/items/EvertideAmulet.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/EvertideAmulet.java
@@ -54,7 +54,7 @@ public class EvertideAmulet extends ItemPE implements IProjectileShooter, IBaubl
 	@Override
 	public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int sideHit, float f1, float f2, float f3)
 	{
-		if (!world.isRemote)
+		if (!world.isRemote && PlayerHelper.hasEditPermission(world, ((EntityPlayerMP) player), x, y, z))
 		{
 			TileEntity tile = world.getTileEntity(x, y, z);
 

--- a/src/main/java/moze_intel/projecte/gameObjs/items/MercurialEye.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/MercurialEye.java
@@ -6,9 +6,11 @@ import moze_intel.projecte.PECore;
 import moze_intel.projecte.api.item.IExtraFunction;
 import moze_intel.projecte.utils.Constants;
 import moze_intel.projecte.utils.EMCHelper;
+import moze_intel.projecte.utils.PlayerHelper;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -150,6 +152,10 @@ public class MercurialEye extends ItemMode implements IExtraFunction
 						{
 							Block oldBlock = world.getBlock(x, y, z);
 							int oldMeta = oldBlock.getDamageValue(world, x, y, z);
+							if (!PlayerHelper.hasEditPermission(world, ((EntityPlayerMP) player), x, y, z))
+							{
+								continue;
+							}
 
 							if (mode == NORMAL_MODE && oldBlock == Blocks.air)
 							{

--- a/src/main/java/moze_intel/projecte/gameObjs/items/PhilosophersStone.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/PhilosophersStone.java
@@ -115,11 +115,11 @@ public class PhilosophersStone extends ItemMode implements IProjectileShooter, I
 			
 			if (mode == 0)
 			{
-				doWorldTransmutation(world, mBlock, result, pos, 0, 0, charge);
+				doWorldTransmutation(world, mBlock, result, pos, 0, 0, charge, player);
 			}
 			else if (mode == 1)
 			{
-				getAxisOrientedPanel(direction, charge, mBlock, result, pos, world);
+				getAxisOrientedPanel(direction, charge, mBlock, result, pos, world, player);
 			}
 			else 
 			{
@@ -134,7 +134,7 @@ public class PhilosophersStone extends ItemMode implements IProjectileShooter, I
 		return true;
 	}
 	
-	private void getAxisOrientedPanel(ForgeDirection direction, int charge, MetaBlock pointed, MetaBlock result, Coordinates coords, World world)
+	private void getAxisOrientedPanel(ForgeDirection direction, int charge, MetaBlock pointed, MetaBlock result, Coordinates coords, World world, EntityPlayer player)
 	{
 		int side;
 		
@@ -151,7 +151,7 @@ public class PhilosophersStone extends ItemMode implements IProjectileShooter, I
 			side = 2;
 		}
 		
-		doWorldTransmutation(world, pointed, result, coords, 1, side, charge);
+		doWorldTransmutation(world, pointed, result, coords, 1, side, charge, player);
 	}
 	
 	private void getAxisOrientedLine(ForgeDirection direction, int charge, MetaBlock pointed, MetaBlock result, Coordinates coords, World world, EntityPlayer player)
@@ -180,13 +180,13 @@ public class PhilosophersStone extends ItemMode implements IProjectileShooter, I
 			}
 		}
 		
-		doWorldTransmutation(world, pointed, result, coords, 2, side, charge);
+		doWorldTransmutation(world, pointed, result, coords, 2, side, charge, player);
 	}
 	
 	/**
 	 * type 0 = cube, type 1 = panel, type 2 = line
 	 */
-	private void doWorldTransmutation(World world, MetaBlock pointed, MetaBlock result, Coordinates coords, int type, int side, int charge)
+	private void doWorldTransmutation(World world, MetaBlock pointed, MetaBlock result, Coordinates coords, int type, int side, int charge, EntityPlayer player)
 	{
 		if (type == 0)
 		{
@@ -194,7 +194,10 @@ public class PhilosophersStone extends ItemMode implements IProjectileShooter, I
 				for (int j = coords.y - charge; j <= coords.y + charge; j++)
 					for (int k = coords.z - charge; k <= coords.z + charge; k++)
 					{
-						changeBlock(world, pointed, result, i, j, k);
+						if (PlayerHelper.hasEditPermission(world, ((EntityPlayerMP) player), i, j, k))
+						{
+							changeBlock(world, pointed, result, i, j, k);
+						}
 					}
 		}
 		else if (type == 1)
@@ -204,7 +207,10 @@ public class PhilosophersStone extends ItemMode implements IProjectileShooter, I
 				for (int i = coords.x - charge; i <= coords.x + charge; i++)
 					for (int j = coords.z - charge; j <= coords.z + charge; j++)
 					{
-						changeBlock(world, pointed, result, i, coords.y, j);
+						if (PlayerHelper.hasEditPermission(world, ((EntityPlayerMP) player), i, coords.y, j))
+						{
+							changeBlock(world, pointed, result, i, coords.y, j);
+						}
 					}
 			}
 			else if (side == 1)
@@ -212,7 +218,10 @@ public class PhilosophersStone extends ItemMode implements IProjectileShooter, I
 				for (int i = coords.y - charge; i <= coords.y + charge; i++)
 					for (int j = coords.z - charge; j <= coords.z + charge; j++)
 					{
-						changeBlock(world, pointed, result, coords.x, i, j);
+						if (PlayerHelper.hasEditPermission(world, ((EntityPlayerMP) player), coords.x, i, j))
+						{
+							changeBlock(world, pointed, result, coords.x, i, j);
+						}
 					}
 			}
 			else
@@ -220,7 +229,10 @@ public class PhilosophersStone extends ItemMode implements IProjectileShooter, I
 				for (int i = coords.x - charge; i <= coords.x + charge; i++)
 					for (int j = coords.y - charge; j <= coords.y + charge; j++)
 					{
-						changeBlock(world, pointed, result, i, j, coords.z);
+						if (PlayerHelper.hasEditPermission(world, ((EntityPlayerMP) player), i, j, coords.z))
+						{
+							changeBlock(world, pointed, result, i, j, coords.z);
+						}
 					}
 			}
 		}
@@ -230,14 +242,20 @@ public class PhilosophersStone extends ItemMode implements IProjectileShooter, I
 			{
 				for (int i = coords.z - charge; i <= coords.z + charge; i++)
 				{
-					changeBlock(world, pointed, result, coords.x, coords.y, i);
+					if (PlayerHelper.hasEditPermission(world, ((EntityPlayerMP) player), coords.x, coords.y, i))
+					{
+						changeBlock(world, pointed, result, coords.x, coords.y, i);
+					}
 				}
 			}
 			else 
 			{
 				for (int i = coords.x - charge; i <= coords.x + charge; i++)
 				{
-					changeBlock(world, pointed, result, i, coords.y, coords.z);
+					if (PlayerHelper.hasEditPermission(world, ((EntityPlayerMP) player), i, coords.y, coords.z))
+					{
+						changeBlock(world, pointed, result, i, coords.y, coords.z);
+					}
 				}
 			}
 		}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/PhilosophersStone.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/PhilosophersStone.java
@@ -22,6 +22,7 @@ import moze_intel.projecte.utils.WorldHelper;
 import moze_intel.projecte.utils.WorldTransmutations;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -55,7 +56,7 @@ public class PhilosophersStone extends ItemMode implements IProjectileShooter, I
 	@Override
 	public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, int blockX, int blockY, int blockZ, int sideHit, float px, float py, float pz)
 	{
-		if (world.isRemote)
+		if (world.isRemote || !PlayerHelper.hasEditPermission(world, ((EntityPlayerMP) player), blockX, blockY, blockZ))
 		{
 			return false;
 		}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/VolcaniteAmulet.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/VolcaniteAmulet.java
@@ -52,7 +52,7 @@ public class VolcaniteAmulet extends ItemPE implements IProjectileShooter, IBaub
 	@Override
 	public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int sideHit, float f1, float f2, float f3)
 	{
-		if (!world.isRemote)
+		if (!world.isRemote && PlayerHelper.hasEditPermission(world, ((EntityPlayerMP) player), x, y, z))
 		{
 			TileEntity tile = world.getTileEntity(x, y, z);
 

--- a/src/main/java/moze_intel/projecte/gameObjs/items/VolcaniteAmulet.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/VolcaniteAmulet.java
@@ -98,7 +98,7 @@ public class VolcaniteAmulet extends ItemPE implements IProjectileShooter, IBaub
 						default: break;
 					}
 
-					if (world.isAirBlock(i, j, k) && consumeFuel(player, stack, 32, true))
+					if (world.isAirBlock(i, j, k) && PlayerHelper.hasEditPermission(world, ((EntityPlayerMP) player), i, j, k) && consumeFuel(player, stack, 32, true))
 					{
 						placeLava(world, i, j, k);
 						world.playSoundAtEntity(player, "projecte:item.petransmute", 1.0F, 1.0F);

--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/HarvestGoddess.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/HarvestGoddess.java
@@ -5,11 +5,13 @@ import moze_intel.projecte.api.item.IPedestalItem;
 import moze_intel.projecte.config.ProjectEConfig;
 import moze_intel.projecte.gameObjs.tiles.DMPedestalTile;
 import moze_intel.projecte.utils.MathUtils;
+import moze_intel.projecte.utils.PlayerHelper;
 import moze_intel.projecte.utils.WorldHelper;
 import net.minecraft.block.Block;
 import net.minecraft.block.IGrowable;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
@@ -64,13 +66,11 @@ public class HarvestGoddess extends RingToggle implements IPedestalItem
 	
 	public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int par7, float par8, float par9, float par10)
 	{
-		if (world.isRemote || !player.canPlayerEdit(x, y, z, par7, stack))
+		if (world.isRemote || !PlayerHelper.hasEditPermission(world, ((EntityPlayerMP) player), x, y, z))
 		{
 			return false;
 		}
-		
-		Block block = world.getBlock(x, y, z);
-		
+
 		if (player.isSneaking())
 		{
 			Object[] obj = getStackFromInventory(player.inventory.mainInventory, Items.dye, 15, 4);

--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/Ignition.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/Ignition.java
@@ -57,14 +57,14 @@ public class Ignition extends RingToggle implements IBauble, IPedestalItem, IFir
 
 		if (stack.getItemDamage() != 0)
 		{
-			if (this.getEmc(stack) == 0 && !this.consumeFuel(player, stack, 64, false))
+			if (getEmc(stack) == 0 && !consumeFuel(player, stack, 64, false))
 			{
 				stack.setItemDamage(0);
 			}
 			else 
 			{
 				WorldHelper.igniteNearby(world, player);
-				this.removeEmc(stack, 0.32F);
+				removeEmc(stack, 0.32F);
 			}
 		}
 		else 

--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/DarkHoe.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/DarkHoe.java
@@ -23,7 +23,7 @@ public class DarkHoe extends PEToolBase
 	@Override
 	public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int par7, float par8, float par9, float par10)
 	{
-		tillAOE(stack, player, world, x, y, z, par7, 0);
+		tillAOE(stack, player, world, x, y, z, 0);
 		return true;
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/RedKatar.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/RedKatar.java
@@ -73,7 +73,7 @@ public class RedKatar extends PEToolBase implements IExtraFunction
 				if (blockHit instanceof BlockGrass || blockHit instanceof BlockDirt)
 				{
 					// Hoe
-					tillAOE(stack, player, world, mop.blockX, mop.blockY, mop.blockZ, world.getBlockMetadata(mop.blockX, mop.blockY, mop.blockZ), 0);
+					tillAOE(stack, player, world, mop.blockX, mop.blockY, mop.blockZ, 0);
 				}
 				else if (blockHit instanceof BlockLog)
 				{

--- a/src/main/java/moze_intel/projecte/utils/NovaExplosion.java
+++ b/src/main/java/moze_intel/projecte/utils/NovaExplosion.java
@@ -143,7 +143,6 @@ public class NovaExplosion extends Explosion
 				}
 			}
 			
-			Entity ent = this.getExplosivePlacedBy();
 			WorldHelper.createLootDrop(list, worldObj, explosionX, explosionY, explosionZ);
 		}
 	}

--- a/src/main/java/moze_intel/projecte/utils/PlayerHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/PlayerHelper.java
@@ -9,9 +9,12 @@ import moze_intel.projecte.network.packets.SwingItemPKT;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Tuple;
 import net.minecraft.util.Vec3;
+import net.minecraft.world.World;
+import net.minecraftforge.common.ForgeHooks;
 
 /**
  * Helper class for player-related methods.
@@ -73,6 +76,18 @@ public final class PlayerHelper
 		Vec3 src = playerPos.addVector(0, player.getEyeHeight(), 0);
 		Vec3 dest = src.addVector(look.xCoord * maxDistance, look.yCoord * maxDistance, look.zCoord * maxDistance);
 		return new Tuple(src, dest);
+	}
+
+	public static boolean hasBreakPermission(World world, EntityPlayerMP player, int x, int y, int z)
+	{
+		return hasEditPermission(world, player, x, y, z)
+				&& !ForgeHooks.onBlockBreakEvent(world, player.theItemInWorldManager.getGameType(), player, x, y, z).isCanceled();
+	}
+
+	public static boolean hasEditPermission(World world, EntityPlayerMP player, int x, int y, int z)
+	{
+		return player.canPlayerEdit(x, y, z, world.getBlockMetadata(x, y, z), null)
+				&& !MinecraftServer.getServer().isBlockProtected(world, x, y, z, player);
 	}
 
 	public static void setPlayerFireImmunity(EntityPlayer player, boolean value)


### PR DESCRIPTION
Because we've been saying "we need to do that" for 2 months and no one's done anything :p

So far:
* Checks for editing blocks (transmutation, power items placing blocks, etc.)
* Checks for breaking blocks via event
* The place block event is kinda complicated in implementation, and firing those would not be very viable. I think those should only be used when actually placing a block from item->world form. Even in vanilla, buckets use the editing check, not a place block check.