### PR TITLE
Allow unlearning from full knowledge

### DIFF
--- a/src/main/java/moze_intel/projecte/api/proxy/ITransmutationProxy.java
+++ b/src/main/java/moze_intel/projecte/api/proxy/ITransmutationProxy.java
@@ -47,7 +47,9 @@ public interface ITransmutationProxy
      * If called on the client side, playerUUID is ignored and the client player is used instead
      * @param playerUUID The Player to query
      * @return Whether the player has full/override knowledge from the Tome, false if player is not found
+     * @deprecated as of API version 8, use {@link #hasKnowledgeFor(UUID, ItemStack)}
      */
+    @Deprecated
     boolean hasFullKnowledge(UUID playerUUID);
 
     /**

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
@@ -63,7 +63,7 @@ public class TransmutationInventory implements IInventory
 		{
 			learnFlag = 300;
 			
-			if (stack.getItem() == ObjHandler.tome && !Transmutation.hasFullKnowledge(player))
+			if (stack.getItem() == ObjHandler.tome)
 			{
 				Transmutation.setFullKnowledge(player);
 			}

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
@@ -59,11 +59,11 @@ public class TransmutationInventory implements IInventory
 			stack.setItemDamage(0);
 		}
 		
-		if (!Transmutation.hasKnowledgeForStack(stack, player) && !Transmutation.hasFullKnowledge(player))
+		if (!Transmutation.hasKnowledgeForStack(stack, player))
 		{
 			learnFlag = 300;
 			
-			if (stack.getItem() == ObjHandler.tome)
+			if (stack.getItem() == ObjHandler.tome && !Transmutation.hasFullKnowledge(player))
 			{
 				Transmutation.setFullKnowledge(player);
 			}
@@ -98,7 +98,7 @@ public class TransmutationInventory implements IInventory
 			stack.setItemDamage(0);
 		}
 		
-		if (Transmutation.hasKnowledgeForStack(stack, player) && !Transmutation.hasFullKnowledge(player))
+		if (Transmutation.hasKnowledgeForStack(stack, player))
 		{
 			unlearnFlag = 300;
 

--- a/src/main/java/moze_intel/projecte/impl/TransmutationProxyImpl.java
+++ b/src/main/java/moze_intel/projecte/impl/TransmutationProxyImpl.java
@@ -95,24 +95,7 @@ public class TransmutationProxyImpl implements ITransmutationProxy
     @Override
     public boolean hasFullKnowledge(UUID playerUUID)
     {
-        if (FMLCommonHandler.instance().getEffectiveSide() == Side.CLIENT)
-        {
-            Preconditions.checkState(PECore.proxy.getClientPlayer() != null, "Client player doesn't exist!");
-            return Transmutation.hasFullKnowledge(PECore.proxy.getClientPlayer());
-        } else
-        {
-            Preconditions.checkNotNull(playerUUID);
-            Preconditions.checkState(Loader.instance().hasReachedState(LoaderState.SERVER_STARTED), "Server must be running to query knowledge!");
-            EntityPlayer player = findOnlinePlayer(playerUUID);
-            if (player != null)
-            {
-                return Transmutation.hasFullKnowledge(player);
-            }
-            else
-            {
-                return TransmutationOffline.hasFullKnowledge(playerUUID);
-            }
-        }
+        return false;
     }
 
     @Override

--- a/src/main/java/moze_intel/projecte/playerData/Transmutation.java
+++ b/src/main/java/moze_intel/projecte/playerData/Transmutation.java
@@ -12,17 +12,13 @@ import moze_intel.projecte.utils.PELogger;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
 import net.minecraftforge.common.MinecraftForge;
 
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 
-public final class Transmutation 
+public final class Transmutation
 {
 	private static final List<ItemStack> CACHED_TOME_KNOWLEDGE = Lists.newArrayList();
 
@@ -60,20 +56,14 @@ public final class Transmutation
 	public static List<ItemStack> getKnowledge(EntityPlayer player)
 	{
 		TransmutationProps data = TransmutationProps.getDataFor(player);
-		if (data.hasFullKnowledge())
-		{
-			return CACHED_TOME_KNOWLEDGE;
-		}
-		else
-		{
-			return data.getKnowledge();
-		}
+		
+		return data.getKnowledge();
 	}
 
 	public static void addKnowledge(ItemStack stack, EntityPlayer player)
 	{
 		TransmutationProps data = TransmutationProps.getDataFor(player);
-		if (!data.hasFullKnowledge())
+		if (!hasKnowledgeForStack(stack, player))
 		{
 			data.getKnowledge().add(stack);
 			if (!player.worldObj.isRemote)
@@ -86,7 +76,7 @@ public final class Transmutation
 	public static void removeKnowledge(ItemStack stack, EntityPlayer player)
 	{
 		TransmutationProps data = TransmutationProps.getDataFor(player);
-		if (!data.hasFullKnowledge())
+		if (hasKnowledgeForStack(stack, player))
 		{
 			Iterator<ItemStack> iter = data.getKnowledge().iterator();
 
@@ -119,7 +109,6 @@ public final class Transmutation
 
 	public static boolean hasKnowledgeForStack(ItemStack stack, EntityPlayer player)
 	{
-		if (hasFullKnowledge(player)) return EMCHelper.doesItemHaveEmc(stack);
 		TransmutationProps data = TransmutationProps.getDataFor(player);
 		for (ItemStack s : data.getKnowledge())
 		{
@@ -133,12 +122,27 @@ public final class Transmutation
 
 	public static boolean hasFullKnowledge(EntityPlayer player)
 	{
-		return TransmutationProps.getDataFor(player).hasFullKnowledge();
+		for (SimpleStack stack : EMCMapper.emc.keySet())
+		{
+			if (!stack.isValid())
+			{
+				continue;
+			}
+
+			if (!hasKnowledgeForStack(stack.toItemStack(), player))
+			{
+				return false;
+			}
+		}
+
+
+		return true;
 	}
 
 	public static void setFullKnowledge(EntityPlayer player)
 	{
-		TransmutationProps.getDataFor(player).setFullKnowledge(true);
+		TransmutationProps.getDataFor(player).getKnowledge().clear();
+		TransmutationProps.getDataFor(player).getKnowledge().addAll(CACHED_TOME_KNOWLEDGE);
 		if (!player.worldObj.isRemote)
 		{
 			MinecraftForge.EVENT_BUS.post(new PlayerKnowledgeChangeEvent(player));
@@ -148,7 +152,6 @@ public final class Transmutation
 	public static void clearKnowledge(EntityPlayer player)
 	{
 		TransmutationProps data = TransmutationProps.getDataFor(player);
-		data.setFullKnowledge(false);
 		data.getKnowledge().clear();
 		if (!player.worldObj.isRemote)
 		{

--- a/src/main/java/moze_intel/projecte/playerData/Transmutation.java
+++ b/src/main/java/moze_intel/projecte/playerData/Transmutation.java
@@ -120,25 +120,6 @@ public final class Transmutation
 		return false;
 	}
 
-	public static boolean hasFullKnowledge(EntityPlayer player)
-	{
-		for (SimpleStack stack : EMCMapper.emc.keySet())
-		{
-			if (!stack.isValid())
-			{
-				continue;
-			}
-
-			if (!hasKnowledgeForStack(stack.toItemStack(), player))
-			{
-				return false;
-			}
-		}
-
-
-		return true;
-	}
-
 	public static void setFullKnowledge(EntityPlayer player)
 	{
 		TransmutationProps.getDataFor(player).getKnowledge().clear();

--- a/src/main/java/moze_intel/projecte/playerData/TransmutationProps.java
+++ b/src/main/java/moze_intel/projecte/playerData/TransmutationProps.java
@@ -23,7 +23,6 @@ public class TransmutationProps implements IExtendedEntityProperties
 	private double transmutationEmc;
 	private List<ItemStack> knowledge = Lists.newArrayList();
 	private ItemStack[] inputLocks = new ItemStack[9];
-	private boolean hasFullKnowledge;
 	public static final String PROP_NAME = "ProjectETransmutation";
 
 	public static void register(EntityPlayer player)
@@ -53,13 +52,9 @@ public class TransmutationProps implements IExtendedEntityProperties
 
 	protected boolean hasFullKnowledge()
 	{
-		return hasFullKnowledge;
+		return Transmutation.hasFullKnowledge(player);
 	}
 
-	protected void setFullKnowledge(boolean fullKnowledge)
-	{
-		this.hasFullKnowledge = fullKnowledge;
-	}
 
 	protected double getTransmutationEmc()
 	{
@@ -105,7 +100,6 @@ public class TransmutationProps implements IExtendedEntityProperties
 	{
 		NBTTagCompound compound = new NBTTagCompound();
 		compound.setDouble("transmutationEmc", transmutationEmc);
-		compound.setBoolean("tome", hasFullKnowledge);
 
 		pruneStaleKnowledge();
 		NBTTagList knowledgeWrite = new NBTTagList();
@@ -124,7 +118,6 @@ public class TransmutationProps implements IExtendedEntityProperties
 	public void readFromPacket(NBTTagCompound compound)
 	{
 		transmutationEmc = compound.getDouble("transmutationEmc");
-		hasFullKnowledge = compound.getBoolean("tome");
 
 		NBTTagList list = compound.getTagList("knowledge", Constants.NBT.TAG_COMPOUND);
 		knowledge.clear();
@@ -146,7 +139,6 @@ public class TransmutationProps implements IExtendedEntityProperties
 	{
 		NBTTagCompound properties = new NBTTagCompound();
 		properties.setDouble("transmutationEmc", transmutationEmc);
-		properties.setBoolean("tome", hasFullKnowledge);
 
 		pruneStaleKnowledge();
 		NBTTagList knowledgeWrite = new NBTTagList();
@@ -168,7 +160,6 @@ public class TransmutationProps implements IExtendedEntityProperties
 		NBTTagCompound properties = compound.getCompoundTag(PROP_NAME);
 
 		transmutationEmc = properties.getDouble("transmutationEmc");
-		hasFullKnowledge = properties.getBoolean("tome");
 
 		NBTTagList list = properties.getTagList("knowledge", Constants.NBT.TAG_COMPOUND);
 		for (int i = 0; i < list.tagCount(); i++)

--- a/src/main/java/moze_intel/projecte/playerData/TransmutationProps.java
+++ b/src/main/java/moze_intel/projecte/playerData/TransmutationProps.java
@@ -50,12 +50,6 @@ public class TransmutationProps implements IExtendedEntityProperties
 		this.inputLocks = inputLocks;
 	}
 
-	protected boolean hasFullKnowledge()
-	{
-		return Transmutation.hasFullKnowledge(player);
-	}
-
-
 	protected double getTransmutationEmc()
 	{
 		return transmutationEmc;


### PR DESCRIPTION
I decided to check to see how the performance was impacted by getting rid of the full knowledge cache and replacing it with addKnowledge for each item not currently known. As it turns out, the difference is noticeable but not inhibitingly so. There's a tiny moment of lag right as you learn the tome. After that, what you're left with is a map from which you can remove items, allowing players to unlearn items even with a full set of knowledge.

The only reason I can think of that could be an argument against this is the performance impact, which like I mentioned is minimal.

Would close #970 