### PR TITLE
Make Fluid World Transmutations one-way only

### DIFF
--- a/src/main/java/moze_intel/projecte/utils/WorldTransmutations.java
+++ b/src/main/java/moze_intel/projecte/utils/WorldTransmutations.java
@@ -19,8 +19,8 @@ public final class WorldTransmutations
 		register(Blocks.dirt, Blocks.sand, Blocks.cobblestone);
 		register(Blocks.sand, Blocks.grass, Blocks.cobblestone);
 		register(Blocks.gravel, Blocks.sandstone);
-		register(Blocks.water, Blocks.ice);
-		register(Blocks.lava, Blocks.obsidian);
+		register(Blocks.ice, new MetaBlock[]{Blocks.water});
+		register(Blocks.obsidian, new MetaBlock[]{Blocks.lava});
 		register(Blocks.melon_block, Blocks.pumpkin);
 
 


### PR DESCRIPTION
Because they do not work, so we don't want them to show in NEI.

Untested.