### PR TITLE
[DONE] Resolve #893 with bonus side of refactor

### DIFF
--- a/src/main/java/moze_intel/projecte/PECore.java
+++ b/src/main/java/moze_intel/projecte/PECore.java
@@ -25,6 +25,7 @@ import moze_intel.projecte.events.ConnectionHandler;
 import moze_intel.projecte.events.PlayerEvents;
 import moze_intel.projecte.events.TickEvents;
 import moze_intel.projecte.gameObjs.ObjHandler;
+import moze_intel.projecte.handlers.PlayerChecks;
 import moze_intel.projecte.handlers.TileEntityHandler;
 import moze_intel.projecte.impl.IMCHandler;
 import moze_intel.projecte.network.PacketHandler;
@@ -162,7 +163,10 @@ public class PECore
 
 		Transmutation.clearCache();
 		PELogger.logDebug("Cleared cached tome knowledge");
-		
+
+		PlayerChecks.clearLists();
+		PELogger.logDebug("Cleared player check-lists: server stopping.");
+
 		EMCMapper.clearMaps();
 		PELogger.logInfo("Completed server-stop actions.");
 	}

--- a/src/main/java/moze_intel/projecte/PECore.java
+++ b/src/main/java/moze_intel/projecte/PECore.java
@@ -25,7 +25,6 @@ import moze_intel.projecte.events.ConnectionHandler;
 import moze_intel.projecte.events.PlayerEvents;
 import moze_intel.projecte.events.TickEvents;
 import moze_intel.projecte.gameObjs.ObjHandler;
-import moze_intel.projecte.handlers.PlayerChecks;
 import moze_intel.projecte.handlers.TileEntityHandler;
 import moze_intel.projecte.impl.IMCHandler;
 import moze_intel.projecte.network.PacketHandler;
@@ -163,9 +162,6 @@ public class PECore
 
 		Transmutation.clearCache();
 		PELogger.logDebug("Cleared cached tome knowledge");
-
-		PlayerChecks.clearLists();
-		PELogger.logDebug("Cleared player check-lists: server stopping.");
 		
 		EMCMapper.clearMaps();
 		PELogger.logInfo("Completed server-stop actions.");

--- a/src/main/java/moze_intel/projecte/config/ProjectEConfig.java
+++ b/src/main/java/moze_intel/projecte/config/ProjectEConfig.java
@@ -36,6 +36,7 @@ public final class ProjectEConfig
 	public static boolean craftableTome;
 	public static boolean altCraftingMat;
 	public static boolean useOldDamage;
+	public static int keybindCooldown;
 	public static int archangelPedCooldown;
 	public static int bodyPedCooldown;
 	public static int evertidePedCooldown;
@@ -100,6 +101,8 @@ public final class ProjectEConfig
 			craftableTome = config.getBoolean("craftableTome", "difficulty", false, "The Tome of Knowledge can be crafted.");
 			altCraftingMat = config.getBoolean("altCraftingMat", "difficulty", false, "If true some ProjectE items require a nether star instead of a diamond.");
 			useOldDamage = config.getBoolean("useOldDamage", "difficulty", false, "If true the old damage amounts from 1.4.7 and before will be used for weapons.");
+			keybindCooldown = config.getInt("keybindCooldown", "difficulty", 0, 0, Integer.MAX_VALUE, "For server admins: Set a cooldown, in ticks, to limit the rate at which the fire projectile and extra function keybinds can be triggered");
+
 
 			config.getCategory("pedestalcooldown").setComment("Cooldown for various items within the pedestal. A cooldown of -1 will disable the functionality.\n" +
 					"A cooldown of 0 will cause the actions happens every tick. Use caution as a very low value could cause TPS issues.");

--- a/src/main/java/moze_intel/projecte/config/ProjectEConfig.java
+++ b/src/main/java/moze_intel/projecte/config/ProjectEConfig.java
@@ -36,7 +36,6 @@ public final class ProjectEConfig
 	public static boolean craftableTome;
 	public static boolean altCraftingMat;
 	public static boolean useOldDamage;
-	public static int keybindCooldown;
 	public static int archangelPedCooldown;
 	public static int bodyPedCooldown;
 	public static int evertidePedCooldown;
@@ -101,8 +100,6 @@ public final class ProjectEConfig
 			craftableTome = config.getBoolean("craftableTome", "difficulty", false, "The Tome of Knowledge can be crafted.");
 			altCraftingMat = config.getBoolean("altCraftingMat", "difficulty", false, "If true some ProjectE items require a nether star instead of a diamond.");
 			useOldDamage = config.getBoolean("useOldDamage", "difficulty", false, "If true the old damage amounts from 1.4.7 and before will be used for weapons.");
-			keybindCooldown = config.getInt("keybindCooldown", "difficulty", 0, 0, Integer.MAX_VALUE, "For server admins: Set a cooldown, in ticks, to limit the rate at which the fire projectile and extra function keybinds can be triggered");
-
 
 			config.getCategory("pedestalcooldown").setComment("Cooldown for various items within the pedestal. A cooldown of -1 will disable the functionality.\n" +
 					"A cooldown of 0 will cause the actions happens every tick. Use caution as a very low value could cause TPS issues.");

--- a/src/main/java/moze_intel/projecte/events/ConnectionHandler.java
+++ b/src/main/java/moze_intel/projecte/events/ConnectionHandler.java
@@ -3,6 +3,7 @@ package moze_intel.projecte.events;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
+import moze_intel.projecte.handlers.PlayerChecks;
 import moze_intel.projecte.handlers.PlayerTimers;
 import moze_intel.projecte.network.PacketHandler;
 import moze_intel.projecte.network.packets.ClientCheckUpdatePKT;
@@ -26,6 +27,7 @@ public class ConnectionHandler
 	{
 		PlayerTimers.removePlayer(event.player);
 		PELogger.logInfo("Removing " + event.player.getCommandSenderName() + " from scheduled timers: Player disconnected.");
+		PlayerChecks.removePlayerFromLists(((EntityPlayerMP) event.player));
 	}
 
 }

--- a/src/main/java/moze_intel/projecte/events/ConnectionHandler.java
+++ b/src/main/java/moze_intel/projecte/events/ConnectionHandler.java
@@ -3,7 +3,6 @@ package moze_intel.projecte.events;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
-import moze_intel.projecte.handlers.PlayerChecks;
 import moze_intel.projecte.handlers.PlayerTimers;
 import moze_intel.projecte.network.PacketHandler;
 import moze_intel.projecte.network.packets.ClientCheckUpdatePKT;
@@ -26,9 +25,7 @@ public class ConnectionHandler
 	public void playerDisconnect(PlayerEvent.PlayerLoggedOutEvent event)
 	{
 		PlayerTimers.removePlayer(event.player);
-
-		PELogger.logInfo("Removing " + event.player.getCommandSenderName() + " from scheduled checklists: Player disconnected.");
-		PlayerChecks.removePlayerFromLists(event.player.getCommandSenderName());
+		PELogger.logInfo("Removing " + event.player.getCommandSenderName() + " from scheduled timers: Player disconnected.");
 	}
 
 }

--- a/src/main/java/moze_intel/projecte/events/TickEvents.java
+++ b/src/main/java/moze_intel/projecte/events/TickEvents.java
@@ -2,8 +2,10 @@ package moze_intel.projecte.events;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
+import cpw.mods.fml.relauncher.Side;
 import moze_intel.projecte.handlers.PlayerChecks;
 import moze_intel.projecte.handlers.PlayerTimers;
