### PR TITLE
[1.9] Fix harvestVein to properly check numMined for every recursion.

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/PEToolBase.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/PEToolBase.java
@@ -574,7 +574,7 @@ public abstract class PEToolBase extends ItemMode
 		for (BlockPos pos : WorldHelper.getPositionsFromBox(box))
 		{
 			IBlockState state = world.getBlockState(pos);
-			if (ItemHelper.isOre(state) && state.getBlockHardness(player.worldObj, pos) != -1 && (canHarvestBlock(state, stack) || ForgeHooks.canToolHarvestBlock(world, pos, stack)))
+			if (state != Blocks.AIR.getDefaultState() && ItemHelper.isOre(state) && state.getBlockHardness(player.worldObj, pos) != -1 && (canHarvestBlock(state, stack) || ForgeHooks.canToolHarvestBlock(world, pos, stack)))
 			{
 				WorldHelper.harvestVein(world, player, stack, pos, state, drops, 0);
 			}

--- a/src/main/java/moze_intel/projecte/utils/ItemHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/ItemHelper.java
@@ -252,6 +252,10 @@ public final class ItemHelper
 
 	public static String getOreDictionaryName(ItemStack stack)
 	{
+		if (stack == null || stack.getItem() == null)
+		{
+			return "Unknown";
+		}
 		int[] oreIds = OreDictionary.getOreIDs(stack);
 
 		if (oreIds.length == 0)

--- a/src/main/java/moze_intel/projecte/utils/WorldHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/WorldHelper.java
@@ -543,11 +543,11 @@ public final class WorldHelper
 			if (currentState == target || (target == Blocks.LIT_REDSTONE_ORE && block == Blocks.REDSTONE_ORE))
 			{
 				numMined++;
-				if (PlayerHelper.hasBreakPermission(((EntityPlayerMP) player), pos))
+				if (PlayerHelper.hasBreakPermission(((EntityPlayerMP) player), currentPos))
 				{
-					currentDrops.addAll(getBlockDrops(world, player, currentState, stack, pos));
-					world.setBlockToAir(pos);
-					numMined = harvestVein(world, player, stack, pos, target, currentDrops, numMined);
+					currentDrops.addAll(getBlockDrops(world, player, currentState, stack, currentPos));
+					world.setBlockToAir(currentPos);
+					numMined = harvestVein(world, player, stack, currentPos, target, currentDrops, numMined);
 					if (numMined >= Constants.MAX_VEIN_SIZE) {
 						break;
 					}

--- a/src/main/java/moze_intel/projecte/utils/WorldHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/WorldHelper.java
@@ -526,11 +526,11 @@ public final class WorldHelper
 	/**
 	 * Recursively mines out a vein of the given Block, starting from the provided coordinates
 	 */
-	public static void harvestVein(World world, EntityPlayer player, ItemStack stack, BlockPos pos, IBlockState target, List<ItemStack> currentDrops, int numMined)
+	public static int harvestVein(World world, EntityPlayer player, ItemStack stack, BlockPos pos, IBlockState target, List<ItemStack> currentDrops, int numMined)
 	{
 		if (numMined >= Constants.MAX_VEIN_SIZE)
 		{
-			return;
+			return numMined;
 		}
 
 		AxisAlignedBB b = new AxisAlignedBB(pos.getX() - 1, pos.getY() - 1, pos.getZ() - 1, pos.getX() + 1, pos.getY() + 1, pos.getZ() + 1);
@@ -547,10 +547,14 @@ public final class WorldHelper
 				{
 					currentDrops.addAll(getBlockDrops(world, player, currentState, stack, pos));
 					world.setBlockToAir(pos);
-					harvestVein(world, player, stack, pos, target, currentDrops, numMined);
+					numMined = harvestVein(world, player, stack, pos, target, currentDrops, numMined);
+					if (numMined >= Constants.MAX_VEIN_SIZE) {
+						break;
+					}
 				}
 			}
 		}
+		return numMined;
 	}
 	
 	public static void igniteNearby(World world, EntityPlayer player)


### PR DESCRIPTION
Without this commit `numMined` will be reset, when one recursion ends and backtracks to the calling recursion again.

~~This is only a partial solution for #1257. It prevents the crash, but because for some reasons the `world.setBlockToAir()`method is not working it does mine the same block multiple times.~~

Found the problem. The block breaking code was not using the `currentPos` variable properly.

Fixes #1257