### PR TITLE
Fix for server-side crash from JEI

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/FuelMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/FuelMapper.java
@@ -103,6 +103,9 @@ public final class FuelMapper
 		jeiRecipeList.clear();
 
 		for(SimpleStack stack : FUEL_MAP){
+			if(EMCHelper.getEmcValue(stack.toItemStack()) > EMCHelper.getEmcValue(getFuelUpgrade(stack.toItemStack())) )
+				continue;
+
 			FuelUpgradeRecipe recipe = new FuelUpgradeRecipe(stack.toItemStack(), getFuelUpgrade(stack.toItemStack()));
 			jeiRecipeList.add(recipe);
 			PEJeiPlugin.RUNTIME.getRecipeRegistry().addRecipe(recipe, CollectorRecipeCategory.UID);

--- a/src/main/java/moze_intel/projecte/integration/jei/PEJeiPlugin.java
+++ b/src/main/java/moze_intel/projecte/integration/jei/PEJeiPlugin.java
@@ -13,7 +13,7 @@ import moze_intel.projecte.gameObjs.container.PhilosStoneContainer;
 import moze_intel.projecte.integration.jei.collectors.CollectorRecipeCategory;
 import moze_intel.projecte.integration.jei.world_transmute.WorldTransmuteRecipeCategory;
 import moze_intel.projecte.utils.WorldTransmutations;
-import net.minecraft.server.MinecraftServer;
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
 import javax.annotation.Nonnull;
@@ -50,8 +50,8 @@ public class PEJeiPlugin implements IModPlugin
     }
 
     public static void refreshJEI(){
-        MinecraftServer server = FMLCommonHandler.instance().getMinecraftServerInstance();
-        server.addScheduledTask(() -> FuelMapper.refreshFuelsJEI());
+        if(FMLCommonHandler.instance().getEffectiveSide().isClient())
+            Minecraft.getMinecraft().addScheduledTask(() -> FuelMapper.refreshFuelsJEI());
     }
 
 }


### PR DESCRIPTION
I'm really really hoping this'll fix it. I can't test, due to not getting the crash when running a client and server on my local machine.

getMinecraftServerInstance() is null when running in certain client/server configurations. Minecraft.getMinecraft() should always exist when a client is running it, which we're checking for.

On top of this, I added a fix for a bug that I noticed while debugging the feature, where the final item in the fuel map would display a recipe going from finalItem -> firstItem due to the wrapping effects of getFuelUpgrade.