+import net.minecraft.entity.player.EntityPlayerMP;
 
 public class TickEvents
 {
@@ -12,8 +14,16 @@ public class TickEvents
 	{
 		if (event.phase == TickEvent.Phase.END)
 		{
-			PlayerChecks.update();
 			PlayerTimers.update();
+		}
+	}
+
+	@SubscribeEvent
+	public void playerTick(TickEvent.PlayerTickEvent event)
+	{
+		if (event.phase == TickEvent.Phase.END && event.side == Side.SERVER)
+		{
+			PlayerChecks.update(((EntityPlayerMP) event.player));
 		}
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/IFireProtector.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/IFireProtector.java
@@ -1,0 +1,15 @@
+package moze_intel.projecte.gameObjs.items;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+
+/**
+ * Internal interface for PlayerChecks.
+ */
+public interface IFireProtector
+{
+    /**
+     * @return If this stack currently should protect the bearer from fire
+     */
+    boolean canProtectAgainstFire(ItemStack stack, EntityPlayerMP player);
+}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/IFlightProvider.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/IFlightProvider.java
@@ -1,5 +1,6 @@
 package moze_intel.projecte.gameObjs.items;
 
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 
 /**
@@ -10,5 +11,5 @@ public interface IFlightProvider
     /**
      * @return If this stack currently should provide its bearer flight
      */
-    boolean canProvideFlight(ItemStack stack);
+    boolean canProvideFlight(ItemStack stack, EntityPlayerMP player);
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/IFlightProvider.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/IFlightProvider.java
@@ -1,0 +1,14 @@
+package moze_intel.projecte.gameObjs.items;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Internal interface for PlayerChecks.
+ */
+public interface IFlightProvider
+{
+    /**
+     * @return If this stack currently should provide its bearer flight
+     */
+    boolean canProvideFlight(ItemStack stack);
+}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/IStepAssister.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/IStepAssister.java
@@ -1,0 +1,14 @@
+package moze_intel.projecte.gameObjs.items;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Internal interface for PlayerChecks.
+ */
+public interface IStepAssister
+{
+    /**
+     * @return If this stack currently should enhance the bearer's step height
+     */
+    boolean canAssistStep(ItemStack stack);
+}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/IStepAssister.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/IStepAssister.java
@@ -1,5 +1,6 @@
 package moze_intel.projecte.gameObjs.items;
 
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 
 /**
@@ -10,5 +11,5 @@ public interface IStepAssister
     /**
      * @return If this stack currently should enhance the bearer's step height
      */
-    boolean canAssistStep(ItemStack stack);
+    boolean canAssistStep(ItemStack stack, EntityPlayerMP player);
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/VolcaniteAmulet.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/VolcaniteAmulet.java
@@ -2,24 +2,20 @@ package moze_intel.projecte.gameObjs.items;
 
 import baubles.api.BaubleType;
 import baubles.api.IBauble;
-
 import com.google.common.collect.Lists;
-
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import moze_intel.projecte.utils.IFireProtectionItem;
 import moze_intel.projecte.api.item.IPedestalItem;
 import moze_intel.projecte.api.item.IProjectileShooter;
 import moze_intel.projecte.config.ProjectEConfig;
 import moze_intel.projecte.gameObjs.entity.EntityLavaProjectile;
 import moze_intel.projecte.gameObjs.tiles.DMPedestalTile;
-import moze_intel.projecte.handlers.PlayerChecks;
 import moze_intel.projecte.utils.ClientKeyHelper;
 import moze_intel.projecte.utils.Constants;
 import moze_intel.projecte.utils.FluidHelper;
-import moze_intel.projecte.utils.PEKeybind;
 import moze_intel.projecte.utils.MathUtils;
+import moze_intel.projecte.utils.PEKeybind;
 import moze_intel.projecte.utils.PlayerHelper;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -40,7 +36,7 @@ import net.minecraftforge.fluids.IFluidHandler;
 import java.util.List;
 
 @Optional.Interface(iface = "baubles.api.IBauble", modid = "Baubles")
-public class VolcaniteAmulet extends ItemPE implements IProjectileShooter, IBauble, IPedestalItem, IFireProtectionItem
+public class VolcaniteAmulet extends ItemPE implements IProjectileShooter, IBauble, IPedestalItem, IFireProtector
 {
 	public VolcaniteAmulet()
 	{
@@ -154,16 +150,6 @@ public class VolcaniteAmulet extends ItemPE implements IProjectileShooter, IBaub
 				PlayerHelper.setPlayerWalkSpeed(player, Constants.PLAYER_WALK_SPEED);
 			}
 		}
-		
-		if (!world.isRemote)
-		{
-			if (!player.isImmuneToFire())
-			{
-				PlayerHelper.setPlayerFireImmunity(player, true);
-			}
-
-			PlayerChecks.addPlayerFireChecks((EntityPlayerMP) player);
-		}
 	}
 	
 	@Override
@@ -241,11 +227,6 @@ public class VolcaniteAmulet extends ItemPE implements IProjectileShooter, IBaub
 				PlayerHelper.setPlayerWalkSpeed(player, Constants.PLAYER_WALK_SPEED);
 			}
 		}
-		
-		if (!world.isRemote && !player.isImmuneToFire())
-		{
-			PlayerHelper.setPlayerFireImmunity(player, true);
-		}
 	}
 
 	@Override
@@ -254,13 +235,7 @@ public class VolcaniteAmulet extends ItemPE implements IProjectileShooter, IBaub
 
 	@Override
 	@Optional.Method(modid = "Baubles")
-	public void onUnequipped(ItemStack itemstack, EntityLivingBase player) 
-	{
-		if (player instanceof EntityPlayer && !player.worldObj.isRemote)
-		{
-			PlayerHelper.setPlayerFireImmunity((EntityPlayer) player, false);
-		}
-	}
+	public void onUnequipped(ItemStack itemstack, EntityLivingBase player) {}
 
 	@Override
 	@Optional.Method(modid = "Baubles")
@@ -308,5 +283,11 @@ public class VolcaniteAmulet extends ItemPE implements IProjectileShooter, IBaub
 			list.add(EnumChatFormatting.BLUE + String.format(StatCollector.translateToLocal("pe.volcanite.pedestal2"), MathUtils.tickToSecFormatted(ProjectEConfig.volcanitePedCooldown)));
 		}
 		return list;
+	}
+
+	@Override
+	public boolean canProtectAgainstFire(ItemStack stack, EntityPlayerMP player)
+	{
+		return true;
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/armor/GemChest.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/armor/GemChest.java
@@ -2,11 +2,10 @@ package moze_intel.projecte.gameObjs.items.armor;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import moze_intel.projecte.handlers.PlayerChecks;
+import moze_intel.projecte.gameObjs.items.IFireProtector;
 import moze_intel.projecte.handlers.PlayerTimers;
 import moze_intel.projecte.utils.EnumArmorType;
 import moze_intel.projecte.utils.NovaExplosion;
-import moze_intel.projecte.utils.PlayerHelper;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -17,7 +16,7 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class GemChest extends GemArmorBase
+public class GemChest extends GemArmorBase implements IFireProtector
 {
     public GemChest()
     {
@@ -61,12 +60,6 @@ public class GemChest extends GemArmorBase
             {
                 player.getFoodStats().addStats(2, 10);
             }
-
-            if (!player.isImmuneToFire())
-            {
-                PlayerHelper.setPlayerFireImmunity(player, true);
-                PlayerChecks.addPlayerFireChecks(playerMP);
-            }
         }
     }
 
@@ -77,5 +70,11 @@ public class GemChest extends GemArmorBase
         explosion.isSmoking = true;
         explosion.doExplosionA();
         explosion.doExplosionB(true);
+    }
+
+    @Override
+    public boolean canProtectAgainstFire(ItemStack stack, EntityPlayerMP player)
+    {
+        return player.getCurrentArmor(2) != null && player.getCurrentArmor(2).getItem() == this;
     }
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/armor/GemChest.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/armor/GemChest.java
@@ -75,6 +75,6 @@ public class GemChest extends GemArmorBase implements IFireProtector
     @Override
     public boolean canProtectAgainstFire(ItemStack stack, EntityPlayerMP player)
     {
-        return player.getCurrentArmor(2) != null && player.getCurrentArmor(2).getItem() == this;
+        return player.getCurrentArmor(2) == stack;
     }
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/armor/GemFeet.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/armor/GemFeet.java
@@ -3,12 +3,12 @@ package moze_intel.projecte.gameObjs.items.armor;
 import com.google.common.collect.Multimap;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import moze_intel.projecte.handlers.PlayerChecks;
+import moze_intel.projecte.gameObjs.items.IFlightProvider;
+import moze_intel.projecte.gameObjs.items.IStepAssister;
 import moze_intel.projecte.utils.ChatHelper;
 import moze_intel.projecte.utils.ClientKeyHelper;
 import moze_intel.projecte.utils.EnumArmorType;
 import moze_intel.projecte.utils.PEKeybind;
-import moze_intel.projecte.utils.PlayerHelper;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.entity.player.EntityPlayer;
@@ -22,20 +22,14 @@ import net.minecraft.world.World;
 
 import java.util.List;
 
-public class GemFeet extends GemArmorBase
+public class GemFeet extends GemArmorBase implements IFlightProvider, IStepAssister
 {
     public GemFeet()
     {
         super(EnumArmorType.FEET);
     }
 
-    public static boolean isStepAssistEnabled(ItemStack boots)
-    {
-        return !boots.hasTagCompound() || !boots.stackTagCompound.hasKey("StepAssist") || boots.stackTagCompound.getBoolean("StepAssist");
-
-    }
-
-    public static void toggleStepAssist(ItemStack boots, EntityPlayer player)
+    public void toggleStepAssist(ItemStack boots, EntityPlayer player)
     {
         if (!boots.hasTagCompound())
         {
@@ -68,21 +62,6 @@ public class GemFeet extends GemArmorBase
         {
             EntityPlayerMP playerMP = ((EntityPlayerMP) player);
             playerMP.fallDistance = 0;
-
-            if (isStepAssistEnabled(stack))
-            {
-                if (playerMP.stepHeight != 1.0f)
-                {
-                    playerMP.stepHeight = 1.0f;
-                    PlayerHelper.updateClientStepHeight(playerMP, 1.0F);
-                    PlayerChecks.addPlayerStepChecks(playerMP);
-                }
-            }
-
-            if (!player.capabilities.allowFlying)
-            {
-                PlayerHelper.enableFlight(playerMP);
-            }
         }
         else
         {
@@ -109,8 +88,8 @@ public class GemFeet extends GemArmorBase
         tooltips.add(String.format(
                 StatCollector.translateToLocal("pe.gem.stepassist.prompt"), ClientKeyHelper.getKeyName(PEKeybind.ARMOR_TOGGLE)));
 
-        EnumChatFormatting e = isStepAssistEnabled(stack) ? EnumChatFormatting.GREEN : EnumChatFormatting.RED;
-        String s = isStepAssistEnabled(stack) ? "pe.gem.enabled" : "pe.gem.disabled";
+        EnumChatFormatting e = canAssistStep(stack) ? EnumChatFormatting.GREEN : EnumChatFormatting.RED;
+        String s = canAssistStep(stack) ? "pe.gem.enabled" : "pe.gem.disabled";
         tooltips.add(StatCollector.translateToLocal("pe.gem.stepassist_tooltip") + " "
                 + e + StatCollector.translateToLocal(s));
     }
@@ -121,5 +100,17 @@ public class GemFeet extends GemArmorBase
         Multimap multimap = super.getAttributeModifiers(stack);
         multimap.put(SharedMonsterAttributes.movementSpeed.getAttributeUnlocalizedName(), new AttributeModifier(field_111210_e, "Armor modifier", 1.0, 2));
         return multimap;
+    }
+
+    @Override
+    public boolean canProvideFlight(ItemStack stack)
+    {
+        return true;
+    }
+
+    @Override
+    public boolean canAssistStep(ItemStack stack)
+    {
+        return stack.getTagCompound() != null && stack.getTagCompound().hasKey("StepAssist") && stack.getTagCompound().getBoolean("StepAssist");
     }
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/armor/GemFeet.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/armor/GemFeet.java
@@ -88,10 +88,15 @@ public class GemFeet extends GemArmorBase implements IFlightProvider, IStepAssis
         tooltips.add(String.format(
                 StatCollector.translateToLocal("pe.gem.stepassist.prompt"), ClientKeyHelper.getKeyName(PEKeybind.ARMOR_TOGGLE)));
 
-        EnumChatFormatting e = canAssistStep(stack) ? EnumChatFormatting.GREEN : EnumChatFormatting.RED;
-        String s = canAssistStep(stack) ? "pe.gem.enabled" : "pe.gem.disabled";
+        EnumChatFormatting e = canStep(stack) ? EnumChatFormatting.GREEN : EnumChatFormatting.RED;
+        String s = canStep(stack) ? "pe.gem.enabled" : "pe.gem.disabled";
         tooltips.add(StatCollector.translateToLocal("pe.gem.stepassist_tooltip") + " "
                 + e + StatCollector.translateToLocal(s));
+    }
+
+    private boolean canStep(ItemStack stack)
+    {
+        return stack.getTagCompound() != null && stack.getTagCompound().hasKey("StepAssist") && stack.getTagCompound().getBoolean("StepAssist");
     }
 
     @Override
@@ -103,14 +108,15 @@ public class GemFeet extends GemArmorBase implements IFlightProvider, IStepAssis
     }
 
     @Override
