### PR TITLE
[DONE but risky] Send search result instead search string in transmutation gui

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
@@ -313,13 +313,13 @@ public class TransmutationInventory implements IInventory
 
 	private void readUpdate()
 	{
-		try
+		List<ItemStack> newOutputSlots = serverOutputSlotUpdates.poll();
+		if (newOutputSlots == null) {
+			throw new RuntimeException("Server could not read output-slot-update from client. Playername: " + this.player.getCommandSenderName());
+		}
+		else
 		{
-			List<ItemStack> newOutputSlots = serverOutputSlotUpdates.take();
 			writeIntoOutputSlots(newOutputSlots);
-		} catch (InterruptedException e)
-		{
-			e.printStackTrace();
 		}
 	}
 

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
@@ -1,6 +1,8 @@
 package moze_intel.projecte.gameObjs.container.inventory;
 
 import com.google.common.collect.Lists;
+
+import moze_intel.projecte.emc.EMCMapper;
 import moze_intel.projecte.emc.FuelMapper;
 import moze_intel.projecte.gameObjs.ObjHandler;
 import moze_intel.projecte.network.PacketHandler;
@@ -326,7 +328,15 @@ public class TransmutationInventory implements IInventory
 	public void writeIntoOutputSlots(List<ItemStack> newOutputSlots)
 	{
 		for (int i = 0; i < 16; i++) {
-			inventory[10 + i] = newOutputSlots.get(i);
+			ItemStack item = newOutputSlots.get(i);
+			if (EMCHelper.doesItemHaveEmc(item) && Transmutation.hasKnowledgeForStack(item, player))
+			{
+				inventory[10 + i] = item;
+			}
+			else
+			{
+				inventory[10 + i] = null;
+			}
 		}
 	}
 

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
@@ -136,21 +136,10 @@ public class TransmutationInventory implements IInventory
 	@SuppressWarnings("unchecked")
 	public void updateOutputs(boolean async)
 	{
-		PELogger.logFatal("updateOutputs()" + this.player.worldObj.isRemote);
+		PELogger.logFatal("updateOutputs(" + async +") isRemote = " + this.player.worldObj.isRemote);
 		if (!this.player.worldObj.isRemote) {
-			if (async) {
-				new Thread(new Runnable()
-				{
-					@Override
-					public void run()
-					{
-						readUpdate();
-					}
-				}).start();
-			} else {
-				readUpdate();
-			}
-
+			if (async) new RuntimeException("updateOutput but async on server").printStackTrace();
+			readUpdate();
 			return;
 		}
 		knowledge = Lists.newArrayList(Transmutation.getKnowledge(player));
@@ -318,7 +307,7 @@ public class TransmutationInventory implements IInventory
  				}
 			}
 		}
-		PacketHandler.sendToServer(new SearchUpdatePKT(getOutputSlots()));
+		PacketHandler.sendToServer(new SearchUpdatePKT(getOutputSlots(), async));
 	}
 
 	private void readUpdate()
@@ -333,7 +322,7 @@ public class TransmutationInventory implements IInventory
 		}
 	}
 
-	private void writeIntoOutputSlots(List<ItemStack> newOutputSlots)
+	public void writeIntoOutputSlots(List<ItemStack> newOutputSlots)
 	{
 		for (int i = 0; i < 16; i++) {
 			inventory[10 + i] = newOutputSlots.get(i);
@@ -434,7 +423,10 @@ public class TransmutationInventory implements IInventory
 		emc = Transmutation.getEmc(player);
 		ItemStack[] inputLocks = Transmutation.getInputsAndLock(player);
 		System.arraycopy(inputLocks, 0, inventory, 0, 9);
-		updateOutputs(true);
+		if (this.player.worldObj.isRemote)
+		{
+			updateOutputs(true);
+		}
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
@@ -164,6 +164,7 @@ public class TransmutationInventory implements IInventory
 			
 			if (this.emc < reqEmc)
 			{
+				PacketHandler.sendToServer(new SearchUpdatePKT(getOutputSlots(), async));
 				return;
 			}
 

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
@@ -116,7 +116,6 @@ public class GUITransmutation extends GuiContainer
 
 			if (!inv.filter.equals(srch))
 			{
-				PacketHandler.sendToServer(new SearchUpdatePKT(srch, 0));
 				inv.filter = srch;
 				inv.searchpage = 0;
 				inv.updateOutputs();
@@ -141,7 +140,6 @@ public class GUITransmutation extends GuiContainer
 
 		if (mouseButton == 1 && x >= minX && x <= maxX && y <= maxY)
 		{
-			PacketHandler.sendToServer(new SearchUpdatePKT("", 0));
 			inv.filter = "";
 			inv.searchpage = 0;
 			inv.updateOutputs();
@@ -178,7 +176,6 @@ public class GUITransmutation extends GuiContainer
 				inv.searchpage++;
 			}
 		}
-		PacketHandler.sendToServer(new SearchUpdatePKT(srch, inv.searchpage));
 		inv.filter = srch;
 		inv.updateOutputs();
 	}

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
@@ -118,7 +118,7 @@ public class GUITransmutation extends GuiContainer
 			{
 				inv.filter = srch;
 				inv.searchpage = 0;
-				inv.updateOutputs();
+				inv.updateOutputs(true);
 			}
 		}
 
