### PR TITLE
Prevent Consume from Unlearn Slot (Dupe Fix)

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/TransmutationContainer.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/TransmutationContainer.java
@@ -105,7 +105,7 @@ public class TransmutationContainer extends Container
 			
 			transmutationInventory.updateOutputs();
 		}
-		else if (slotIndex >= 26)
+		else if (slotIndex >= 27)
 		{
 			int emc = EMCHelper.getEmcValue(stack);
 			


### PR DESCRIPTION
A player on my server found a dupe glitch where consuming items from the unlearn slot allows them to produce free EMC.

I wasn't able to replicate this myself, the entities kept disappearing for me, but here is the video of him doing it on my server :https://www.youtube.com/watch?v=OYIhOrFaCLU&feature=youtu.be