-    public boolean canProvideFlight(ItemStack stack)
+    public boolean canProvideFlight(ItemStack stack, EntityPlayerMP player)
     {
-        return true;
+        return player.getCurrentArmor(0) == stack;
     }
 
     @Override
-    public boolean canAssistStep(ItemStack stack)
+    public boolean canAssistStep(ItemStack stack, EntityPlayerMP player)
     {
-        return stack.getTagCompound() != null && stack.getTagCompound().hasKey("StepAssist") && stack.getTagCompound().getBoolean("StepAssist");
+        return player.getCurrentArmor(0) == stack
+                && canStep(stack);
     }
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/armor/GemHelmet.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/armor/GemHelmet.java
@@ -1,7 +1,5 @@
 package moze_intel.projecte.gameObjs.items.armor;
 
-import cpw.mods.fml.client.FMLClientHandler;
-import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -26,7 +24,6 @@ import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
-import org.lwjgl.input.Keyboard;
 import thaumcraft.api.IGoggles;
 import thaumcraft.api.nodes.IRevealer;
 
@@ -42,7 +39,7 @@ public class GemHelmet extends GemArmorBase implements IGoggles, IRevealer
 
     public static boolean isNightVisionEnabled(ItemStack helm)
     {
-        return !helm.hasTagCompound() || !helm.stackTagCompound.hasKey("NightVision") || helm.stackTagCompound.getBoolean("NightVision");
+        return helm.hasTagCompound() && helm.getTagCompound().hasKey("NightVision") && helm.getTagCompound().getBoolean("NightVision");
 
     }
 

--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/Arcana.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/Arcana.java
@@ -8,11 +8,9 @@ import moze_intel.projecte.api.item.IModeChanger;
 import moze_intel.projecte.api.item.IProjectileShooter;
 import moze_intel.projecte.gameObjs.entity.EntityFireProjectile;
 import moze_intel.projecte.gameObjs.entity.EntitySWRGProjectile;
+import moze_intel.projecte.gameObjs.items.IFireProtector;
+import moze_intel.projecte.gameObjs.items.IFlightProvider;
 import moze_intel.projecte.gameObjs.items.ItemPE;
-import moze_intel.projecte.handlers.PlayerChecks;
-import moze_intel.projecte.utils.IFireProtectionItem;
-import moze_intel.projecte.utils.IFlightItem;
-import moze_intel.projecte.utils.PlayerHelper;
 import moze_intel.projecte.utils.WorldHelper;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -32,7 +30,7 @@ import net.minecraft.world.World;
 import java.util.List;
 
 @Optional.Interface(iface = "baubles.api.IBauble", modid = "Baubles")
