### PR TITLE
Fix a few bugs

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/AlchemicalBag.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/AlchemicalBag.java
@@ -3,6 +3,8 @@ package moze_intel.projecte.gameObjs.items;
 import moze_intel.projecte.PECore;
 import moze_intel.projecte.api.ProjectEAPI;
 import moze_intel.projecte.gameObjs.ObjHandler;
+import moze_intel.projecte.gameObjs.items.rings.BlackHoleBand;
+import moze_intel.projecte.gameObjs.items.rings.VoidRing;
 import moze_intel.projecte.utils.Constants;
 import moze_intel.projecte.utils.ItemHelper;
 import net.minecraft.creativetab.CreativeTabs;
@@ -96,9 +98,15 @@ public class AlchemicalBag extends ItemPE
 			{
 				IItemHandler inv = player.getCapability(ProjectEAPI.ALCH_BAG_CAPABILITY, null)
 						.getBag(EnumDyeColor.byMetadata(stack.getItemDamage()));
-				if (ItemHelper.invContainsItem(inv, new ItemStack(ObjHandler.blackHole, 1, 1))
-						|| ItemHelper.invContainsItem(inv, new ItemStack(ObjHandler.voidRing, 1, 1)))
-				return stack;
+				for (int i = 0; i < inv.getSlots(); i++) {
+					ItemStack ring = inv.getStackInSlot(i);
+
+					if (!ring.isEmpty() && (ring.getItem() instanceof BlackHoleBand || ring.getItem() instanceof VoidRing)) {
+						if (ItemHelper.getOrCreateCompound(ring).getBoolean(TAG_ACTIVE)) {
+							return stack;
+						}
+					}
+				}
 			}
 		}
 

--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/VoidRing.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/VoidRing.java
@@ -41,7 +41,9 @@ public class VoidRing extends GemEternalDensity implements IPedestalItem, IExtra
 		{
 			stack.getTagCompound().setByte("teleportCooldown", ((byte) 10));
 		}
-		stack.getTagCompound().setByte("teleportCooldown", ((byte) (stack.getTagCompound().getByte("teleportCooldown") - 1)));
+		if(stack.getTagCompound().getByte("teleportCooldown") > 0) {
+			stack.getTagCompound().setByte("teleportCooldown", ((byte) (stack.getTagCompound().getByte("teleportCooldown") - 1)));
+		}
 	}
 
 

--- a/src/main/java/moze_intel/projecte/impl/AlchBagImpl.java
+++ b/src/main/java/moze_intel/projecte/impl/AlchBagImpl.java
@@ -19,6 +19,7 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -60,7 +61,7 @@ public final class AlchBagImpl
         }
 
         @Override
-        public void sync(@Nonnull EnumDyeColor color, @Nonnull EntityPlayerMP player)
+        public void sync(@Nullable EnumDyeColor color, @Nonnull EntityPlayerMP player)
         {
             PacketHandler.sendTo(new SyncBagDataPKT(writeNBT(color)), player);
         }


### PR DESCRIPTION
* Check for NBT, not item damage for Void Rings and Black Hole Band in bags. This allows them to suck items into the bags again.
* Only tick down the Void Ring teleport cooldown when positive. Otherwise it goes negative, and wraps around constantly.
* Fix a wrong null annotation causing a crash on startup. (Color should be null to sync all of them, and the functions handle this correctly.)