### PR TITLE
Update single output slot when clicked on client

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/TransmutationContainer.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/TransmutationContainer.java
@@ -7,6 +7,8 @@ import moze_intel.projecte.gameObjs.container.slots.transmutation.SlotInput;
 import moze_intel.projecte.gameObjs.container.slots.transmutation.SlotLock;
 import moze_intel.projecte.gameObjs.container.slots.transmutation.SlotOutput;
 import moze_intel.projecte.gameObjs.container.slots.transmutation.SlotUnlearn;
+import moze_intel.projecte.network.PacketHandler;
+import moze_intel.projecte.network.packets.SearchUpdatePKT;
 import moze_intel.projecte.utils.EMCHelper;
 import moze_intel.projecte.utils.ItemHelper;
 import net.minecraft.entity.player.EntityPlayer;
@@ -138,6 +140,9 @@ public class TransmutationContainer extends Container
 	@Override
 	public ItemStack slotClick(int slot, int button, int flag, EntityPlayer player)
 	{
+		if (player.worldObj.isRemote && 10 <= slot && slot <= 25) {
+			PacketHandler.sendToServer(new SearchUpdatePKT(slot, getSlot(slot).getStack()));
+		}
 		if (slot >= 0 && getSlot(slot) != null)
 		{
 			if (getSlot(slot).getStack() != null && getSlot(slot).getStack().getItem() == ObjHandler.transmutationTablet

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
@@ -131,8 +131,6 @@ public class TransmutationInventory implements IInventory
 		}
 	}
 
-	public LinkedBlockingQueue<List<ItemStack>> serverOutputSlotUpdates = Queues.newLinkedBlockingQueue();
-
 	public void updateOutputs() {
 		updateOutputs(false);
 	}
@@ -141,8 +139,6 @@ public class TransmutationInventory implements IInventory
 	{
 		PELogger.logFatal("updateOutputs(" + async +") isRemote = " + this.player.worldObj.isRemote);
 		if (!this.player.worldObj.isRemote) {
-			if (async) new RuntimeException("updateOutput but async on server").printStackTrace();
-			readUpdate();
 			return;
 		}
 		knowledge = Lists.newArrayList(Transmutation.getKnowledge(player));
@@ -167,7 +163,6 @@ public class TransmutationInventory implements IInventory
 			
 			if (this.emc < reqEmc)
 			{
-				PacketHandler.sendToServer(new SearchUpdatePKT(getOutputSlots(), async));
 				return;
 			}
 
@@ -277,33 +272,18 @@ public class TransmutationInventory implements IInventory
  				}
 			}
 		}
-		PacketHandler.sendToServer(new SearchUpdatePKT(getOutputSlots(), async));
 	}
 
-	private void readUpdate()
+	public void writeIntoOutputSlot(int slot, ItemStack item)
 	{
-		List<ItemStack> newOutputSlots = serverOutputSlotUpdates.poll();
-		if (newOutputSlots == null) {
-			throw new RuntimeException("Server could not read output-slot-update from client. Playername: " + this.player.getCommandSenderName());
+
+		if (EMCHelper.doesItemHaveEmc(item) && Transmutation.hasKnowledgeForStack(item, player))
+		{
+			inventory[slot] = item;
 		}
 		else
 		{
-			writeIntoOutputSlots(newOutputSlots);
-		}
-	}
-
-	public void writeIntoOutputSlots(List<ItemStack> newOutputSlots)
-	{
-		for (int i = 0; i < 16; i++) {
-			ItemStack item = newOutputSlots.get(i);
-			if (EMCHelper.doesItemHaveEmc(item) && Transmutation.hasKnowledgeForStack(item, player))
-			{
-				inventory[10 + i] = item;
-			}
-			else
-			{
-				inventory[10 + i] = null;
-			}
+			inventory[slot] = null;
 		}
 	}
 

--- a/src/main/java/moze_intel/projecte/network/packets/SearchUpdatePKT.java
+++ b/src/main/java/moze_intel/projecte/network/packets/SearchUpdatePKT.java
@@ -1,6 +1,5 @@
 package moze_intel.projecte.network.packets;
 
-import com.google.common.collect.Lists;
 import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
@@ -11,38 +10,31 @@ import net.minecraft.item.ItemStack;
 import moze_intel.projecte.gameObjs.container.TransmutationContainer;
 import moze_intel.projecte.utils.PELogger;
 
-import java.util.List;
 
 public class SearchUpdatePKT implements IMessage
 {
 	public SearchUpdatePKT() {}
 
-	public boolean applyImmediately = false;
-	public List<ItemStack> outslots;
-	public SearchUpdatePKT(List<ItemStack> outslots, boolean applyImmediately)
+	public int slot;
+	public ItemStack itemStack;
+	public SearchUpdatePKT(int slot, ItemStack itemStack)
 	{
-		this.applyImmediately = applyImmediately;
-		this.outslots = outslots;
+		this.slot = slot;
+		this.itemStack = itemStack.copy();
 	}
 
 	@Override
 	public void fromBytes(ByteBuf buf)
 	{
-		applyImmediately = buf.readBoolean();
-		List<ItemStack> l = Lists.newArrayList();
-		for (int i = 0; i < 16; i++) {
-			l.add(ByteBufUtils.readItemStack(buf));
-		}
-		this.outslots = l;
+		slot = buf.readInt();
+		itemStack = ByteBufUtils.readItemStack(buf);
 	}
 
 	@Override
 	public void toBytes(ByteBuf buf)
 	{
-		buf.writeBoolean(applyImmediately);
-		for (int i = 0; i < 16; i++) {
-			ByteBufUtils.writeItemStack(buf, outslots.get(i));
-		}
+		buf.writeInt(slot);
+		ByteBufUtils.writeItemStack(buf, itemStack);
 	}
 
 	public static class Handler implements IMessageHandler<SearchUpdatePKT, IMessage>
@@ -53,22 +45,8 @@ public class SearchUpdatePKT implements IMessage
 			if (ctx.getServerHandler().playerEntity.openContainer instanceof TransmutationContainer)
 			{
 				TransmutationContainer container = ((TransmutationContainer) ctx.getServerHandler().playerEntity.openContainer);
-				if (pkt.applyImmediately)
-				{
-					container.transmutationInventory.writeIntoOutputSlots(pkt.outslots);
-					PELogger.logFatal("Wrote Output Slots from UpdatePacket immediately");
-				}
-				else
-				{
-					try
-					{
-						container.transmutationInventory.serverOutputSlotUpdates.put(pkt.outslots);
-					} catch (InterruptedException e)
-					{
-						e.printStackTrace();
-					}
-					PELogger.logFatal("Got Output Slots from UpdatePacket... Size: " + container.transmutationInventory.serverOutputSlotUpdates.size());
-				}
+				container.transmutationInventory.writeIntoOutputSlot(pkt.slot, pkt.itemStack);
+				PELogger.logFatal("Wrote Output Slots from UpdatePacket immediately");
 			}
 
 			return null;


### PR DESCRIPTION
Alternative implementation for #955.

Instead of syncing the output slots whenever they change we just send the content of the clicked to the server when its clicked in the client.

What do you think?

(Hacked this together in <20mins before i had to leave - but it passed the singleplayer smoke test)