### PR TITLE
Reduce unnecessary calls to getItemDamage()

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/SimpleStack.java
+++ b/src/main/java/moze_intel/projecte/emc/SimpleStack.java
@@ -19,6 +19,11 @@ public class SimpleStack
 	
 	public SimpleStack(ItemStack stack)
 	{
+		this(stack, true);
+	}
+
+	public SimpleStack(ItemStack stack, boolean shouldInitDamage)
+	{
 		if (stack == null)
 		{
 			id = -1;
@@ -26,10 +31,15 @@ public class SimpleStack
 		else
 		{
 			id = Item.itemRegistry.getIDForObject(stack.getItem());
-			damage = stack.getItemDamage();
+			if (shouldInitDamage)
+			{
+				damage = stack.getItem().getDamage(stack);
+			}
+
 			qnty = stack.stackSize;
 		}
 	}
+
 
 	public boolean isValid()
 	{

--- a/src/main/java/moze_intel/projecte/utils/EMCHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/EMCHelper.java
@@ -115,7 +115,7 @@ public final class EMCHelper
 			return false;
 		}
 
-		SimpleStack iStack = new SimpleStack(stack);
+		SimpleStack iStack = new SimpleStack(stack, false);
 
 		if (!iStack.isValid())
 		{


### PR DESCRIPTION
On my server, I have a mod that makes excessive calls to insertion and removal from a Condenser's inventory. Because of this, I noticed a node (though small) for `getItemStackDamage()` under `EMCHelper`.

To get rid of this slowdown, I have restructured the constructor for SimpleStack so that it can be initialized without a damage value. This is done in the EMCHelper to prevent calls in the constructor to `getItemStackDamage()`.