### PR TITLE
Check for overflow on EMC display value

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserMK2Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserMK2Tile.java
@@ -37,7 +37,10 @@ public class CondenserMK2Tile extends CondenserTile
 					continue;
 				}
 
-				this.addEMC(EMCHelper.getEmcValue(stack) * stack.stackSize);
+				int emcValue = EMCHelper.getEmcValue(stack);
+				for (int j = 0; j < stack.stackSize; j++) {
+					this.addEMC(emcValue);
+				}
 				inventory[i] = null;
 				break;
 			}

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserTile.java
@@ -55,6 +55,10 @@ public class CondenserTile extends TileEmcDirection implements IInventory, ISide
 		}
 
 		displayEmc = (int) this.getStoredEmc();
+		if (displayEmc < 0 && this.getStoredEmc() > 0) {
+		    // overflow, display requiredEMC instead
+		    displayEmc = requiredEmc;
+		}
 
 		if (lock != null && requiredEmc != 0)
 		{


### PR DESCRIPTION
Shows the required EMC instead of the current EMC when the current EMC is greater than `Integer.MAX_VALUE`.

Fixes #1065.