-public class Arcana extends ItemPE implements IBauble, IModeChanger, IFlightItem, IFireProtectionItem, IExtraFunction, IProjectileShooter
+public class Arcana extends ItemPE implements IBauble, IModeChanger, IFlightProvider, IFireProtector, IExtraFunction, IProjectileShooter
 {
 	private IIcon[] icons = new IIcon[4];
 	private IIcon[] iconsOn = new IIcon[4];
@@ -66,23 +64,6 @@ public class Arcana extends ItemPE implements IBauble, IModeChanger, IFlightItem
 	
 	private void tick(ItemStack stack, World world, EntityPlayerMP player)
 	{
-		if(!player.capabilities.isCreativeMode)
-		{
-			if(!player.capabilities.allowFlying)
-			{
-				//System.out.println("Enabling flight");
-				PlayerHelper.enableFlight(player);
-				PlayerChecks.addPlayerFlyChecks(player);
-			}
-			
-			if(!player.isImmuneToFire())
-			{
-				//System.out.println("Immunising against fire");
-				PlayerHelper.setPlayerFireImmunity(player, true);
-				PlayerChecks.addPlayerFireChecks(player);
-			}
-		}
-		
 		if(stack.getTagCompound().getBoolean("Active"))
 		{
 			switch(stack.getItemDamage())
@@ -133,17 +114,11 @@ public class Arcana extends ItemPE implements IBauble, IModeChanger, IFlightItem
 
 	@Override
 	@Optional.Method(modid = "Baubles")
-	public void onEquipped(ItemStack stack, EntityLivingBase player)
-	{
-		
-	}
+	public void onEquipped(ItemStack stack, EntityLivingBase player) {}
 
 	@Override
 	@Optional.Method(modid = "Baubles")
-	public void onUnequipped(ItemStack stack, EntityLivingBase player)
-	{
-		
-	}
+	public void onUnequipped(ItemStack stack, EntityLivingBase player) {}
 
 	@Override
 	@Optional.Method(modid = "Baubles")
@@ -168,7 +143,7 @@ public class Arcana extends ItemPE implements IBauble, IModeChanger, IFlightItem
 	@Override
 	public IIcon getIconIndex(ItemStack stack)
 	{
-		boolean active = (stack.hasTagCompound() ? stack.getTagCompound().getBoolean("Active") : false);
+		boolean active = stack.hasTagCompound() && stack.getTagCompound().getBoolean("Active");
 		return (active ? iconsOn : icons)[MathHelper.clamp_int(stack.getItemDamage(), 0, 3)];
 	}
 
@@ -276,6 +251,18 @@ public class Arcana extends ItemPE implements IBauble, IModeChanger, IFlightItem
 				break;
 		}
 		
+		return true;
+	}
+
+	@Override
+	public boolean canProtectAgainstFire(ItemStack stack, EntityPlayerMP player)
+	{
+		return true;
+	}
+
+	@Override
+	public boolean canProvideFlight(ItemStack stack)
+	{
 		return true;
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/Arcana.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/Arcana.java
@@ -261,7 +261,7 @@ public class Arcana extends ItemPE implements IBauble, IModeChanger, IFlightProv
 	}
 
 	@Override
-	public boolean canProvideFlight(ItemStack stack)
+	public boolean canProvideFlight(ItemStack stack, EntityPlayerMP player)
 	{
 		return true;
 	}

--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/Ignition.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/Ignition.java
@@ -2,19 +2,15 @@ package moze_intel.projecte.gameObjs.items.rings;
 
 import baubles.api.BaubleType;
 import baubles.api.IBauble;
-
 import com.google.common.collect.Lists;
-
 import cpw.mods.fml.common.Optional;
-import moze_intel.projecte.utils.IFireProtectionItem;
 import moze_intel.projecte.api.item.IPedestalItem;
 import moze_intel.projecte.api.item.IProjectileShooter;
 import moze_intel.projecte.config.ProjectEConfig;
 import moze_intel.projecte.gameObjs.entity.EntityFireProjectile;
+import moze_intel.projecte.gameObjs.items.IFireProtector;
 import moze_intel.projecte.gameObjs.tiles.DMPedestalTile;
-import moze_intel.projecte.handlers.PlayerChecks;
 import moze_intel.projecte.utils.MathUtils;
-import moze_intel.projecte.utils.PlayerHelper;
 import moze_intel.projecte.utils.WorldHelper;
 import net.minecraft.block.BlockTNT;
 import net.minecraft.entity.Entity;
@@ -32,7 +28,7 @@ import net.minecraft.world.World;
 import java.util.List;
 
 @Optional.Interface(iface = "baubles.api.IBauble", modid = "Baubles")
-public class Ignition extends RingToggle implements IBauble, IPedestalItem, IFireProtectionItem, IProjectileShooter
+public class Ignition extends RingToggle implements IBauble, IPedestalItem, IFireProtector, IProjectileShooter
 {
 	public Ignition()
 	{
@@ -47,24 +43,17 @@ public class Ignition extends RingToggle implements IBauble, IPedestalItem, IFir
 		
 		super.onUpdate(stack, world, entity, inventorySlot, par5);
 		EntityPlayerMP player = (EntityPlayerMP)entity;
-		
-		if(!player.capabilities.isCreativeMode && !player.isImmuneToFire())
-		{
-			//System.out.println("Immunising against fire");
-			PlayerHelper.setPlayerFireImmunity(player, true);
-			PlayerChecks.addPlayerFireChecks(player);
-		}
 
 		if (stack.getItemDamage() != 0)
 		{
-			if (this.getEmc(stack) == 0 && !this.consumeFuel(player, stack, 64, false))
+			if (getEmc(stack) == 0 && !consumeFuel(player, stack, 64, false))
 			{
 				stack.setItemDamage(0);
 			}
 			else 
 			{
 				WorldHelper.igniteNearby(world, player);
-				this.removeEmc(stack, 0.32F);
+				removeEmc(stack, 0.32F);
 			}
 		}
 		else 
@@ -79,7 +68,7 @@ public class Ignition extends RingToggle implements IBauble, IPedestalItem, IFir
 		
 		if (stack.getItemDamage() == 0)
 		{
-			if (this.getEmc(stack) == 0 && !this.consumeFuel(player, stack, 64, false))
+			if (getEmc(stack) == 0 && !consumeFuel(player, stack, 64, false))
 			{
 				//NOOP (used to be sounds)
 			}
@@ -197,6 +186,12 @@ public class Ignition extends RingToggle implements IBauble, IPedestalItem, IFir
 		EntityFireProjectile fire = new EntityFireProjectile(world, player);
 		world.spawnEntityInWorld(fire);
 		
+		return true;
+	}
+
+	@Override
+	public boolean canProtectAgainstFire(ItemStack stack, EntityPlayerMP player)
+	{
 		return true;
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/SWRG.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/SWRG.java
@@ -177,7 +177,7 @@ public class SWRG extends ItemPE implements IBauble, IPedestalItem, IFlightProvi
 	}
 
 	@Override
-	public boolean canProvideFlight(ItemStack stack)
+	public boolean canProvideFlight(ItemStack stack, EntityPlayerMP player)
 	{
 		// Dummy result - swrg needs special-casing
 		return false;

--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/SWRG.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/SWRG.java
@@ -119,6 +119,8 @@ public class SWRG extends ItemPE implements IBauble, IPedestalItem, IFlightProvi
 		}
 
 		removeEmc(stack, toRemove);
+
+		playerMP.fallDistance = 0;
 	}
 
 	private boolean isFlyingEnabled(ItemStack stack)

--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/SWRG.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/SWRG.java
@@ -6,13 +6,12 @@ import com.google.common.collect.Lists;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import moze_intel.projecte.utils.IFlightItem;
 import moze_intel.projecte.api.item.IPedestalItem;
 import moze_intel.projecte.config.ProjectEConfig;
+import moze_intel.projecte.gameObjs.items.IFlightProvider;
 import moze_intel.projecte.gameObjs.items.ItemPE;
 import moze_intel.projecte.gameObjs.tiles.DMPedestalTile;
 import moze_intel.projecte.utils.MathUtils;
-import moze_intel.projecte.utils.PlayerHelper;
 import moze_intel.projecte.utils.WorldHelper;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -32,7 +31,7 @@ import net.minecraft.world.World;
 import java.util.List;
 
 @Optional.Interface(iface = "baubles.api.IBauble", modid = "Baubles")
-public class SWRG extends ItemPE implements IBauble, IPedestalItem, IFlightItem
+public class SWRG extends ItemPE implements IBauble, IPedestalItem, IFlightProvider
 {
 	@SideOnly(Side.CLIENT)
 	private IIcon ringOff;
@@ -46,77 +45,63 @@ public class SWRG extends ItemPE implements IBauble, IPedestalItem, IFlightItem
 		this.setMaxDamage(0);
 		this.setNoRepair();
 	}
-	
-	@Override
-	public void onUpdate(ItemStack stack, World world, Entity entity, int invSlot, boolean isHeldItem) 
-	{
-		if (invSlot > 8 || !(entity instanceof EntityPlayer))
-		{
-			return;
-		}
-		
-		EntityPlayer player = (EntityPlayer) entity;
 
+	private void tick(ItemStack stack, EntityPlayer player)
+	{
 		if (stack.getItemDamage() > 1)
 		{
 			// Repel on both sides - smooth animation
-			WorldHelper.repelEntitiesInAABBFromPoint(world, player.boundingBox.expand(5.0, 5.0, 5.0), player.posX, player.posY, player.posZ, true);
+			WorldHelper.repelEntitiesInAABBFromPoint(player.worldObj, player.boundingBox.expand(5.0, 5.0, 5.0), player.posX, player.posY, player.posZ, true);
 		}
 
-		if (world.isRemote)
+		if (player.worldObj.isRemote)
 		{
 			return;
 		}
 
-		EntityPlayerMP playerMP = (EntityPlayerMP) entity;
+		EntityPlayerMP playerMP = (EntityPlayerMP) player;
 
 		if (!stack.hasTagCompound())
 		{
 			stack.stackTagCompound = new NBTTagCompound();
 		}
 
-		if (getEmc(stack) == 0 && !consumeFuel(player, stack, 64, false))
+		if (!playerMP.capabilities.isFlying || playerMP.onGround)
 		{
-			if (stack.getItemDamage() > 0)
+			if (stack.getItemDamage() == 3)
 			{
-				changeMode(player, stack, 0);
-			}
-			
-			if (playerMP.capabilities.allowFlying)
+				changeMode(stack, 2);
+			} else if (stack.getItemDamage() == 1)
 			{
-				PlayerHelper.disableFlight(playerMP);
+				changeMode(stack, 0);
 			}
-			
+		}
+
+		// Pre-consume a bit of fuel so canProvideFlight can return true, for auto-activate
+		if (getEmc(stack) <= 2.0 && !consumeFuel(player, stack, 64, true))
+		{
+			changeMode(stack, 0);
+		}
+
+		if (stack.getItemDamage() == 0)
+		{
 			return;
 		}
-		
-		if (!playerMP.capabilities.allowFlying)
-		{
-			PlayerHelper.enableFlight(playerMP);
-		}
+
+		float toRemove = 0;
 
 		if (playerMP.capabilities.isFlying)
 		{
-			if (!isFlyingEnabled(stack))
+			if (stack.getItemDamage() == 0)
 			{
-				changeMode(player, stack, stack.getItemDamage() == 0 ? 1 : 3);
-			}
-		}
-		else
-		{
-			if (isFlyingEnabled(stack))
+				changeMode(stack, 1);
+			} else if (stack.getItemDamage() == 2)
 			{
-				changeMode(player, stack, stack.getItemDamage() == 1 ? 0 : 2);
+				changeMode(stack, 3);
 			}
-		}
-		
-		float toRemove = 0;
-		
-		if (playerMP.capabilities.isFlying)
-		{
 			toRemove = 0.32F;
 		}
-		
+
 		if (stack.getItemDamage() == 2)
 		{
 			toRemove = 0.32F;
@@ -125,8 +110,21 @@ public class SWRG extends ItemPE implements IBauble, IPedestalItem, IFlightItem
 		{
 			toRemove = 0.64F;
 		}
-		
-		removeEmc(stack, toRemove);
+
+		if (!consumeFuel(playerMP, stack, toRemove, true) || getEmc(stack) <= 2.0)
+		{
+			changeMode(stack, 0);
+		}
+	}
+
+	@Override
+	public void onUpdate(ItemStack stack, World world, Entity entity, int invSlot, boolean isHeldItem) 
+	{
+		if (invSlot > 8 || !(entity instanceof EntityPlayer))
+		{
+			return;
+		}
+		tick(stack, ((EntityPlayer) entity));
 	}
 	
 	@Override
@@ -152,78 +150,11 @@ public class SWRG extends ItemPE implements IBauble, IPedestalItem, IFlightItem
 					break;
 			}
 			
-			if (newMode > 1)
-			{
-				if (getEmc(stack) > 0)
-				{
-					changeMode(player, stack, newMode);
-				}
-				else 
-				{
-					if (consumeFuel(player, stack, 64, false))
-					{
-						changeMode(player, stack, newMode);
-					}
-				}
-			}
-			else 
-			{
-				changeMode(player, stack, newMode);
-			}
+			changeMode(stack, newMode);
 		}
 		return stack;
 	}
-	
-	public void ToggleFlight(EntityPlayer player, ItemStack ring)
-	{
-		if (getEmc(ring) == 0 && !consumeFuel(player, ring, 64, false))
-		{
-			return;
-		}
-		
-		switch (ring.getItemDamage())
-		{
-			case 0:
-				changeMode(player, ring, 1);
-				break;
-			case 1:
-				changeMode(player, ring, 0);
-				break;
-			case 2:
-				changeMode(player, ring, 3);
-				break;
-			case 3:
-				changeMode(player, ring, 2);
-				break;
-		}
-	}
-	
-	public void enableFlightNoChecks(EntityPlayerMP playerMP)
-	{
-		if (playerMP.capabilities.isCreativeMode)
-		{
-			return;
-		}
-		
-		if (!playerMP.capabilities.allowFlying)
-		{
-			PlayerHelper.updateClientServerFlight(playerMP, true);
-		}
-	}
-	
-	public void disableFlightNoChecks(EntityPlayerMP playerMP)
-	{
-		if (playerMP.capabilities.isCreativeMode)
-		{
-			return;
-		}
-		
-		if (playerMP.capabilities.allowFlying)
-		{
-			PlayerHelper.updateClientServerFlight(playerMP, false);
-		}
-	}
-	
+
 	/**
 	 * Change the mode of SWRG. Modes:<p>
 	 * 0 = Ring Off<p>  
@@ -231,32 +162,20 @@ public class SWRG extends ItemPE implements IBauble, IPedestalItem, IFlightItem
 	 * 2 = Shield<p>
 	 * 3 = Flight + Shield<p>
 	 */
