### PR TITLE
CraftTweaker Recipe Mapping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,9 +76,9 @@ dependencies {
 
     deobfCompile "mezz.jei:jei_1.12:4.7.0.67"
     deobfCompile "com.azanor.baubles:Baubles:1.12-1.5.2"
-    /*deobfCompile "MineTweaker3:MineTweaker3-API:3.0.11.26"
-    deobfCompile "MineTweaker3:MineTweaker3-MC1102-Main:1.10.2-3.0.11.26"
-    deobfCompile "MineTweaker3:ZenScript:3.0.11.26"*/
+    deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.9.481"
+    deobfCompile "CraftTweaker2:CraftTweaker2-API:1.12-4.1.9.481"
+    deobfCompile "CraftTweaker2:ZenScript:1.12-4.1.9.481"
 
     compile fileTree(dir: 'libs', include: '*.jar')
 }

--- a/src/main/java/moze_intel/projecte/emc/mappers/CraftTweakerRecipeMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/CraftTweakerRecipeMapper.java
@@ -1,24 +1,17 @@
 package moze_intel.projecte.emc.mappers;
 
-import com.google.common.collect.Iterables;
+import crafttweaker.mc1120.recipes.MCRecipeShaped;
+import crafttweaker.mc1120.recipes.MCRecipeShapeless;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraftforge.fml.common.Loader;
-import net.minecraftforge.fml.common.ModAPIManager;
-import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.fml.common.versioning.VersionParser;
 
 public class CraftTweakerRecipeMapper implements CraftingMapper.IRecipeMapper {
     private boolean ctCompat;
 
     public CraftTweakerRecipeMapper() {
-        if (Loader.isModLoaded("crafttweaker")) { //Check to make sure it is a version of CraftTweaker that uses the new Recipe System
-            for (ModContainer mod : Iterables.concat(Loader.instance().getActiveModList(), ModAPIManager.INSTANCE.getAPIList())) {
-                if (mod.getModId().equals("crafttweaker")) {
-                    ctCompat = VersionParser.parseVersionReference("crafttweaker@[4.1.5,)").containsVersion(mod.getProcessedVersion());
-                    break;
-                }
-            }
-        }
+        //Check to make sure it is a version of CraftTweaker that uses the new Recipe System
+        ctCompat = Loader.isModLoaded("crafttweaker") && VersionParser.parseVersionReference("crafttweaker@[4.1.5,)").containsVersion(Loader.instance().getIndexedModList().get("crafttweaker").getProcessedVersion());
     }
 
     @Override
@@ -33,7 +26,6 @@ public class CraftTweakerRecipeMapper implements CraftingMapper.IRecipeMapper {
 
     @Override
     public boolean canHandle(IRecipe recipe) {
-        //Make sure no imports are added that could cause problems
-        return ctCompat && (recipe instanceof crafttweaker.mc1120.recipes.MCRecipeShaped || recipe instanceof crafttweaker.mc1120.recipes.MCRecipeShapeless);
+        return ctCompat && (recipe instanceof MCRecipeShaped || recipe instanceof MCRecipeShapeless);
     }
 }

--- a/src/main/java/moze_intel/projecte/emc/mappers/CraftTweakerRecipeMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/CraftTweakerRecipeMapper.java
@@ -1,0 +1,39 @@
+package moze_intel.projecte.emc.mappers;
+
+import com.google.common.collect.Iterables;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.ModAPIManager;
+import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.fml.common.versioning.VersionParser;
+
+public class CraftTweakerRecipeMapper implements CraftingMapper.IRecipeMapper {
+    private boolean ctCompat;
+
+    public CraftTweakerRecipeMapper() {
+        if (Loader.isModLoaded("crafttweaker")) { //Check to make sure it is a version of CraftTweaker that uses the new Recipe System
+            for (ModContainer mod : Iterables.concat(Loader.instance().getActiveModList(), ModAPIManager.INSTANCE.getAPIList())) {
+                if (mod.getModId().equals("crafttweaker")) {
+                    ctCompat = VersionParser.parseVersionReference("crafttweaker@[4.1.5,)").containsVersion(mod.getProcessedVersion());
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "CraftTweakerRecipeMapper";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Maps `IRecipe` CraftTweaker crafting recipes that extend `MCRecipeShaped` or `MCRecipeShapeless";
+    }
+
+    @Override
+    public boolean canHandle(IRecipe recipe) {
+        //Make sure no imports are added that could cause problems
+        return ctCompat && (recipe instanceof crafttweaker.mc1120.recipes.MCRecipeShaped || recipe instanceof crafttweaker.mc1120.recipes.MCRecipeShapeless);
+    }
+}

--- a/src/main/java/moze_intel/projecte/emc/mappers/CraftingMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/CraftingMapper.java
@@ -31,7 +31,7 @@ import java.util.Set;
 
 public class CraftingMapper implements IEMCMapper<NormalizedSimpleStack, Integer> {
 
-	private final List<IRecipeMapper> recipeMappers = Arrays.asList(new VanillaRecipeMapper(), new PECustomRecipeMapper());
+	private final List<IRecipeMapper> recipeMappers = Arrays.asList(new VanillaRecipeMapper(), new PECustomRecipeMapper(), new CraftTweakerRecipeMapper());
 	private final Set<Class> canNotMap = new HashSet<>();
 	private final Map<Class, Integer> recipeCount = new HashMap<>();
 


### PR DESCRIPTION
The new CraftTweaker mapper is only used for newer versions of CraftTweaker that have their new recipe system.

This preserves compatibility with older versions of CraftTweaker