### PR TITLE
Fix for Life Stone infinite EMC consumption

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/LifeStone.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/LifeStone.java
@@ -46,7 +46,7 @@ public class LifeStone extends RingToggle implements IBauble, IPedestalItem
 		{
 			double itemEmc = getEmc(stack);
 			
-			if (itemEmc < 2*64 && !consumeFuel(player, stack, 2*64, false))
+			if (itemEmc < 64 && !consumeFuel(player, stack, 2*64, false))
 			{
 				stack.setItemDamage(0);
 			}


### PR DESCRIPTION
After merging https://github.com/sinkillerj/ProjectE/pull/852 Life Stone wasn't stopping to consume EMC even if player had full hunger and health.
This change I made seems to fix it.