-	public void changeMode(EntityPlayer player, ItemStack stack, int mode)
+	public void changeMode(ItemStack stack, int mode)
 	{
 		stack.setItemDamage(mode);
 	}
-	
-	public boolean isFlyingEnabled(ItemStack stack)
+
+	@Override
+	public boolean canProvideFlight(ItemStack stack)
 	{
-		return stack.getItemDamage() == 1 || stack.getItemDamage() == 3;
-	}
-	
-	public float getEmcToRemove(ItemStack stack)
-	{
-		int damage = stack.getItemDamage();
-		
-		if (damage == 0)
+		boolean flag = getEmc(stack) > 2.0;
+		if (System.currentTimeMillis() % 50 == 0)
 		{
-			return 0;
+			System.out.println("SWRG canProvideFlight: " + flag);
 		}
-		else if (damage < 3)
-		{
-			return 0.32F;
-		}
-		else
-		{
-			return 0.64F;
-		}
+		return flag;
 	}
 	
 	@Override
@@ -307,79 +226,7 @@ public class SWRG extends ItemPE implements IBauble, IPedestalItem, IFlightItem
 		{
 			return;
 		}
-
-		EntityPlayer player = (EntityPlayer) ent;
-
-		if (stack.getItemDamage() > 1)
-		{
-			// Repel on both sides - smooth animation
-			WorldHelper.repelEntitiesInAABBFromPoint(player.worldObj, player.boundingBox.expand(5.0, 5.0, 5.0), player.posX, player.posY, player.posZ, true);
-		}
-
-		if (player.worldObj.isRemote)
-		{
-			return;
-		}
-
-		EntityPlayerMP playerMP = (EntityPlayerMP) player;
-
-		if (!stack.hasTagCompound())
-		{
-			stack.stackTagCompound = new NBTTagCompound();
-		}
-
-		if (getEmc(stack) == 0 && !consumeFuel(player, stack, 64, false))
-		{
-			if (stack.getItemDamage() > 0)
-			{
-				changeMode(player, stack, 0);
-			}
-			
-			if (playerMP.capabilities.allowFlying)
-			{
-				disableFlightNoChecks(playerMP);
-			}
-			
-			return;
-		}
-		
-		if (!playerMP.capabilities.allowFlying)
-		{
-			enableFlightNoChecks(playerMP);
-		}
-			
-		if (playerMP.capabilities.isFlying)
-		{
-			if (!isFlyingEnabled(stack))
-			{
-				changeMode(player, stack, stack.getItemDamage() == 0 ? 1 : 3);
-			}
-		}
-		else
-		{
-			if (isFlyingEnabled(stack))
-			{
-				changeMode(player, stack, stack.getItemDamage() == 1 ? 0 : 2);
-			}
-		}
-		
-		float toRemove = 0;
-		
-		if (playerMP.capabilities.isFlying)
-		{
-			toRemove = 0.32F;
-		}
-		
-		if (stack.getItemDamage() == 2)
-		{
-			toRemove = 0.32F;
-		}
-		else if (stack.getItemDamage() == 3)
-		{
-			toRemove = 0.64F;
-		}
-		
-		removeEmc(stack, toRemove);
+		tick(stack, ((EntityPlayer) ent));
 	}
 
 	@Override
@@ -388,15 +235,7 @@ public class SWRG extends ItemPE implements IBauble, IPedestalItem, IFlightItem
 
 	@Override
 	@Optional.Method(modid = "Baubles")
-	public void onUnequipped(ItemStack itemstack, EntityLivingBase player) 
-	{
-		if (player.worldObj.isRemote || !(player instanceof EntityPlayer))
-		{
-			return;
-		}
-
-		disableFlightNoChecks((EntityPlayerMP) player);
-	}
+	public void onUnequipped(ItemStack itemstack, EntityLivingBase player) {}
 
 	@Override
 	@Optional.Method(modid = "Baubles")

--- a/src/main/java/moze_intel/projecte/handlers/PlayerChecks.java
+++ b/src/main/java/moze_intel/projecte/handlers/PlayerChecks.java
@@ -33,37 +33,19 @@ public final class PlayerChecks
 		return gemArmorReadyChecks.contains(player);
 	}
 
-	// Checks if the server state of player capas mismatches with what ProjectE determines. If so, change it serverside and send a packet to client
 	public static void update(EntityPlayerMP player)
 	{
-		if (!shouldPlayerFly(player))
+		// Checks if the server state of player capas mismatches with what ProjectE determines. If so, change it serverside and send a packet to client
+		boolean shouldFly = shouldPlayerFly(player);
+		if (shouldFly != player.capabilities.allowFlying)
 		{
-			if (player.capabilities.allowFlying)
-			{
-				PlayerHelper.updateClientServerFlight(player, false);
-			}
-		}
-		else
-		{
-			if (!player.capabilities.allowFlying)
-			{
-				PlayerHelper.updateClientServerFlight(player, true);
-			}
+			PlayerHelper.updateClientServerFlight(player, shouldFly);
 		}
 
-		if (!shouldPlayerResistFire(player))
+		boolean shouldFireResist = shouldPlayerResistFire(player);
+		if (shouldFireResist != player.isImmuneToFire())
 		{
-			if (player.isImmuneToFire())
-			{
-				PlayerHelper.setPlayerFireImmunity(player, false);
-			}
-		}
-		else
-		{
-			if (!player.isImmuneToFire())
-			{
-				PlayerHelper.setPlayerFireImmunity(player, true);
-			}
+			PlayerHelper.setPlayerFireImmunity(player, shouldFireResist);
 		}
 
 		if (!shouldPlayerStep(player))

--- a/src/main/java/moze_intel/projecte/handlers/PlayerChecks.java
+++ b/src/main/java/moze_intel/projecte/handlers/PlayerChecks.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Sets;
 import moze_intel.projecte.gameObjs.items.IFireProtector;
 import moze_intel.projecte.gameObjs.items.IFlightProvider;
 import moze_intel.projecte.gameObjs.items.IStepAssister;
-import moze_intel.projecte.utils.PELogger;
 import moze_intel.projecte.utils.PlayerHelper;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
@@ -14,10 +13,8 @@ import java.util.Set;
 
 public final class PlayerChecks
 {
-	private static final Set<EntityPlayerMP> flyChecks = Sets.newHashSet();
-	private static final Set<EntityPlayerMP> fireChecks = Sets.newHashSet();
-	private static final Set<EntityPlayerMP> stepChecks = Sets.newHashSet();
-	public static final Set<EntityPlayerMP> gemArmorReadyChecks = Sets.newHashSet();
+	private static final Set<EntityPlayerMP> swrgOverrides = Sets.newHashSet();
+	private static final Set<EntityPlayerMP> gemArmorReadyChecks = Sets.newHashSet();
 
 	public static void setGemState(EntityPlayerMP player, boolean state)
 	{
@@ -43,7 +40,6 @@ public final class PlayerChecks
 		{
 			if (player.capabilities.allowFlying)
 			{
-				PELogger.logDebug("PE says cannot fly, MC can fly, telling client it can't fly");
 				PlayerHelper.updateClientServerFlight(player, false);
 			}
 		}
@@ -51,7 +47,6 @@ public final class PlayerChecks
 		{
 			if (!player.capabilities.allowFlying)
 			{
-				PELogger.logDebug("PE says fly, MC cannot fly, telling client it can fly");
 				PlayerHelper.updateClientServerFlight(player, true);
 			}
 		}
@@ -97,7 +92,7 @@ public final class PlayerChecks
 
 	private static boolean shouldPlayerFly(EntityPlayerMP player)
 	{
-		if (player.capabilities.isCreativeMode)
+		if (player.capabilities.isCreativeMode || swrgOverrides.contains(player))
 		{
 			return true;
 		}
@@ -236,5 +231,27 @@ public final class PlayerChecks
 		}
 
 		return false;
+	}
+
+	public static void enableSwrgFlightOverride(EntityPlayerMP player)
+	{
+		swrgOverrides.add(player);
+	}
+
+	public static void disableSwrgFlightOverride(EntityPlayerMP player)
+	{
+		swrgOverrides.remove(player);
+	}
+
+	public static void clearLists()
+	{
+		swrgOverrides.clear();
+		gemArmorReadyChecks.clear();
+	}
+
+	public static void removePlayerFromLists(EntityPlayerMP player)
+	{
+		swrgOverrides.remove(player);
+		gemArmorReadyChecks.remove(player);
 	}
 }

--- a/src/main/java/moze_intel/projecte/handlers/PlayerChecks.java
+++ b/src/main/java/moze_intel/projecte/handlers/PlayerChecks.java
@@ -33,19 +33,37 @@ public final class PlayerChecks
 		return gemArmorReadyChecks.contains(player);
 	}
 
