### PR TITLE
[1.9] Fix Wildcard in setValue.

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/EMCMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/EMCMapper.java
@@ -8,6 +8,7 @@ import moze_intel.projecte.emc.arithmetics.IValueArithmetic;
 import moze_intel.projecte.emc.collector.DumpToFileCollector;
 import moze_intel.projecte.emc.collector.IExtendedMappingCollector;
 import moze_intel.projecte.emc.collector.IntToFractionCollector;
+import moze_intel.projecte.emc.collector.WildcardSetValueFixCollector;
 import moze_intel.projecte.emc.generators.FractionToIntGenerator;
 import moze_intel.projecte.emc.generators.IValueGenerator;
 import moze_intel.projecte.emc.mappers.APICustomConversionMapper;
@@ -61,6 +62,7 @@ public final class EMCMapper
 		SimpleGraphMapper<NormalizedSimpleStack, Fraction, IValueArithmetic<Fraction>> mapper = new SimpleGraphMapper<>(((IValueArithmetic<Fraction>) new HiddenFractionArithmetic()));
 		IValueGenerator<NormalizedSimpleStack, Integer> valueGenerator = new FractionToIntGenerator<>(mapper);
 		IExtendedMappingCollector<NormalizedSimpleStack, Integer, IValueArithmetic<Fraction>> mappingCollector = new IntToFractionCollector<>(mapper);
+		mappingCollector = new WildcardSetValueFixCollector<>(mappingCollector);
 
 		Configuration config = new Configuration(new File(PECore.CONFIG_DIR, "mapping.cfg"));
 		config.load();

