### PR TITLE
[DONE] Catch IllegalArgmentException when trying to create an illegal NSSItem

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/NormalizedSimpleStack.java
+++ b/src/main/java/moze_intel/projecte/emc/NormalizedSimpleStack.java
@@ -22,7 +22,14 @@ public abstract class NormalizedSimpleStack {
 	public static Map<String, Set<Integer>> idWithUsedMetaData = Maps.newHashMap();
 
 	public static NormalizedSimpleStack getFor(String itemName, int damage) {
-		NSSItem normStack = new NSSItem(itemName, damage);
+		NSSItem normStack;
+		try
+		{
+			normStack = new NSSItem(itemName, damage);
+		} catch (Exception e) {
+			PELogger.logFatal("Could not create NSSItem: " + e.getMessage());
+			return null;
+		}
 		Set<Integer> usedMetadata;
 		if (!idWithUsedMetaData.containsKey(normStack.itemName)) {
 			usedMetadata = Sets.newHashSet();


### PR DESCRIPTION
This method is supposed to return `null` when something goes wrong and not throw exceptions, so the recipe/conversion is just ignored.

Fixes #1106 