+	// Checks if the server state of player capas mismatches with what ProjectE determines. If so, change it serverside and send a packet to client
 	public static void update(EntityPlayerMP player)
 	{
-		// Checks if the server state of player capas mismatches with what ProjectE determines. If so, change it serverside and send a packet to client
-		boolean shouldFly = shouldPlayerFly(player);
-		if (shouldFly != player.capabilities.allowFlying)
+		if (!shouldPlayerFly(player))
 		{
-			PlayerHelper.updateClientServerFlight(player, shouldFly);
+			if (player.capabilities.allowFlying)
+			{
+				PlayerHelper.updateClientServerFlight(player, false);
+			}
+		}
+		else
+		{
+			if (!player.capabilities.allowFlying)
+			{
+				PlayerHelper.updateClientServerFlight(player, true);
+			}
 		}
 
-		boolean shouldFireResist = shouldPlayerResistFire(player);
-		if (shouldFireResist != player.isImmuneToFire())
+		if (!shouldPlayerResistFire(player))
 		{
-			PlayerHelper.setPlayerFireImmunity(player, shouldFireResist);
+			if (player.isImmuneToFire())
+			{
+				PlayerHelper.setPlayerFireImmunity(player, false);
+			}
+		}
+		else
+		{
+			if (!player.isImmuneToFire())
+			{
+				PlayerHelper.setPlayerFireImmunity(player, true);
+			}
 		}
 
 		if (!shouldPlayerStep(player))

--- a/src/main/java/moze_intel/projecte/handlers/PlayerChecks.java
+++ b/src/main/java/moze_intel/projecte/handlers/PlayerChecks.java
@@ -101,7 +101,7 @@ public final class PlayerChecks
 		{
 			if (stack != null
 					&& stack.getItem() instanceof IFlightProvider
-					&& ((IFlightProvider) stack.getItem()).canProvideFlight(stack))
+					&& ((IFlightProvider) stack.getItem()).canProvideFlight(stack, player))
 			{
 				return true;
 			}
@@ -113,7 +113,7 @@ public final class PlayerChecks
 
 			if (stack != null
 					&& stack.getItem() instanceof IFlightProvider
-					&& ((IFlightProvider) stack.getItem()).canProvideFlight(stack))
+					&& ((IFlightProvider) stack.getItem()).canProvideFlight(stack, player))
 			{
 				return true;
 			}
@@ -127,7 +127,7 @@ public final class PlayerChecks
 				ItemStack stack = baubles.getStackInSlot(i);
 				if (stack != null
 						&& stack.getItem() instanceof IFlightProvider
-						&& ((IFlightProvider) stack.getItem()).canProvideFlight(stack))
+						&& ((IFlightProvider) stack.getItem()).canProvideFlight(stack, player))
 				{
 					return true;
 				}
@@ -197,7 +197,7 @@ public final class PlayerChecks
 		{
 			if (stack != null
 					&& stack.getItem() instanceof IStepAssister
-					&& ((IStepAssister) stack.getItem()).canAssistStep(stack))
+					&& ((IStepAssister) stack.getItem()).canAssistStep(stack, player))
 			{
 				return true;
 			}
@@ -209,7 +209,7 @@ public final class PlayerChecks
 
 			if (stack != null
 					&& stack.getItem() instanceof IStepAssister
-					&& ((IStepAssister) stack.getItem()).canAssistStep(stack))
+					&& ((IStepAssister) stack.getItem()).canAssistStep(stack, player))
 			{
 				return true;
 			}
@@ -223,7 +223,7 @@ public final class PlayerChecks
 				ItemStack stack = baubles.getStackInSlot(i);
 				if (stack != null
 						&& stack.getItem() instanceof IStepAssister
-						&& ((IStepAssister) stack.getItem()).canAssistStep(stack))
+						&& ((IStepAssister) stack.getItem()).canAssistStep(stack, player))
 				{
 					return true;
 				}

--- a/src/main/java/moze_intel/projecte/handlers/PlayerChecks.java
+++ b/src/main/java/moze_intel/projecte/handlers/PlayerChecks.java
@@ -1,29 +1,22 @@
 package moze_intel.projecte.handlers;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
-import moze_intel.projecte.utils.IFireProtectionItem;
-import moze_intel.projecte.utils.IFlightItem;
-import moze_intel.projecte.utils.IStepAssistItem;
-
-import moze_intel.projecte.gameObjs.ObjHandler;
-import moze_intel.projecte.gameObjs.items.armor.GemFeet;
+import moze_intel.projecte.gameObjs.items.IFireProtector;
+import moze_intel.projecte.gameObjs.items.IFlightProvider;
+import moze_intel.projecte.gameObjs.items.IStepAssister;
 import moze_intel.projecte.utils.PELogger;
 import moze_intel.projecte.utils.PlayerHelper;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
-import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 
 public final class PlayerChecks
 {
-	private static final List<EntityPlayerMP> flyChecks = Lists.newArrayList();
-	private static final List<EntityPlayerMP> fireChecks = Lists.newArrayList();
-	private static final List<EntityPlayerMP> stepChecks = Lists.newArrayList();
+	private static final Set<EntityPlayerMP> flyChecks = Sets.newHashSet();
+	private static final Set<EntityPlayerMP> fireChecks = Sets.newHashSet();
+	private static final Set<EntityPlayerMP> stepChecks = Sets.newHashSet();
 	public static final Set<EntityPlayerMP> gemArmorReadyChecks = Sets.newHashSet();
 
 	public static void setGemState(EntityPlayerMP player, boolean state)
@@ -43,291 +36,205 @@ public final class PlayerChecks
 		return gemArmorReadyChecks.contains(player);
 	}
 
-	public static void update()
+	// Checks if the server state of player capas mismatches with what ProjectE determines. If so, change it serverside and send a packet to client
+	public static void update(EntityPlayerMP player)
 	{
-		Iterator<EntityPlayerMP> iter = flyChecks.iterator();
-
-		while (iter.hasNext())
+		if (!shouldPlayerFly(player))
 		{
-			EntityPlayerMP player = iter.next();
-
-			if (!canPlayerFly(player))
+			if (player.capabilities.allowFlying)
 			{
-				if (player.capabilities.allowFlying)
-				{
-					PlayerHelper.updateClientServerFlight(player, false);
-				}
-
-				iter.remove();
-				PELogger.logDebug("Removed " + player.getCommandSenderName() + " from flight checks.");
+				PELogger.logDebug("PE says cannot fly, MC can fly, telling client it can't fly");
+				PlayerHelper.updateClientServerFlight(player, false);
+			}
+		}
+		else
+		{
+			if (!player.capabilities.allowFlying)
+			{
+				PELogger.logDebug("PE says fly, MC cannot fly, telling client it can fly");
+				PlayerHelper.updateClientServerFlight(player, true);
 			}
 		}
 
-		iter = fireChecks.iterator();
-
-		while (iter.hasNext())
+		if (!shouldPlayerResistFire(player))
 		{
-			EntityPlayerMP player = iter.next();
-
-			if (!isPlayerFireImmune(player))
+			if (player.isImmuneToFire())
 			{
-				if (player.isImmuneToFire())
-				{
-					PlayerHelper.setPlayerFireImmunity(player, false);
-				}
-
-				iter.remove();
-				PELogger.logDebug("Removed " + player.getCommandSenderName() + " from fire checks.");
+				PlayerHelper.setPlayerFireImmunity(player, false);
+			}
+		}
+		else
+		{
+			if (!player.isImmuneToFire())
+			{
+				PlayerHelper.setPlayerFireImmunity(player, true);
 			}
 		}
 
-		iter = stepChecks.iterator();
-
-		while (iter.hasNext())
+		if (!shouldPlayerStep(player))
 		{
-			EntityPlayerMP player = iter.next();
-
-			if (!canPlayerStep(player))
+			if (player.stepHeight > 0.5F)
 			{
-				player.stepHeight = 0.5f;
-				PlayerHelper.updateClientStepHeight(player, 0.5F);
-
-				iter.remove();
-				PELogger.logDebug("Removed " + player.getCommandSenderName() + " from step checks.");
+				PlayerHelper.updateClientServerStepHeight(player, 0.5F);
+			}
+		}
+		else
+		{
+			if (player.stepHeight < 1.0F)
+			{
+				PlayerHelper.updateClientServerStepHeight(player, 1.0F);
 			}
 		}
 	}
+
 
 	public static void onPlayerChangeDimension(EntityPlayerMP playerMP)
 	{
-		if (canPlayerFly(playerMP))
-		{
-			PlayerHelper.updateClientServerFlight(playerMP, true);
-		}
-
-		if (isPlayerFireImmune(playerMP))
-		{
-			PlayerHelper.setPlayerFireImmunity(playerMP, true);
-		}
-
-		if (canPlayerStep(playerMP))
-		{
-			playerMP.stepHeight = 1.0f;
-			PlayerHelper.updateClientStepHeight(playerMP, 1.0F);
-		}
+		// Resend everything needed on clientside (all except fire resist)
+		PlayerHelper.updateClientServerFlight(playerMP, playerMP.capabilities.allowFlying);
+		PlayerHelper.updateClientServerStepHeight(playerMP, playerMP.stepHeight);
 	}
 