--- a/src/main/java/moze_intel/projecte/emc/NormalizedSimpleStack.java
+++ b/src/main/java/moze_intel/projecte/emc/NormalizedSimpleStack.java
@@ -20,7 +20,22 @@ import java.util.Set;
 public abstract class NormalizedSimpleStack {
 	private static final Map<String, Set<Integer>> idWithUsedMetaData = Maps.newHashMap();
 
-	private static NormalizedSimpleStack getFor(String itemName, int damage) {
+	public static Set<Integer> getUsedMetadata(String itemName) {
+		if (idWithUsedMetaData.containsKey(itemName)) {
+			return idWithUsedMetaData.get(itemName);
+		} else {
+			return Sets.newHashSet();
+		}
+	}
+	public static Set<Integer> getUsedMetadata(NormalizedSimpleStack nss) {
+		if (nss instanceof NSSItem) {
+			return getUsedMetadata(((NSSItem) nss).itemName);
+		} else {
+			throw new IllegalArgumentException("Can only get Metadata for Items!");
+		}
+	}
+
+	public static NormalizedSimpleStack getFor(String itemName, int damage) {
 		NSSItem normStack;
 		try
 		{

--- a/src/main/java/moze_intel/projecte/emc/collector/WildcardSetValueFixCollector.java
+++ b/src/main/java/moze_intel/projecte/emc/collector/WildcardSetValueFixCollector.java
@@ -1,0 +1,99 @@
+package moze_intel.projecte.emc.collector;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import moze_intel.projecte.emc.NormalizedSimpleStack;
+import moze_intel.projecte.emc.arithmetics.IValueArithmetic;
+import moze_intel.projecte.emc.mappers.customConversions.json.CustomConversion;
+import net.minecraftforge.oredict.OreDictionary;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This Collector catches all setValueBefore, setValueAfter and setValueFromConversion calls that use Wildcard-Metadata.
+ * These are then delayed until finishCollection() and will be expanded to all metadata that has been found.
+ */
+public class WildcardSetValueFixCollector<V extends Comparable<V>, A extends IValueArithmetic> extends AbstractMappingCollector<NormalizedSimpleStack, V, A> {
+	IExtendedMappingCollector<NormalizedSimpleStack, V, A> inner;
+	public WildcardSetValueFixCollector(IExtendedMappingCollector<NormalizedSimpleStack, V, A> inner) {
+		super(inner.getArithmetic());
+		this.inner = inner;
+	}
+
+	Map<NormalizedSimpleStack.NSSItem, V> setValueBeforeMap = Maps.newHashMap();
+	Map<NormalizedSimpleStack.NSSItem, V> setValueAfterMap = Maps.newHashMap();
+	List<CustomConversion> setValueConversionList = Lists.newArrayList();
+	private boolean isWildCard(NormalizedSimpleStack nss) {
+		return nss instanceof NormalizedSimpleStack.NSSItem && ((NormalizedSimpleStack.NSSItem) nss).damage == OreDictionary.WILDCARD_VALUE;
+	}
+
+	@Override
+	public void setValueBefore(NormalizedSimpleStack something, V value) {
+		if (this.isWildCard(something)) {
+			setValueBeforeMap.put((NormalizedSimpleStack.NSSItem) something, value);
+		} else {
+			inner.setValueBefore(something, value);
+		}
+	}
+
+	@Override
+	public void setValueAfter(NormalizedSimpleStack something, V value) {
+		if (this.isWildCard(something)) {
+			setValueAfterMap.put((NormalizedSimpleStack.NSSItem) something, value);
+		} else {
+			inner.setValueAfter(something, value);
+		}
+	}
+
+	@Override
+	public void setValueFromConversion(int outnumber, NormalizedSimpleStack something, Map<NormalizedSimpleStack, Integer> ingredientsWithAmount) {
+		if (this.isWildCard(something)) {
+			setValueConversionList.add(CustomConversion.getFor(outnumber, something, ingredientsWithAmount));
+		} else {
+			inner.setValueFromConversion(outnumber, something, ingredientsWithAmount);
+		}
+	}
+
+	@Override
+	public void addConversion(int outnumber, NormalizedSimpleStack output, Map<NormalizedSimpleStack, Integer> ingredientsWithAmount, A arithmeticForConversion) {
+		inner.addConversion(outnumber, output, ingredientsWithAmount, arithmeticForConversion);
+
+	}
+
+	@Override
+	public void finishCollection() {
+		for (Map.Entry<NormalizedSimpleStack.NSSItem, V> entry: setValueBeforeMap.entrySet()) {
+			for (Integer meta: NormalizedSimpleStack.getUsedMetadata(entry.getKey())) {
+				if (meta == OreDictionary.WILDCARD_VALUE) continue;
+				MappingCollector.debugFormat("Inserting Wildcard SetValueBefore %s:%d to %s", entry.getKey().itemName, meta, entry.getValue());
+				inner.setValueBefore(NormalizedSimpleStack.getFor(entry.getKey().itemName, meta), entry.getValue());
+			}
+		}
+
+		for (Map.Entry<NormalizedSimpleStack.NSSItem, V> entry: setValueAfterMap.entrySet()) {
+			for (Integer meta: NormalizedSimpleStack.getUsedMetadata(entry.getKey())) {
+				if (meta == OreDictionary.WILDCARD_VALUE) continue;
+				inner.setValueAfter(NormalizedSimpleStack.getFor(entry.getKey().itemName, meta), entry.getValue());
+				MappingCollector.debugFormat("Inserting Wildcard SetValueAfter: %s:%d to %s", entry.getKey().itemName, meta, entry.getValue());
+			}
+		}
+
+		for (CustomConversion conversion: setValueConversionList) {
+			for (Integer meta: NormalizedSimpleStack.getUsedMetadata(conversion.output)) {
+				if (meta == OreDictionary.WILDCARD_VALUE) continue;
+				MappingCollector.debugFormat("Inserting Wildcard SetValueFromConversion %s:%d to %s", conversion.output, meta, conversion);
+				inner.setValueFromConversion(conversion.count, NormalizedSimpleStack.getFor(conversion.output, meta), ingredientMapFromStringMap(conversion.ingredients));
+			}
+		}
+		inner.finishCollection();
+	}
+
+	private Map<NormalizedSimpleStack, Integer> ingredientMapFromStringMap(Map<String, Integer> map) {
+		Map<NormalizedSimpleStack, Integer> out = Maps.newHashMap();
+		for (Map.Entry<String, Integer> entry: map.entrySet()) {
+			out.put(NormalizedSimpleStack.fromSerializedItem(entry.getKey()), entry.getValue());
+		}
+		return out;
+	}
+}

--- a/src/main/java/moze_intel/projecte/emc/mappers/customConversions/json/CustomConversion.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/customConversions/json/CustomConversion.java
@@ -22,4 +22,8 @@ public class CustomConversion
 		}
 		return conversion;
 	}
+
+	public String toString() {
+		return "{" + count + " * " + output + " = " + ingredients.toString() + "}";
+	}
 }


### PR DESCRIPTION
Fixes #1245 

The OreDict entry for logWood uses Wildcard-values and i didn't account for that. 