@@ -142,7 +142,7 @@ public class GUITransmutation extends GuiContainer
 		{
 			inv.filter = "";
 			inv.searchpage = 0;
-			inv.updateOutputs();
+			inv.updateOutputs(true);
 			this.textBoxFilter.setText("");
 		}
 
@@ -177,6 +177,6 @@ public class GUITransmutation extends GuiContainer
 			}
 		}
 		inv.filter = srch;
-		inv.updateOutputs();
+		inv.updateOutputs(true);
 	}
 }

--- a/src/main/java/moze_intel/projecte/network/packets/SearchUpdatePKT.java
+++ b/src/main/java/moze_intel/projecte/network/packets/SearchUpdatePKT.java
@@ -1,30 +1,28 @@
 package moze_intel.projecte.network.packets;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Queues;
 import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import scala.actors.threadpool.BlockingQueue;
 
 import moze_intel.projecte.gameObjs.container.TransmutationContainer;
+import moze_intel.projecte.utils.PELogger;
 
 import java.util.List;
-import java.util.concurrent.LinkedBlockingQueue;
 
 public class SearchUpdatePKT implements IMessage, IMessageHandler<SearchUpdatePKT, IMessage> 
 {
 
-
-
 	public SearchUpdatePKT() {}
+
+	public boolean applyImmediately = false;
 	public List<ItemStack> outslots;
-	public SearchUpdatePKT(List<ItemStack> outslots)
+	public SearchUpdatePKT(List<ItemStack> outslots, boolean applyImmediately)
 	{
+		this.applyImmediately = applyImmediately;
 		this.outslots = outslots;
 	}
 
@@ -34,12 +32,21 @@ public class SearchUpdatePKT implements IMessage, IMessageHandler<SearchUpdatePK
 		if (ctx.getServerHandler().playerEntity.openContainer instanceof TransmutationContainer)
 		{
 			TransmutationContainer container = ((TransmutationContainer) ctx.getServerHandler().playerEntity.openContainer);
-			try
+			if (pkt.applyImmediately)
 			{
-				container.transmutationInventory.serverOutputSlotUpdates.put(pkt.outslots);
-			} catch (InterruptedException e)
+				container.transmutationInventory.writeIntoOutputSlots(pkt.outslots);
+				PELogger.logFatal("Wrote Output Slots from UpdatePacket immediately");
+			}
+			else
 			{
-				e.printStackTrace();
+				try
+				{
+					container.transmutationInventory.serverOutputSlotUpdates.put(pkt.outslots);
+				} catch (InterruptedException e)
+				{
+					e.printStackTrace();
+				}
+				PELogger.logFatal("Got Output Slots from UpdatePacket... Size: " + container.transmutationInventory.serverOutputSlotUpdates.size());
 			}
 		}
 		
@@ -49,6 +56,7 @@ public class SearchUpdatePKT implements IMessage, IMessageHandler<SearchUpdatePK
 	@Override
 	public void fromBytes(ByteBuf buf) 
 	{
+		applyImmediately = buf.readBoolean();
 		List<ItemStack> l = Lists.newArrayList();
 		for (int i = 0; i < 16; i++) {
 			l.add(ByteBufUtils.readItemStack(buf));
@@ -59,6 +67,7 @@ public class SearchUpdatePKT implements IMessage, IMessageHandler<SearchUpdatePK
 	@Override
 	public void toBytes(ByteBuf buf)
 	{
+		buf.writeBoolean(applyImmediately);
 		for (int i = 0; i < 16; i++) {
 			ByteBufUtils.writeItemStack(buf, outslots.get(i));
 		}

--- a/src/main/java/moze_intel/projecte/playerData/Transmutation.java
+++ b/src/main/java/moze_intel/projecte/playerData/Transmutation.java
@@ -122,6 +122,7 @@ public final class Transmutation
 
 	public static boolean hasKnowledgeForStack(ItemStack stack, EntityPlayer player)
 	{
+		if (hasFullKnowledge(player)) return EMCHelper.doesItemHaveEmc(stack);
 		TransmutationProps data = TransmutationProps.getDataFor(player);
 		for (ItemStack s : data.getKnowledge())
 		{


### PR DESCRIPTION
This should finally fix #265 and #474 and also allows to search for localized item names on servers.

Needs testing on a server...

How it works:
When both server & client call `TransmutationInventory.updateOutputs()` the Client will execute the method before the server and will send its ItemStacks in the output slots to the server. (This is caused by inventory clicks being evaluated on the client before the WindowClickPacket is send to the server)

When the client wants to update the outputs based on an Event that is not fired on the Server (keyPress, mouseClick into Searchbar) it uses `TransmutationInventory.updateOutputs(true)` which will result in a Packet that the server will write into its output slot without waiting for a call to `updateOutputs`.

This is needed, because otherwise the server would write the new output stacks into its internal slots before it recieves the slotClick-Event.