-	public static void addPlayerFlyChecks(EntityPlayerMP player)
-	{
-		if (!flyChecks.contains(player))
-		{
-			flyChecks.add(player);
-			PELogger.logDebug("Added " + player.getCommandSenderName() + " to flight checks.");
-		}
-	}
-	
-	public static void addPlayerFireChecks(EntityPlayerMP player)
-	{
-		if (!fireChecks.contains(player))
-		{
-			fireChecks.add(player);
-			PELogger.logDebug("Added " + player.getCommandSenderName() + " to fire checks.");
-		}
-	}
-	
-	public static void addPlayerStepChecks(EntityPlayerMP player)
-	{
-		if (!stepChecks.contains(player))
-		{
-			stepChecks.add(player);
-			PELogger.logDebug("Added " + player.getCommandSenderName() + " to step height checks.");
-		}
-	}
-
-	public static void removePlayerFlyChecks(EntityPlayerMP player)
-	{
-		if (flyChecks.contains(player))
-		{
-			Iterator<EntityPlayerMP> iterator = flyChecks.iterator();
-			
-			while (iterator.hasNext())
-			{
-				if (iterator.next().equals(player))
-				{
-					iterator.remove();
-					PELogger.logDebug("Removed " + player.getCommandSenderName() + " from flight checks.");
-					return;
-				}
-			}
-		}
-	}
-	
-	public static void removePlayerFireChecks(EntityPlayerMP player)
-	{
-		if (fireChecks.contains(player))
-		{
-			Iterator<EntityPlayerMP> iterator = fireChecks.iterator();
-			
-			while (iterator.hasNext())
-			{
-				if (iterator.next().equals(player))
-				{
-					iterator.remove();
-					PELogger.logDebug("Removed " + player + " from fire checks.");
-					return;
-				}
-			}
-		}
-	}
-	
-	public static void removePlayerStepChecks(EntityPlayerMP player)
-	{
-		if (stepChecks.contains(player))
-		{
-			Iterator<EntityPlayerMP> iterator = stepChecks.iterator();
-			
-			while (iterator.hasNext())
-			{
-				if (iterator.next().equals(player))
-				{
-					iterator.remove();
-					PELogger.logDebug("Removed " + player + " from step height checks.");
-					return;
-				}
-			}
-		}
-	}
-	
-	public static void removePlayerFromLists(String username)
-	{
-		Iterator<EntityPlayerMP> iterator = flyChecks.iterator();
-		
-		while (iterator.hasNext())
-		{
-			if (iterator.next().getCommandSenderName().equals(username))
-			{
-				iterator.remove();
-				break;
-			}
-		}
-		
-		iterator = fireChecks.iterator();
-		
-		while (iterator.hasNext())
-		{
-			if (iterator.next().getCommandSenderName().equals(username))
-			{
-				iterator.remove();
-				break;
-			}
-		}
-		
-		iterator = stepChecks.iterator();
-		
-		while (iterator.hasNext())
-		{
-			if (iterator.next().getCommandSenderName().equals(username))
-			{
-				iterator.remove();
-				break;
-			}
-		}
-	}
-
-	public static boolean isPlayerCheckedForStep(String player)
-	{
-		Iterator<EntityPlayerMP> iter = stepChecks.iterator();
-
-		while (iter.hasNext())
-		{
-			if (iter.next().getCommandSenderName().equals(player))
-			{
-				return true;
-			}
-		}
-
-		return false;
-	}
-	
-	public static void clearLists()
-	{
-		flyChecks.clear();
-		fireChecks.clear();
-		stepChecks.clear();
-	}
-	
-	private static boolean canPlayerFly(EntityPlayer player)
+	private static boolean shouldPlayerFly(EntityPlayerMP player)
 	{
 		if (player.capabilities.isCreativeMode)
 		{
 			return true;
 		}
 
-		ItemStack armor = player.getCurrentArmor(0);
-		if (armor != null && armor.getItem() instanceof GemFeet)
+		for (ItemStack stack : player.inventory.armorInventory)
 		{
-			return true;
+			if (stack != null
+					&& stack.getItem() instanceof IFlightProvider
+					&& ((IFlightProvider) stack.getItem()).canProvideFlight(stack))
+			{
+				return true;
+			}
 		}
 
 		for (int i = 0; i <= 8; i++)
 		{
 			ItemStack stack = player.inventory.getStackInSlot(i);
-			
-			if (stack != null && stack.getItem() instanceof IFlightItem)
+
+			if (stack != null
+					&& stack.getItem() instanceof IFlightProvider
+					&& ((IFlightProvider) stack.getItem()).canProvideFlight(stack))
 			{
 				return true;
 			}
 		}
-		
+
+		IInventory baubles = PlayerHelper.getBaubles(player);
+		if (baubles != null)
+		{
+			for (int i = 0; i < baubles.getSizeInventory(); i++)
+			{
+				ItemStack stack = baubles.getStackInSlot(i);
+				if (stack != null
+						&& stack.getItem() instanceof IFlightProvider
+						&& ((IFlightProvider) stack.getItem()).canProvideFlight(stack))
+				{
+					return true;
+				}
+			}
+		}
+
 		return false;
 	}
 	
-	private static boolean isPlayerFireImmune(EntityPlayer player)
+	private static boolean shouldPlayerResistFire(EntityPlayerMP player)
 	{
 		if (player.capabilities.isCreativeMode)
 		{
 			return true;
 		}
-		
-		ItemStack chest = player.getCurrentArmor(2);
-		
-		if (chest != null && chest.getItem() == ObjHandler.gemChest)
+
+
+		for (ItemStack stack : player.inventory.armorInventory)
 		{
-			return true;
-		}
-		
-		for (int i = 0; i <= 8; i++)
-		{
-			ItemStack stack = player.inventory.getStackInSlot(i);
-			
-			if (stack != null && stack.getItem() instanceof IFireProtectionItem)
+			if (stack != null
+					&& stack.getItem() instanceof IFireProtector
+					&& ((IFireProtector) stack.getItem()).canProtectAgainstFire(stack, player))
 			{
 				return true;
 			}
 		}
-		
+
+		for (int i = 0; i <= 8; i++)
+		{
+			ItemStack stack = player.inventory.getStackInSlot(i);
+
+			if (stack != null
+					&& stack.getItem() instanceof IFireProtector
+					&& ((IFireProtector) stack.getItem()).canProtectAgainstFire(stack, player))
+			{
+				return true;
+			}
+		}
+
+		IInventory baubles = PlayerHelper.getBaubles(player);
+		if (baubles != null)
+		{
+			for (int i = 0; i < baubles.getSizeInventory(); i++)
+			{
+				ItemStack stack = baubles.getStackInSlot(i);
+				if (stack != null
+						&& stack.getItem() instanceof IFireProtector
+						&& ((IFireProtector) stack.getItem()).canProtectAgainstFire(stack, player))
+				{
+					return true;
+				}
+			}
+		}
+
 		return false;
 	}
 	
-	private static boolean canPlayerStep(EntityPlayer player)
+	private static boolean shouldPlayerStep(EntityPlayerMP player)
 	{
-		ItemStack boots = player.getCurrentArmor(0);
-		
-		return ((boots != null && boots.getItem() == ObjHandler.gemFeet && GemFeet.isStepAssistEnabled(boots)) || hasPlayerEquippedStepAssist(player));
-	}
-	
-	private static boolean hasPlayerEquippedStepAssist(EntityPlayer player)
-	{
-		for (int i = 0; i <= 8; i++)
+		if (player.capabilities.isCreativeMode)
 		{
-			ItemStack stack = player.inventory.getStackInSlot(i);
-			
-			if (stack != null && stack.getItem() instanceof IStepAssistItem)
+			return true;
+		}
+
+
+		for (ItemStack stack : player.inventory.armorInventory)
+		{
+			if (stack != null
+					&& stack.getItem() instanceof IStepAssister
+					&& ((IStepAssister) stack.getItem()).canAssistStep(stack))
 			{
 				return true;
 			}
 		}
-		
+
+		for (int i = 0; i <= 8; i++)
+		{
+			ItemStack stack = player.inventory.getStackInSlot(i);
+
+			if (stack != null
+					&& stack.getItem() instanceof IStepAssister
+					&& ((IStepAssister) stack.getItem()).canAssistStep(stack))
+			{
+				return true;
+			}
+		}
+
+		IInventory baubles = PlayerHelper.getBaubles(player);
+		if (baubles != null)
+		{
+			for (int i = 0; i < baubles.getSizeInventory(); i++)
+			{
+				ItemStack stack = baubles.getStackInSlot(i);
+				if (stack != null
+						&& stack.getItem() instanceof IStepAssister
+						&& ((IStepAssister) stack.getItem()).canAssistStep(stack))
+				{
+					return true;
+				}
+			}
+		}
+
 		return false;
 	}
 }

--- a/src/main/java/moze_intel/projecte/network/packets/KeyPressPKT.java
+++ b/src/main/java/moze_intel/projecte/network/packets/KeyPressPKT.java
@@ -17,6 +17,7 @@ import moze_intel.projecte.handlers.PlayerChecks;
 import moze_intel.projecte.utils.PEKeybind;
 import moze_intel.projecte.utils.PlayerHelper;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentTranslation;
 
