### PR TITLE
Made condenser easier to subclass externally

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/CondenserContainer.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/CondenserContainer.java
@@ -2,6 +2,7 @@ package moze_intel.projecte.gameObjs.container;
 
 import moze_intel.projecte.api.event.PlayerAttemptCondenserSetEvent;
 import moze_intel.projecte.gameObjs.ObjHandler;
+import moze_intel.projecte.gameObjs.blocks.Condenser;
 import moze_intel.projecte.gameObjs.container.slots.SlotCondenserLock;
 import moze_intel.projecte.gameObjs.container.slots.SlotPredicates;
 import moze_intel.projecte.gameObjs.container.slots.ValidatedSlot;
@@ -25,7 +26,7 @@ import javax.annotation.Nonnull;
 
 public class CondenserContainer extends LongContainer
 {	
-	final CondenserTile tile;
+	protected final CondenserTile tile;
 	public long displayEmc;
 	public long requiredEmc;
 	
@@ -36,7 +37,7 @@ public class CondenserContainer extends LongContainer
 		initSlots(invPlayer);
 	}
 
-	void initSlots(InventoryPlayer invPlayer)
+	protected void initSlots(InventoryPlayer invPlayer)
 	{
 		this.addSlotToContainer(new SlotCondenserLock(tile.getLock(), 0, 12, 6));
 
@@ -152,7 +153,7 @@ public class CondenserContainer extends LongContainer
 	@Override
 	public boolean canInteractWith(@Nonnull EntityPlayer player)
 	{
-		return player.world.getBlockState(tile.getPos()).getBlock() == ObjHandler.condenser
+		return player.world.getBlockState(tile.getPos()).getBlock() instanceof Condenser
 			&& player.getDistanceSq(tile.getPos().getX() + 0.5, tile.getPos().getY() + 0.5, tile.getPos().getZ() + 0.5) <= 64.0;
 	}
 	

--- a/src/main/java/moze_intel/projecte/gameObjs/container/CondenserMK2Container.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/CondenserMK2Container.java
@@ -22,7 +22,7 @@ public class CondenserMK2Container extends CondenserContainer
 	}
 
 	@Override
-	void initSlots(InventoryPlayer invPlayer)
+	protected void initSlots(InventoryPlayer invPlayer)
 	{
 		this.addSlotToContainer(new SlotCondenserLock(tile.getLock(), 0, 12, 6));
 

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserTile.java
@@ -21,7 +21,7 @@ import javax.annotation.Nonnull;
 
 public class CondenserTile extends TileEmc implements IEmcAcceptor
 {
-	private final ItemStackHandler inputInventory = createInput();
+	protected final ItemStackHandler inputInventory = createInput();
 	private final ItemStackHandler outputInventory = createOutput();
 	private final IItemHandler automationInventory = createAutomationInventory();
 	private final ItemStackHandler lock = new StackHandler(1);

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserTile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CondenserTile.java
@@ -243,7 +243,7 @@ public class CondenserTile extends TileEmc implements IEmcAcceptor
 	{
 		if (++ticksSinceSync % 20 * 4 == 0)
 		{
-			world.addBlockEvent(pos, ObjHandler.condenser, 1, numPlayersUsing);
+			world.addBlockEvent(pos, getBlockType(), 1, numPlayersUsing);
 		}
 
 		prevLidAngle = lidAngle;

--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/WrappedItemHandler.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/WrappedItemHandler.java
@@ -64,7 +64,7 @@ public class WrappedItemHandler implements IItemHandlerModifiable
         compose.setStackInSlot(slot, stack);
     }
 
-    enum WriteMode
+    public enum WriteMode
     {
         IN,
         OUT,


### PR DESCRIPTION
- This mostly changes "private" to "protected" in a few places, allowing these things to be accessed by subclasses in external mods
- In CondenserContainer.java line 156, im checking with "instanceof Condenser" instead to allow this to work with subclasses
- In CondenserTile.java line 246, im using "getBlockType()" instead to allow this to work with subclasses

These changes are required for me to create an addon mod with custom condensers (They restrict items by EMC value). Repository for addon found here: https://github.com/zerofall/ProgressiveAlchemy