### PR TITLE
Allow Redmatter Morningstar to break RM/DM blocks

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/blocks/MatterBlock.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/blocks/MatterBlock.java
@@ -51,15 +51,14 @@ public class MatterBlock extends Block
 		
 		if (stack != null)
 		{
-                        if (meta == 1)
-                        {
-                                return stack.getItem() == ObjHandler.rmPick || stack.getItem() == ObjHandler.rmStar;
-                        }
-                        else
-                        {
-                                return stack.getItem() == ObjHandler.rmPick || stack.getItem() == ObjHandler.dmPick || stack.getItem() == ObjHandler.rmStar;
-                        }
-
+                       if (meta == 1)
+                       {
+                               return stack.getItem() == ObjHandler.rmPick || stack.getItem() == ObjHandler.rmStar;
+                       }
+                       else
+                       {
+                               return stack.getItem() == ObjHandler.rmPick || stack.getItem() == ObjHandler.dmPick || stack.getItem() == ObjHandler.rmStar;
+                       }
 		}
 		
 		return false;

--- a/src/main/java/moze_intel/projecte/gameObjs/blocks/MatterBlock.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/blocks/MatterBlock.java
@@ -51,14 +51,15 @@ public class MatterBlock extends Block
 		
 		if (stack != null)
 		{
-			if (meta == 1)
-			{
-				return stack.getItem() == ObjHandler.rmPick;
-			}
-			else
-			{
-				return stack.getItem() == ObjHandler.rmPick || stack.getItem() == ObjHandler.dmPick;
-			}
+                        if (meta == 1)
+                        {
+                                return stack.getItem() == ObjHandler.rmPick || stack.getItem() == ObjHandler.rmStar;
+                        }
+                        else
+                        {
+                                return stack.getItem() == ObjHandler.rmPick || stack.getItem() == ObjHandler.dmPick || stack.getItem() == ObjHandler.rmStar;
+                        }
+
 		}
 		
 		return false;

--- a/src/main/java/moze_intel/projecte/gameObjs/blocks/MatterBlock.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/blocks/MatterBlock.java
@@ -51,14 +51,14 @@ public class MatterBlock extends Block
 		
 		if (stack != null)
 		{
-                       if (meta == 1)
-                       {
-                               return stack.getItem() == ObjHandler.rmPick || stack.getItem() == ObjHandler.rmStar;
-                       }
-                       else
-                       {
-                               return stack.getItem() == ObjHandler.rmPick || stack.getItem() == ObjHandler.dmPick || stack.getItem() == ObjHandler.rmStar;
-                       }
+			if (meta == 1)
+			{
+				return stack.getItem() == ObjHandler.rmPick || stack.getItem() == ObjHandler.rmStar;
+			}
+			else
+			{
+				return stack.getItem() == ObjHandler.rmPick || stack.getItem() == ObjHandler.dmPick || stack.getItem() == ObjHandler.rmStar;
+			}
 		}
 		
 		return false;


### PR DESCRIPTION
A player noticed a bug where RM and DM blocks are broken but not returned by the redmatter morningstar, I believe this change should fix the issue.