@@ -36,78 +37,75 @@ public class KeyPressPKT implements IMessage, IMessageHandler<KeyPressPKT, IMess
 	{
 		EntityPlayerMP player = ctx.getServerHandler().playerEntity;
 		ItemStack stack = player.getHeldItem();
-		switch (message.key)
+		
+		if (message.key == PEKeybind.ARMOR_TOGGLE)
 		{
-			case ARMOR_TOGGLE:
-				if (player.isSneaking())
+			if (player.isSneaking())
+			{
+				ItemStack helm = player.inventory.armorItemInSlot(3);
+				
+				if (helm != null && helm.getItem() == ObjHandler.gemHelmet)
 				{
-					ItemStack helm = player.inventory.armorItemInSlot(3);
-
-					if (helm != null && helm.getItem() == ObjHandler.gemHelmet)
-					{
-						GemHelmet.toggleNightVision(helm, player);
-					}
+					GemHelmet.toggleNightVision(helm, player);
 				}
-				else
+			}
+			else
+			{
+				ItemStack boots = player.inventory.armorItemInSlot(0);
+			
+				if (boots != null && boots.getItem() == ObjHandler.gemFeet)
 				{
-					ItemStack boots = player.inventory.armorItemInSlot(0);
-
-					if (boots != null && boots.getItem() == ObjHandler.gemFeet)
-					{
-						((GemFeet) ObjHandler.gemFeet).toggleStepAssist(boots, player);
-					}
+					((GemFeet) ObjHandler.gemFeet).toggleStepAssist(boots, player);
 				}
-				break;
-			case CHARGE:
-				if (stack == null && GemArmorBase.hasAnyPiece(player))
-				{
-					PlayerChecks.setGemState(player, !PlayerChecks.getGemState(player));
-					player.addChatMessage(new ChatComponentTranslation(PlayerChecks.getGemState(player) ? "pe.gem.activate" : "pe.gem.deactivate"));
-				}
-
-				if (stack != null && stack.getItem() instanceof IItemCharge)
-				{
-					((IItemCharge) stack.getItem()).changeCharge(player, stack);
-				}
-				break;
-			case EXTRA_FUNCTION:
-				if (stack == null && PlayerChecks.getGemState(player))
-				{
-					if (player.getCurrentArmor(2) != null && player.getCurrentArmor(2).getItem() == ObjHandler.gemChest)
-					{
-						GemChest.doExplode(player);
-					}
-				}
-
-				if (stack != null && stack.getItem() instanceof IExtraFunction)
-				{
-					((IExtraFunction) stack.getItem()).doExtraFunction(stack, player);
-				}
-				break;
-			case FIRE_PROJECTILE:
-				if (stack == null && PlayerChecks.getGemState(player))
-				{
-					if (player.getCurrentArmor(3) != null && player.getCurrentArmor(3).getItem() == ObjHandler.gemHelmet)
-					{
-						GemHelmet.doZap(player);
-					}
-				}
-
-				if (stack != null && stack.getItem() instanceof IProjectileShooter)
-				{
-					if (((IProjectileShooter) stack.getItem()).shootProjectile(player, stack))
-					{
-						PlayerHelper.swingItem((player));
-					}
-				}
-				break;
-			case MODE:
-				if (stack != null && stack.getItem() instanceof IModeChanger)
-				{
-					((IModeChanger) stack.getItem()).changeMode(player, stack);
-				}
-				break;
+			}
 		}
+		
+		if (stack == null)
+		{
+			if (message.key == PEKeybind.CHARGE && GemArmorBase.hasAnyPiece(player))
+			{
+				PlayerChecks.setGemState(player, !PlayerChecks.getGemState(player));
+				player.addChatMessage(new ChatComponentTranslation(PlayerChecks.getGemState(player) ? "pe.gem.activate" : "pe.gem.deactivate"));
+				return null;
+			}
+
+			if (PlayerChecks.getGemState(player)) {
+				ItemStack[] armor = player.inventory.armorInventory;
+				if (armor[2] != null && armor[2].getItem() == ObjHandler.gemChest && message.key == PEKeybind.EXTRA_FUNCTION)
+                {
+                    GemChest.doExplode(player);
+                }
+				if (armor[3] != null && armor[3].getItem() == ObjHandler.gemHelmet && message.key == PEKeybind.FIRE_PROJECTILE)
+                {
+                    GemHelmet.doZap(player);
+                }
+			}
+
+			return null;
+		}
+		
+		Item item = stack.getItem();
+		
+		if (message.key == PEKeybind.CHARGE && item instanceof IItemCharge)
+		{
+			((IItemCharge) item).changeCharge(player, stack);
+		}
+		else if (message.key == PEKeybind.MODE && item instanceof IModeChanger)
+		{
+			((IModeChanger) item).changeMode(player, stack);
+		}
+		else if (message.key == PEKeybind.FIRE_PROJECTILE && item instanceof IProjectileShooter)
+		{
+			if (((IProjectileShooter) item).shootProjectile(player, stack))
+			{
+				PlayerHelper.swingItem((player));
+			}
+		}
+		else if (message.key == PEKeybind.EXTRA_FUNCTION && item instanceof IExtraFunction)
+		{
+			((IExtraFunction) item).doExtraFunction(stack, player);
+		}
+		
 		return null;
 	}
 

--- a/src/main/java/moze_intel/projecte/network/packets/KeyPressPKT.java
+++ b/src/main/java/moze_intel/projecte/network/packets/KeyPressPKT.java
@@ -55,7 +55,7 @@ public class KeyPressPKT implements IMessage, IMessageHandler<KeyPressPKT, IMess
 			
 				if (boots != null && boots.getItem() == ObjHandler.gemFeet)
 				{
-					GemFeet.toggleStepAssist(boots, player);
+					((GemFeet) ObjHandler.gemFeet).toggleStepAssist(boots, player);
 				}
 			}
 		}

--- a/src/main/java/moze_intel/projecte/utils/EMCHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/EMCHelper.java
@@ -37,7 +37,6 @@ public final class EMCHelper
 		IInventory inv = player.inventory;
 		LinkedHashMap<Integer, Integer> map = Maps.newLinkedHashMap();
 		boolean metRequirement = false;
-		int decrement = 0;
 		int emcConsumed = 0;
 
 		for (int i = 0; i < inv.getSizeInventory(); i++)

--- a/src/main/java/moze_intel/projecte/utils/IFireProtectionItem.java
+++ b/src/main/java/moze_intel/projecte/utils/IFireProtectionItem.java
@@ -1,6 +1,0 @@
-package moze_intel.projecte.utils;
-
-/**
- * Internal marker interface for PlayerChecks. Addon-makers: DO NOT USE.
- */
-public interface IFireProtectionItem {}

--- a/src/main/java/moze_intel/projecte/utils/IFlightItem.java
+++ b/src/main/java/moze_intel/projecte/utils/IFlightItem.java
@@ -1,6 +1,0 @@
-package moze_intel.projecte.utils;
-
-/**
- * Internal marker interface for PlayerChecks. Addon-makers: DO NOT USE.
- */
-public interface IFlightItem {}

--- a/src/main/java/moze_intel/projecte/utils/IStepAssistItem.java
+++ b/src/main/java/moze_intel/projecte/utils/IStepAssistItem.java
@@ -1,6 +1,0 @@
-package moze_intel.projecte.utils;
-
-/**
- * Internal marker interface for PlayerChecks. Addon-makers: DO NOT USE.
- */
-public interface IStepAssistItem {}

--- a/src/main/java/moze_intel/projecte/utils/PlayerHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/PlayerHelper.java
@@ -1,13 +1,15 @@
 package moze_intel.projecte.utils;
 
+import baubles.api.BaublesApi;
+import cpw.mods.fml.common.Loader;
 import moze_intel.projecte.gameObjs.items.ItemPE;
-import moze_intel.projecte.handlers.PlayerChecks;
 import moze_intel.projecte.network.PacketHandler;
 import moze_intel.projecte.network.packets.SetFlyPKT;
 import moze_intel.projecte.network.packets.StepHeightPKT;
 import moze_intel.projecte.network.packets.SwingItemPKT;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Tuple;
@@ -19,26 +21,6 @@ import net.minecraft.util.Vec3;
  */
 public final class PlayerHelper
 {
-	public static void disableFlight(EntityPlayerMP playerMP)
-	{
-		if (!playerMP.capabilities.isCreativeMode)
-		{
-			updateClientServerFlight(playerMP, false);
-			PlayerChecks.removePlayerFlyChecks(playerMP);
-		}
-	}
-
-	public static void enableFlight(EntityPlayerMP playerMP)
-	{
-		if (playerMP.capabilities.isCreativeMode)
-		{
-			return;
-		}
-
-		updateClientServerFlight(playerMP, true);
-		PlayerChecks.addPlayerFlyChecks(playerMP);
-	}
-
 	public static ItemStack findFirstItem(EntityPlayer player, ItemPE consumeFrom)
 	{
 		for (ItemStack s : player.inventory.mainInventory)
@@ -49,6 +31,17 @@ public final class PlayerHelper
 			}
 		}
 		return null;
+	}
+
+	public static IInventory getBaubles(EntityPlayer player)
+	{
+		if (!Loader.isModLoaded("Baubles"))
+		{
+			return null;
+		} else
+		{
+			return BaublesApi.getBaubles(player);
+		}
 	}
 
 	public static Coordinates getBlockLookingAt(EntityPlayer player, double maxDistance)
@@ -104,8 +97,9 @@ public final class PlayerHelper
 		}
 	}
 
-	public static void updateClientStepHeight(EntityPlayerMP player, float value)
+	public static void updateClientServerStepHeight(EntityPlayerMP player, float value)
 	{
+		player.stepHeight = value;
 		PacketHandler.sendTo(new StepHeightPKT(value), player);
 	}
 }


### PR DESCRIPTION
Resolve #893 with bonus side of refactor

Explication of refactor:
I thought a little and realized just how retarded the PlayerChecks mechanism was. (It was mehhhh already, and got a lot worse when Arcana was added). Big huge complicated thing that multiple items had to do multiple times all over the codebase, just look at the negative/red/removed parts of the diff to get an idea...
The purpose of PlayerChecks was to query mc's player capabilities, query what we said the capabilities should be, and if the two don't match, change mc and optionally send it to the client if needed.
I moved it from trying to juggle around a list of who to check and who not to check (which was basically thrashing a collection over and over) in a server tick event to a player tick event for every player. Now it's clean and simple: if what PE and MC say mismatch, change MC and send a packet.
I also improved how "what PE says" is determined. Before it was all over the place in each class that provided a capability. Now it's all based on the marker interfaces. I could literally add a new item, give it IFireProtector and implement the required method, and the rest of the mod would automagically do the work for me. Before this you would've had to fiddle with calling playerchecks manually etc. etc. (just look at arcana 0.o).

One wrench in the works was the SWRG, because it has the stupid function of auto-activating on double jump, which basically means you have to be able to fly before you're *really* able to fly....
In short, I just used the existing implementation and hotwired an override on top of the new, pretty stuff. A little of me died working around my own refactor like that, but oh well it works.

Extensively tested with and without Baubles, jumping in and out and in again to the nether.
Also removed a bunch of unused methods around.

Tldr: Fixed the damn bug and you get a refactor too :D <3