### PR TITLE
Another fix for what is causing the scroll wheel dupe in 1.9.2

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
@@ -276,7 +276,7 @@ public class TransmutationInventory implements IInventory
 	public void writeIntoOutputSlot(int slot, ItemStack item)
 	{
 
-		if (EMCHelper.doesItemHaveEmc(item) && Transmutation.hasKnowledgeForStack(item, player))
+		if (EMCHelper.doesItemHaveEmc(item) && EMCHelper.getEmcValue(item) < this.emc && Transmutation.hasKnowledgeForStack(item, player))
 		{
 			inventory[slot] = item;
 		}


### PR DESCRIPTION
Code was written under the assumption that `writeIntoOutputSlot` would only ever be called with valid results from `updateOutputs`... NEI apparently changes that...

For some reason 'scrollwheel up' did write the itemstack into the first output slot on the server, which then allowed the client to pull it out again...  or something like that...