### PR TITLE
Fix smaller/smaller equals derp

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
@@ -276,7 +276,7 @@ public class TransmutationInventory implements IInventory
 	public void writeIntoOutputSlot(int slot, ItemStack item)
 	{
 
-		if (EMCHelper.doesItemHaveEmc(item) && EMCHelper.getEmcValue(item) < this.emc && Transmutation.hasKnowledgeForStack(item, player))
+		if (EMCHelper.doesItemHaveEmc(item) && EMCHelper.getEmcValue(item) <= this.emc && Transmutation.hasKnowledgeForStack(item, player))
 		{
 			inventory[slot] = item;
 		}


### PR DESCRIPTION
So before you couldn't pull out an item for which you had the exact amount of emc.