### PR TITLE
Fix crash when player inventory size is not 36

### DIFF
--- a/src/main/java/moze_intel/projecte/utils/ItemHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/ItemHelper.java
@@ -411,7 +411,7 @@ public final class ItemHelper
 
 		if (inv instanceof InventoryPlayer)
 		{
-			limit = 36;
+			limit = ((InventoryPlayer) inv).mainInventory.length;
 		}
 		else
 		{


### PR DESCRIPTION
I got this crash report in 1.7.10-PE1.10.0. 
http://pastebin.com/q26ZwXrr

This, despite the Entity of LittleMaidMobX is inheriting the EntityPlayer, it is the cause the size of the inventory is 36 or less. As a result of this change, even if the size of the inventory is less than 36, it will not crash.