### PR TITLE
Support cancelling learning and setting condenser duplicator item

### DIFF
--- a/src/main/java/moze_intel/projecte/api/event/PlayerAttemptCondenserSetEvent.java
+++ b/src/main/java/moze_intel/projecte/api/event/PlayerAttemptCondenserSetEvent.java
@@ -1,0 +1,44 @@
+package moze_intel.projecte.api.event;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+import javax.annotation.Nonnull;
+
+/**
+ * This event is fired when a player is attempting to place an item in the condenser.
+ * This event is cancelable
+ * This event is fired on MinecraftForge#EVENT_BUS
+ */
+@Cancelable
+public class PlayerAttemptCondenserSetEvent extends Event
+{
+    private final EntityPlayer player;
+    private final ItemStack stack;
+
+    public PlayerAttemptCondenserSetEvent(@Nonnull EntityPlayer entityPlayer, @Nonnull ItemStack stack)
+    {
+        player = entityPlayer;
+        this.stack = stack;
+    }
+
+    /**
+     * @return The player who is attempting to put in the condenser slot.
+     */
+    @Nonnull
+    public EntityPlayer getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * @return The stack that the player is trying to learn.
+     */
+    @Nonnull
+    public ItemStack getStack()
+    {
+        return stack;
+    }
+}

--- a/src/main/java/moze_intel/projecte/api/event/PlayerAttemptCondenserSetEvent.java
+++ b/src/main/java/moze_intel/projecte/api/event/PlayerAttemptCondenserSetEvent.java
@@ -8,7 +8,7 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 import javax.annotation.Nonnull;
 
 /**
- * This event is fired when a player is attempting to place an item in the condenser.
+ * This event is fired on both the server and client when a player is attempting to place an item in the condenser.
  * This event is cancelable
  * This event is fired on MinecraftForge#EVENT_BUS
  */

--- a/src/main/java/moze_intel/projecte/api/event/PlayerAttemptLearnEvent.java
+++ b/src/main/java/moze_intel/projecte/api/event/PlayerAttemptLearnEvent.java
@@ -8,7 +8,7 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 import javax.annotation.Nonnull;
 
 /**
- * This event is fired when a player is attempting to learn a new item
+ * This event is fired on both the server and client when a player is attempting to learn a new item
  * This event is cancelable
  * This event is fired on MinecraftForge#EVENT_BUS
  */

--- a/src/main/java/moze_intel/projecte/api/event/PlayerAttemptLearnEvent.java
+++ b/src/main/java/moze_intel/projecte/api/event/PlayerAttemptLearnEvent.java
@@ -1,0 +1,44 @@
+package moze_intel.projecte.api.event;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.eventhandler.Cancelable;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+import javax.annotation.Nonnull;
+
+/**
+ * This event is fired when a player is attempting to learn a new item
+ * This event is cancelable
+ * This event is fired on MinecraftForge#EVENT_BUS
+ */
+@Cancelable
+public class PlayerAttemptLearnEvent extends Event
+{
+    private final EntityPlayer player;
+    private final ItemStack stack;
+
+    public PlayerAttemptLearnEvent(@Nonnull EntityPlayer entityPlayer, @Nonnull ItemStack stack)
+    {
+        player = entityPlayer;
+        this.stack = stack;
+    }
+
+    /**
+     * @return The player who is attempting to learn a new item.
+     */
+    @Nonnull
+    public EntityPlayer getPlayer()
+    {
+        return player;
+    }
+
+    /**
+     * @return The stack that the player is trying to learn.
+     */
+    @Nonnull
+    public ItemStack getStack()
+    {
+        return stack;
+    }
+}

--- a/src/main/java/moze_intel/projecte/gameObjs/container/CondenserContainer.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/CondenserContainer.java
@@ -1,5 +1,6 @@
 package moze_intel.projecte.gameObjs.container;
 
+import moze_intel.projecte.api.event.PlayerAttemptCondenserSetEvent;
 import moze_intel.projecte.gameObjs.ObjHandler;
 import moze_intel.projecte.gameObjs.container.slots.SlotCondenserLock;
 import moze_intel.projecte.gameObjs.container.slots.SlotPredicates;
@@ -15,6 +16,7 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IContainerListener;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandler;
@@ -154,7 +156,7 @@ public class CondenserContainer extends Container
 	@Override
 	public ItemStack slotClick(int slot, int button, ClickType flag, EntityPlayer player)
 	{
-		if (slot == 0 && !tile.getLock().getStackInSlot(0).isEmpty())
+		if (slot == 0 && (!tile.getLock().getStackInSlot(0).isEmpty() || MinecraftForge.EVENT_BUS.post(new PlayerAttemptCondenserSetEvent(player, player.inventory.getItemStack()))))
 		{
 			if (!player.getEntityWorld().isRemote)
 			{

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
@@ -2,6 +2,7 @@ package moze_intel.projecte.gameObjs.container.inventory;
 
 import moze_intel.projecte.api.ProjectEAPI;
 import moze_intel.projecte.api.capabilities.IKnowledgeProvider;
+import moze_intel.projecte.api.event.PlayerAttemptLearnEvent;
 import moze_intel.projecte.emc.FuelMapper;
 import moze_intel.projecte.utils.Constants;
 import moze_intel.projecte.utils.EMCHelper;
@@ -14,6 +15,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.MathHelper;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.wrapper.CombinedInvWrapper;
@@ -72,16 +74,18 @@ public class TransmutationInventory extends CombinedInvWrapper
 		
 		if (!provider.hasKnowledge(stack))
 		{
-			learnFlag = 300;
-			unlearnFlag = 0;
-
 			if (stack.hasTagCompound() && !NBTWhitelist.shouldDupeWithNBT(stack))
 			{
 				stack.setTagCompound(null);
 			}
 
-			provider.addKnowledge(stack);
-			
+			if (!MinecraftForge.EVENT_BUS.post(new PlayerAttemptLearnEvent(player, stack))) //Only show the "learned" text if the knowledge was added
+			{
+				learnFlag = 300;
+				unlearnFlag = 0;
+				provider.addKnowledge(stack);
+			}
+
 			if (!player.getEntityWorld().isRemote)
 			{
 				provider.sync(((EntityPlayerMP) player));
@@ -237,7 +241,7 @@ public class TransmutationInventory extends CombinedInvWrapper
 		int matterCounter = 0;
 		int fuelCounter = 0;
 
-		if (!lockCopy.isEmpty())
+		if (!lockCopy.isEmpty() && provider.hasKnowledge(lockCopy))
 		{
 			if (FuelMapper.isStackFuel(lockCopy))
 			{


### PR DESCRIPTION
Implements #1706 

The general description can be found in the issue above. For the implementation of the AttemptLearnEvent I decided that cancelling transmutation learning would still give the player emc; however, it does not add the item to their "learned" items.

EDIT: One thing I forgot to mention is I have fully tested the code and it works properly. If needed I can push my local repo changes to CompatSkills to a branch on my fork of it so that it is easier to test for you guys.