### PR TITLE
Shifts crafttweaker integration to just use the API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ repositories {
 
     maven {
         name 'jared'
-        url "http://blamejared.com/maven/"
+        url "http://maven.blamejared.com"
     }
 }
  
@@ -80,8 +80,7 @@ dependencies {
 
     deobfCompile "mezz.jei:jei_1.12:4.7.0.67"
     deobfCompile "com.azanor.baubles:Baubles:1.12-1.5.2"
-    deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.9.481"
-    deobfCompile "CraftTweaker2:CraftTweaker2-API:1.12-4.1.9.481"
+    deobfCompile "CraftTweaker2:CraftTweaker2-API:4.1.9.481"
     deobfCompile "CraftTweaker2:ZenScript:1.12-4.1.9.481"
 
     compile group: "org.apache.commons", name: "commons-math3", version: "3.6.1"

--- a/src/main/java/moze_intel/projecte/emc/mappers/CraftTweakerRecipeMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/CraftTweakerRecipeMapper.java
@@ -1,7 +1,6 @@
 package moze_intel.projecte.emc.mappers;
 
-import crafttweaker.mc1120.recipes.MCRecipeShaped;
-import crafttweaker.mc1120.recipes.MCRecipeShapeless;
+import crafttweaker.api.recipes.ICraftingRecipe;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.versioning.VersionParser;
@@ -26,6 +25,6 @@ public class CraftTweakerRecipeMapper implements CraftingMapper.IRecipeMapper {
 
     @Override
     public boolean canHandle(IRecipe recipe) {
-        return ctCompat && (recipe instanceof MCRecipeShaped || recipe instanceof MCRecipeShapeless);
+        return ctCompat && (recipe instanceof ICraftingRecipe);
     }
 }


### PR DESCRIPTION
Using the modern CraftTweaker main jar was causing issues with
compilation in a dev environment for some devs. This keeps the
functionality for the CraftTweaker fix, and makes all of us able to
compile again.