### PR TITLE
Added abreviations for large EMC values (Transmutation table & Condensers)

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenser.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenser.java
@@ -4,11 +4,15 @@ import moze_intel.projecte.PECore;
 import moze_intel.projecte.gameObjs.container.CondenserContainer;
 import moze_intel.projecte.gameObjs.tiles.CondenserTile;
 import moze_intel.projecte.utils.Constants;
+import moze_intel.projecte.utils.TransmutationEMCFormatter;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
+
+import java.util.Arrays;
 
 public class GUICondenser extends GuiContainer
 {
@@ -50,6 +54,27 @@ public class GUICondenser extends GuiContainer
 	protected void drawGuiContainerForegroundLayer(int var1, int var2) 
 	{
 		long toDisplay = container.displayEmc > container.requiredEmc ? container.requiredEmc : container.displayEmc;
-		this.fontRenderer.drawString(Constants.EMC_FORMATTER.format(toDisplay), 140, 10, 4210752);
+		String emc = TransmutationEMCFormatter.EMCFormat(toDisplay);
+		this.fontRenderer.drawString(emc, 140, 10, 4210752);
+	}
+
+	@Override
+	protected void renderHoveredToolTip(int mouseX, int mouseY) {
+		long toDisplay = container.displayEmc > container.requiredEmc ? container.requiredEmc : container.displayEmc;
+
+		int emcLeft = 140 + (this.width - this.xSize) / 2;
+		int emcRight = emcLeft + 110;
+		int emcTop = 6 + (this.height - this.ySize) / 2;
+		int emcBottom = emcTop + 15;
+
+		PECore.debugLog(mouseX + " " + mouseY);
+
+		String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(toDisplay);
+
+		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom && toDisplay >= 1e12) {
+			drawHoveringText(Arrays.asList(emcAsString), mouseX, mouseY);
+		} else {
+			super.renderHoveredToolTip(mouseX, mouseY);
+		}
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenser.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenser.java
@@ -62,12 +62,15 @@ public class GUICondenser extends GuiContainer
 	protected void renderHoveredToolTip(int mouseX, int mouseY) {
 		long toDisplay = container.displayEmc > container.requiredEmc ? container.requiredEmc : container.displayEmc;
 
+		if (toDisplay < 1e12) {
+			super.renderHoveredToolTip(mouseX, mouseY);
+			return;
+		}
+
 		int emcLeft = 140 + (this.width - this.xSize) / 2;
 		int emcRight = emcLeft + 110;
 		int emcTop = 6 + (this.height - this.ySize) / 2;
 		int emcBottom = emcTop + 15;
-
-		PECore.debugLog(mouseX + " " + mouseY);
 
 		String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(toDisplay);
 

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenser.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenser.java
@@ -74,7 +74,7 @@ public class GUICondenser extends GuiContainer
 
 		String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(toDisplay);
 
-		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom && toDisplay >= 1e12) {
+		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom) {
 			drawHoveringText(Arrays.asList(emcAsString), mouseX, mouseY);
 		} else {
 			super.renderHoveredToolTip(mouseX, mouseY);

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenser.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenser.java
@@ -16,15 +16,21 @@ import java.util.Arrays;
 
 public class GUICondenser extends GuiContainer
 {
-	private static final ResourceLocation texture = new ResourceLocation(PECore.MODID.toLowerCase(), "textures/gui/condenser.png");
-	private final CondenserContainer container;
-	
-	public GUICondenser(InventoryPlayer invPlayer, CondenserTile tile)
+	protected final ResourceLocation texture;
+	protected final CondenserContainer container;
+
+	public GUICondenser(CondenserContainer condenser, ResourceLocation texture)
 	{
-		super(new CondenserContainer(invPlayer, tile));
-		this.container = ((CondenserContainer) inventorySlots);
+		super(condenser);
+		this.container = condenser;
+		this.texture = texture;
 		this.xSize = 255;
 		this.ySize = 233;
+	}
+
+	public GUICondenser(InventoryPlayer invPlayer, CondenserTile tile)
+	{
+		this(new CondenserContainer(invPlayer, tile), new ResourceLocation(PECore.MODID.toLowerCase(), "textures/gui/condenser.png"));
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenser.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenser.java
@@ -72,9 +72,8 @@ public class GUICondenser extends GuiContainer
 		int emcTop = 6 + (this.height - this.ySize) / 2;
 		int emcBottom = emcTop + 15;
 
-		String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(toDisplay);
-
 		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom) {
+			String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(toDisplay);
 			drawHoveringText(Arrays.asList(emcAsString), mouseX, mouseY);
 		} else {
 			super.renderHoveredToolTip(mouseX, mouseY);

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenserMK2.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenserMK2.java
@@ -62,6 +62,11 @@ public class GUICondenserMK2 extends GuiContainer
 	protected void renderHoveredToolTip(int mouseX, int mouseY) {
 		long toDisplay = container.displayEmc > container.requiredEmc ? container.requiredEmc : container.displayEmc;
 
+		if (toDisplay < 1e12) {
+			super.renderHoveredToolTip(mouseX, mouseY);
+			return;
+		}
+
 		int emcLeft = 140 + (this.width - this.xSize) / 2;
 		int emcRight = emcLeft + 110;
 		int emcTop = 6 + (this.height - this.ySize) / 2;
@@ -69,7 +74,7 @@ public class GUICondenserMK2 extends GuiContainer
 
 		String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(toDisplay);
 
-		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom && toDisplay >= 1e12) {
+		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom) {
 			drawHoveringText(Arrays.asList(emcAsString), mouseX, mouseY);
 		} else {
 			super.renderHoveredToolTip(mouseX, mouseY);

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenserMK2.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenserMK2.java
@@ -3,16 +3,8 @@ package moze_intel.projecte.gameObjs.gui;
 import moze_intel.projecte.PECore;
 import moze_intel.projecte.gameObjs.container.CondenserMK2Container;
 import moze_intel.projecte.gameObjs.tiles.CondenserMK2Tile;
-import moze_intel.projecte.utils.Constants;
-import moze_intel.projecte.utils.TransmutationEMCFormatter;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
-
-import java.util.Arrays;
 
 public class GUICondenserMK2 extends GUICondenser
 {

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenserMK2.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenserMK2.java
@@ -4,11 +4,15 @@ import moze_intel.projecte.PECore;
 import moze_intel.projecte.gameObjs.container.CondenserMK2Container;
 import moze_intel.projecte.gameObjs.tiles.CondenserMK2Tile;
 import moze_intel.projecte.utils.Constants;
+import moze_intel.projecte.utils.TransmutationEMCFormatter;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
+
+import java.util.Arrays;
 
 public class GUICondenserMK2 extends GuiContainer
 {
@@ -50,6 +54,25 @@ public class GUICondenserMK2 extends GuiContainer
 	protected void drawGuiContainerForegroundLayer(int var1, int var2)
 	{
 		long toDisplay = container.displayEmc > container.requiredEmc ? container.requiredEmc : container.displayEmc;
-		this.fontRenderer.drawString(Constants.EMC_FORMATTER.format(toDisplay), 140, 10, 4210752);
+		String emc = TransmutationEMCFormatter.EMCFormat(toDisplay);
+		this.fontRenderer.drawString(emc, 140, 10, 4210752);
+	}
+
+	@Override
+	protected void renderHoveredToolTip(int mouseX, int mouseY) {
+		long toDisplay = container.displayEmc > container.requiredEmc ? container.requiredEmc : container.displayEmc;
+
+		int emcLeft = 140 + (this.width - this.xSize) / 2;
+		int emcRight = emcLeft + 110;
+		int emcTop = 6 + (this.height - this.ySize) / 2;
+		int emcBottom = emcTop + 15;
+
+		String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(toDisplay);
+
+		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom && toDisplay >= 1e12) {
+			drawHoveringText(Arrays.asList(emcAsString), mouseX, mouseY);
+		} else {
+			super.renderHoveredToolTip(mouseX, mouseY);
+		}
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenserMK2.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenserMK2.java
@@ -72,9 +72,8 @@ public class GUICondenserMK2 extends GuiContainer
 		int emcTop = 6 + (this.height - this.ySize) / 2;
 		int emcBottom = emcTop + 15;
 
-		String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(toDisplay);
-
 		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom) {
+			String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(toDisplay);
 			drawHoveringText(Arrays.asList(emcAsString), mouseX, mouseY);
 		} else {
 			super.renderHoveredToolTip(mouseX, mouseY);

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenserMK2.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUICondenserMK2.java
@@ -14,69 +14,10 @@ import net.minecraft.util.ResourceLocation;
 
 import java.util.Arrays;
 
-public class GUICondenserMK2 extends GuiContainer
+public class GUICondenserMK2 extends GUICondenser
 {
-	private static final ResourceLocation texture = new ResourceLocation(PECore.MODID.toLowerCase(), "textures/gui/condenser_mk2.png");
-	private final CondenserMK2Container container;
-
 	public GUICondenserMK2(InventoryPlayer invPlayer, CondenserMK2Tile tile)
 	{
-		super(new CondenserMK2Container(invPlayer, tile));
-		this.container = ((CondenserMK2Container) inventorySlots);
-		this.xSize = 255;
-		this.ySize = 233;
-	}
-
-	@Override
-	public void drawScreen(int mouseX, int mouseY, float partialTicks)
-    {
-        this.drawDefaultBackground();
-        super.drawScreen(mouseX, mouseY, partialTicks);
-        this.renderHoveredToolTip(mouseX, mouseY);
-    }
-
-	@Override
-	protected void drawGuiContainerBackgroundLayer(float var1, int var2, int var3)
-	{
-		GlStateManager.color(1, 1, 1, 1);
-		Minecraft.getMinecraft().renderEngine.bindTexture(texture);
-
-		int x = (width - xSize) / 2;
-		int y = (height - ySize) / 2;
-
-		this.drawTexturedModalRect(x, y, 0, 0, xSize, ySize);
-
-		int progress = container.getProgressScaled();
-		this.drawTexturedModalRect(x + 33, y + 10, 0, 235, progress, 10);
-	}
-
-	@Override
-	protected void drawGuiContainerForegroundLayer(int var1, int var2)
-	{
-		long toDisplay = container.displayEmc > container.requiredEmc ? container.requiredEmc : container.displayEmc;
-		String emc = TransmutationEMCFormatter.EMCFormat(toDisplay);
-		this.fontRenderer.drawString(emc, 140, 10, 4210752);
-	}
-
-	@Override
-	protected void renderHoveredToolTip(int mouseX, int mouseY) {
-		long toDisplay = container.displayEmc > container.requiredEmc ? container.requiredEmc : container.displayEmc;
-
-		if (toDisplay < 1e12) {
-			super.renderHoveredToolTip(mouseX, mouseY);
-			return;
-		}
-
-		int emcLeft = 140 + (this.width - this.xSize) / 2;
-		int emcRight = emcLeft + 110;
-		int emcTop = 6 + (this.height - this.ySize) / 2;
-		int emcBottom = emcTop + 15;
-
-		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom) {
-			String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(toDisplay);
-			drawHoveringText(Arrays.asList(emcAsString), mouseX, mouseY);
-		} else {
-			super.renderHoveredToolTip(mouseX, mouseY);
-		}
+		super(new CondenserMK2Container(invPlayer, tile), new ResourceLocation(PECore.MODID.toLowerCase(), "textures/gui/condenser_mk2.png"));
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
@@ -193,19 +193,14 @@ public class GUITransmutation extends GuiContainer
 	protected void renderHoveredToolTip(int mouseX, int mouseY) {
 		double emcAmount = inv.player.getCapability(ProjectEAPI.KNOWLEDGE_CAPABILITY, null).getEmc();
 
-		if (emcAmount < 1e9) {
-			return;
-		}
-
-
 		int emcLeft = (this.width - this.xSize) / 2;
 		int emcRight = emcLeft + 82;
 		int emcTop = 95 + (this.height - this.ySize) / 2;
 		int emcBottom = emcTop + 15;
 
-		String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.FULL_EMC_FORMATTER.format(emcAmount);
+		String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(emcAmount);
 
-		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom) {
+		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom && emcAmount >= 1e12) {
 			drawHoveringText(Arrays.asList(emcAsString), mouseX, mouseY);
 		} else {
 			super.renderHoveredToolTip(mouseX, mouseY);

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
@@ -203,9 +203,8 @@ public class GUITransmutation extends GuiContainer
 		int emcTop = 95 + (this.height - this.ySize) / 2;
 		int emcBottom = emcTop + 15;
 
-		String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(emcAmount);
-
 		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom) {
+			String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(emcAmount);
 			drawHoveringText(Arrays.asList(emcAsString), mouseX, mouseY);
 		} else {
 			super.renderHoveredToolTip(mouseX, mouseY);

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
@@ -193,6 +193,11 @@ public class GUITransmutation extends GuiContainer
 	protected void renderHoveredToolTip(int mouseX, int mouseY) {
 		double emcAmount = inv.player.getCapability(ProjectEAPI.KNOWLEDGE_CAPABILITY, null).getEmc();
 
+		if (emcAmount < 1e12) {
+			super.renderHoveredToolTip(mouseX, mouseY);
+			return;
+		}
+
 		int emcLeft = (this.width - this.xSize) / 2;
 		int emcRight = emcLeft + 82;
 		int emcTop = 95 + (this.height - this.ySize) / 2;

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
@@ -205,7 +205,7 @@ public class GUITransmutation extends GuiContainer
 
 		String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(emcAmount);
 
-		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom && emcAmount >= 1e12) {
+		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom) {
 			drawHoveringText(Arrays.asList(emcAsString), mouseX, mouseY);
 		} else {
 			super.renderHoveredToolTip(mouseX, mouseY);

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
@@ -19,6 +19,7 @@ import net.minecraft.util.ResourceLocation;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Arrays;
 
 public class GUITransmutation extends GuiContainer
 {
@@ -71,8 +72,9 @@ public class GUITransmutation extends GuiContainer
 	{
 		this.fontRenderer.drawString(I18n.format("pe.transmutation.transmute"), 6, 8, 4210752);
 		double emcAmount = inv.player.getCapability(ProjectEAPI.KNOWLEDGE_CAPABILITY, null).getEmc();
-		String emcFormatted = TransmutationEMCFormatter.EMCFormat(emcAmount);
-		String emc = I18n.format("pe.emc.emc_tooltip_prefix") + " " + emcFormatted;
+		String emcLabel = I18n.format("pe.emc.emc_tooltip_prefix");
+		this.fontRenderer.drawString(emcLabel, 6, this.ySize - 104, 4210752);
+		String emc = TransmutationEMCFormatter.EMCFormat(emcAmount);
 		this.fontRenderer.drawString(emc, 6, this.ySize - 94, 4210752);
 
 		if (inv.learnFlag > 0)
@@ -185,5 +187,28 @@ public class GUITransmutation extends GuiContainer
 		}
 		inv.filter = srch;
 		inv.updateClientTargets();
+	}
+
+	@Override
+	protected void renderHoveredToolTip(int mouseX, int mouseY) {
+		double emcAmount = inv.player.getCapability(ProjectEAPI.KNOWLEDGE_CAPABILITY, null).getEmc();
+
+		if (emcAmount < 1e9) {
+			return;
+		}
+
+
+		int emcLeft = (this.width - this.xSize) / 2;
+		int emcRight = emcLeft + 82;
+		int emcTop = 95 + (this.height - this.ySize) / 2;
+		int emcBottom = emcTop + 15;
+
+		String emcAsString = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.FULL_EMC_FORMATTER.format(emcAmount);
+
+		if (mouseX > emcLeft && mouseX < emcRight && mouseY > emcTop && mouseY < emcBottom) {
+			drawHoveringText(Arrays.asList(emcAsString), mouseX, mouseY);
+		} else {
+			super.renderHoveredToolTip(mouseX, mouseY);
+		}
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
@@ -5,6 +5,7 @@ import moze_intel.projecte.api.ProjectEAPI;
 import moze_intel.projecte.gameObjs.container.TransmutationContainer;
 import moze_intel.projecte.gameObjs.container.inventory.TransmutationInventory;
 import moze_intel.projecte.utils.Constants;
+import moze_intel.projecte.utils.TransmutationEMCFormatter;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiTextField;
@@ -70,7 +71,8 @@ public class GUITransmutation extends GuiContainer
 	{
 		this.fontRenderer.drawString(I18n.format("pe.transmutation.transmute"), 6, 8, 4210752);
 		double emcAmount = inv.player.getCapability(ProjectEAPI.KNOWLEDGE_CAPABILITY, null).getEmc();
-		String emc = I18n.format("pe.emc.emc_tooltip_prefix") + " " + Constants.EMC_FORMATTER.format(emcAmount);
+		String emcFormatted = TransmutationEMCFormatter.EMCFormat(emcAmount);
+		String emc = I18n.format("pe.emc.emc_tooltip_prefix") + " " + emcFormatted;
 		this.fontRenderer.drawString(emc, 6, this.ySize - 94, 4210752);
 
 		if (inv.learnFlag > 0)

--- a/src/main/java/moze_intel/projecte/utils/Constants.java
+++ b/src/main/java/moze_intel/projecte/utils/Constants.java
@@ -4,7 +4,7 @@ import java.text.DecimalFormat;
 
 public final class Constants 
 {
-	public static final DecimalFormat EMC_FORMATTER = new DecimalFormat("#,###.##");
+	public static final DecimalFormat EMC_FORMATTER = new DecimalFormat("#,###.####");
 
 	public static final int[] MAX_KLEIN_EMC = new int[] {50000, 200000, 800000, 3200000, 12800000, 51200000};
 	public static final int[] RELAY_KLEIN_CHARGE_RATE = new int[] {16, 48, 160};

--- a/src/main/java/moze_intel/projecte/utils/Constants.java
+++ b/src/main/java/moze_intel/projecte/utils/Constants.java
@@ -5,7 +5,7 @@ import java.text.DecimalFormat;
 public final class Constants 
 {
 	public static final DecimalFormat EMC_FORMATTER = new DecimalFormat("#,###.##");
-	public static final DecimalFormat FULL_EMC_FORMATTER = new DecimalFormat("#,###");
+	public static final DecimalFormat SINGLE_DP_EMC_FORMATTER = new DecimalFormat("#,###.#");
 
 	public static final int[] MAX_KLEIN_EMC = new int[] {50000, 200000, 800000, 3200000, 12800000, 51200000};
 	public static final int[] RELAY_KLEIN_CHARGE_RATE = new int[] {16, 48, 160};

--- a/src/main/java/moze_intel/projecte/utils/Constants.java
+++ b/src/main/java/moze_intel/projecte/utils/Constants.java
@@ -4,7 +4,8 @@ import java.text.DecimalFormat;
 
 public final class Constants 
 {
-	public static final DecimalFormat EMC_FORMATTER = new DecimalFormat("#,###.####");
+	public static final DecimalFormat EMC_FORMATTER = new DecimalFormat("#,###.##");
+	public static final DecimalFormat FULL_EMC_FORMATTER = new DecimalFormat("#,###");
 
 	public static final int[] MAX_KLEIN_EMC = new int[] {50000, 200000, 800000, 3200000, 12800000, 51200000};
 	public static final int[] RELAY_KLEIN_CHARGE_RATE = new int[] {16, 48, 160};

--- a/src/main/java/moze_intel/projecte/utils/TransmutationEMCFormatter.java
+++ b/src/main/java/moze_intel/projecte/utils/TransmutationEMCFormatter.java
@@ -5,7 +5,7 @@ public class TransmutationEMCFormatter {
 		String postFix = "";
 		double magnitude = 1;
 
-		String formats[] = {"Q", "T","B"};
+		String formats[] = {"Quadrillion", "Trillion", "Billion"};
 		Double magnitudes[] = {1e15, 1e12, 1e9};
 
 		for (int i=0; i <formats.length; i++) {
@@ -17,6 +17,6 @@ public class TransmutationEMCFormatter {
 			}
 		}
 
-		return Constants.EMC_FORMATTER.format(EMC / magnitude) + postFix;
+		return Constants.EMC_FORMATTER.format(EMC / magnitude) + " " + postFix;
 	}
 }

--- a/src/main/java/moze_intel/projecte/utils/TransmutationEMCFormatter.java
+++ b/src/main/java/moze_intel/projecte/utils/TransmutationEMCFormatter.java
@@ -7,9 +7,9 @@ public class TransmutationEMCFormatter {
 		String postFix = "";
 		double magnitude = 1;
 
-		Double magnitudes[] = {1e18, 1e15, 1e12};
+		Double magnitudes[] = {1e12, 1e15, 1e18};
 
-		for (int i=0; i < magnitudes.length; i++) {
+		for (int i=magnitudes.length - 1; i >= 0; i--) {
 			double testMag = magnitudes[i];
 			if (EMC >= testMag) {
 				magnitude = testMag;

--- a/src/main/java/moze_intel/projecte/utils/TransmutationEMCFormatter.java
+++ b/src/main/java/moze_intel/projecte/utils/TransmutationEMCFormatter.java
@@ -1,18 +1,19 @@
 package moze_intel.projecte.utils;
 
+import net.minecraft.client.resources.I18n;
+
 public class TransmutationEMCFormatter {
 	public static String EMCFormat(double EMC) {
 		String postFix = "";
 		double magnitude = 1;
 
-		String formats[] = {"Quintillion", "Quadrillion", "Trillion"};
 		Double magnitudes[] = {1e18, 1e15, 1e12};
 
-		for (int i=0; i <formats.length; i++) {
+		for (int i=0; i < magnitudes.length; i++) {
 			double testMag = magnitudes[i];
 			if (EMC >= testMag) {
 				magnitude = testMag;
-				postFix = formats[i];
+				postFix =  I18n.format("pe.emc.postfix." + i);
 				break;
 			}
 		}

--- a/src/main/java/moze_intel/projecte/utils/TransmutationEMCFormatter.java
+++ b/src/main/java/moze_intel/projecte/utils/TransmutationEMCFormatter.java
@@ -1,0 +1,22 @@
+package moze_intel.projecte.utils;
+
+public class TransmutationEMCFormatter {
+	public static String EMCFormat(double EMC) {
+		String postFix = "";
+		double magnitude = 1;
+
+		String formats[] = {"Q", "T","B"};
+		Double magnitudes[] = {1e15, 1e12, 1e9};
+
+		for (int i=0; i <formats.length; i++) {
+			double testMag = magnitudes[i];
+			if (EMC >= testMag) {
+				magnitude = testMag;
+				postFix = formats[i];
+				break;
+			}
+		}
+
+		return Constants.EMC_FORMATTER.format(EMC / magnitude) + postFix;
+	}
+}

--- a/src/main/java/moze_intel/projecte/utils/TransmutationEMCFormatter.java
+++ b/src/main/java/moze_intel/projecte/utils/TransmutationEMCFormatter.java
@@ -5,8 +5,8 @@ public class TransmutationEMCFormatter {
 		String postFix = "";
 		double magnitude = 1;
 
-		String formats[] = {"Quadrillion", "Trillion"};
-		Double magnitudes[] = {1e15, 1e12};
+		String formats[] = {"Quintillion", "Quadrillion", "Trillion"};
+		Double magnitudes[] = {1e18, 1e15, 1e12};
 
 		for (int i=0; i <formats.length; i++) {
 			double testMag = magnitudes[i];

--- a/src/main/java/moze_intel/projecte/utils/TransmutationEMCFormatter.java
+++ b/src/main/java/moze_intel/projecte/utils/TransmutationEMCFormatter.java
@@ -5,8 +5,8 @@ public class TransmutationEMCFormatter {
 		String postFix = "";
 		double magnitude = 1;
 
-		String formats[] = {"Quadrillion", "Trillion", "Billion"};
-		Double magnitudes[] = {1e15, 1e12, 1e9};
+		String formats[] = {"Quadrillion", "Trillion"};
+		Double magnitudes[] = {1e15, 1e12};
 
 		for (int i=0; i <formats.length; i++) {
 			double testMag = magnitudes[i];
@@ -17,6 +17,6 @@ public class TransmutationEMCFormatter {
 			}
 		}
 
-		return Constants.EMC_FORMATTER.format(EMC / magnitude) + " " + postFix;
+		return Constants.SINGLE_DP_EMC_FORMATTER.format(EMC / magnitude) + " " + postFix;
 	}
 }

--- a/src/main/resources/assets/projecte/lang/de_de.lang
+++ b/src/main/resources/assets/projecte/lang/de_de.lang
@@ -206,9 +206,9 @@ pe.emc.rate=EMC/s
 pe.emc.stackemc_tooltip_prefix=Stack-EMC:
 pe.emc.storedemc_tooltip=Gespeicherte EMC:
 pe.emc.too_much=VIEL ZU VIEL
-pe.emc.postfix.0=Trillion
+pe.emc.postfix.0=Billion
 pe.emc.postfix.1=Billiarde
-pe.emc.postfix.2=Billion
+pe.emc.postfix.2=Trillion
 
 pe.evertide.tooltip1=Drücke %s, um ein Wasserprojektil zu feuern.
 pe.evertide.tooltip2=Funktioniert wie ein unendlicher Wassereimer.

--- a/src/main/resources/assets/projecte/lang/de_de.lang
+++ b/src/main/resources/assets/projecte/lang/de_de.lang
@@ -206,6 +206,9 @@ pe.emc.rate=EMC/s
 pe.emc.stackemc_tooltip_prefix=Stack-EMC:
 pe.emc.storedemc_tooltip=Gespeicherte EMC:
 pe.emc.too_much=VIEL ZU VIEL
+pe.emc.postfix.0=Trillion
+pe.emc.postfix.1=Billiarde
+pe.emc.postfix.2=Billion
 
 pe.evertide.tooltip1=Drücke %s, um ein Wasserprojektil zu feuern.
 pe.evertide.tooltip2=Funktioniert wie ein unendlicher Wassereimer.

--- a/src/main/resources/assets/projecte/lang/en_us.lang
+++ b/src/main/resources/assets/projecte/lang/en_us.lang
@@ -213,6 +213,9 @@ pe.emc.rate=EMC/s
 pe.emc.stackemc_tooltip_prefix=Stack EMC:
 pe.emc.storedemc_tooltip=Stored EMC:
 pe.emc.too_much=WAY TOO MUCH
+pe.emc.postfix.0=Quintillion
+pe.emc.postfix.1=Quadrillion
+pe.emc.postfix.2=Trillion
 pe.emc.has_knowledge=Transmutable
 
 pe.evertide.tooltip1=Press %s to fire a water projectile

--- a/src/main/resources/assets/projecte/lang/en_us.lang
+++ b/src/main/resources/assets/projecte/lang/en_us.lang
@@ -213,9 +213,9 @@ pe.emc.rate=EMC/s
 pe.emc.stackemc_tooltip_prefix=Stack EMC:
 pe.emc.storedemc_tooltip=Stored EMC:
 pe.emc.too_much=WAY TOO MUCH
-pe.emc.postfix.0=Quintillion
+pe.emc.postfix.0=Trillion
 pe.emc.postfix.1=Quadrillion
-pe.emc.postfix.2=Trillion
+pe.emc.postfix.2=Quintillion
 pe.emc.has_knowledge=Transmutable
 
 pe.evertide.tooltip1=Press %s to fire a water projectile

--- a/src/main/resources/assets/projecte/lang/fr_fr.lang
+++ b/src/main/resources/assets/projecte/lang/fr_fr.lang
@@ -207,9 +207,9 @@ pe.emc.rate=EMC/s
 pe.emc.stackemc_tooltip_prefix=Stack d'EMC:
 pe.emc.storedemc_tooltip=EMC stockés:
 pe.emc.too_much=BEAUCOUP TROP
-pe.emc.postfix.0=Quintillion
+pe.emc.postfix.0=Billion
 pe.emc.postfix.1=Quadrillions
-pe.emc.postfix.2=Billion
+pe.emc.postfix.2=Quintillion
 pe.emc.has_knowledge=Transmutable
 
 pe.evertide.tooltip1=Appuyez sur %s pour tirer un projectile d'eau

--- a/src/main/resources/assets/projecte/lang/fr_fr.lang
+++ b/src/main/resources/assets/projecte/lang/fr_fr.lang
@@ -207,6 +207,9 @@ pe.emc.rate=EMC/s
 pe.emc.stackemc_tooltip_prefix=Stack d'EMC:
 pe.emc.storedemc_tooltip=EMC stockés:
 pe.emc.too_much=BEAUCOUP TROP
+pe.emc.postfix.0=Quintillion
+pe.emc.postfix.1=Quadrillions
+pe.emc.postfix.2=Billion
 pe.emc.has_knowledge=Transmutable
 
 pe.evertide.tooltip1=Appuyez sur %s pour tirer un projectile d'eau

--- a/src/main/resources/assets/projecte/lang/pt_br.lang
+++ b/src/main/resources/assets/projecte/lang/pt_br.lang
@@ -206,9 +206,9 @@ pe.emc.rate=EMC/s
 pe.emc.stackemc_tooltip_prefix=EMC da Stack:
 pe.emc.storedemc_tooltip=EMC Armazenado:
 pe.emc.too_much=MUITO MESMO
-pe.emc.postfix.0=Quintilhão
+pe.emc.postfix.0=Trilhão
 pe.emc.postfix.1=Quadrilhão
-pe.emc.postfix.2=Trilhão
+pe.emc.postfix.2=Quintilhão
 
 pe.evertide.tooltip1=Pressione %s para atirar um projétil de água
 pe.evertide.tooltip2=Age como um balde d'água infinito

--- a/src/main/resources/assets/projecte/lang/pt_br.lang
+++ b/src/main/resources/assets/projecte/lang/pt_br.lang
@@ -206,6 +206,9 @@ pe.emc.rate=EMC/s
 pe.emc.stackemc_tooltip_prefix=EMC da Stack:
 pe.emc.storedemc_tooltip=EMC Armazenado:
 pe.emc.too_much=MUITO MESMO
+pe.emc.postfix.0=Quintilhão
+pe.emc.postfix.1=Quadrilhão
+pe.emc.postfix.2=Trilhão
 
 pe.evertide.tooltip1=Pressione %s para atirar um projétil de água
 pe.evertide.tooltip2=Age como um balde d'água infinito

--- a/src/main/resources/assets/projecte/lang/ru_ru.lang
+++ b/src/main/resources/assets/projecte/lang/ru_ru.lang
@@ -245,6 +245,9 @@ pe.emc.rate=EMC/сек
 pe.emc.stackemc_tooltip_prefix=EMC в стеке:
 pe.emc.storedemc_tooltip=Накоплено EMC:
 pe.emc.too_much=СЛИШКОМ МНОГО
+pe.emc.postfix.0=нониллион
+pe.emc.postfix.1=квадрильон
+pe.emc.postfix.2=триллион
 
 pe.evertide.tooltip1=Нажмите %s, чтобы выпустить водный снаряд
 pe.evertide.tooltip2=Работает как бесконечное ведро воды

--- a/src/main/resources/assets/projecte/lang/ru_ru.lang
+++ b/src/main/resources/assets/projecte/lang/ru_ru.lang
@@ -245,9 +245,9 @@ pe.emc.rate=EMC/сек
 pe.emc.stackemc_tooltip_prefix=EMC в стеке:
 pe.emc.storedemc_tooltip=Накоплено EMC:
 pe.emc.too_much=СЛИШКОМ МНОГО
-pe.emc.postfix.0=нониллион
+pe.emc.postfix.0=триллион
 pe.emc.postfix.1=квадрильон
-pe.emc.postfix.2=триллион
+pe.emc.postfix.2=нониллион
 
 pe.evertide.tooltip1=Нажмите %s, чтобы выпустить водный снаряд
 pe.evertide.tooltip2=Работает как бесконечное ведро воды

--- a/src/main/resources/assets/projecte/lang/uk_ua.lang
+++ b/src/main/resources/assets/projecte/lang/uk_ua.lang
@@ -203,6 +203,9 @@ pe.emc.rate=EMC/сек
 pe.emc.stackemc_tooltip_prefix=Stack EMC:
 pe.emc.storedemc_tooltip=Накопичено EMC:
 pe.emc.too_much=ЗАНАДТО БАГАТО
+pe.emc.postfix.0=Quintillion
+pe.emc.postfix.1=квадрильйон
+pe.emc.postfix.2=Трильйон
 
 pe.evertide.tooltip1=Натисніть %s, аби вистрілити водним снарядом
 pe.evertide.tooltip2=Працює як нескінченне відро води

--- a/src/main/resources/assets/projecte/lang/uk_ua.lang
+++ b/src/main/resources/assets/projecte/lang/uk_ua.lang
@@ -203,9 +203,9 @@ pe.emc.rate=EMC/сек
 pe.emc.stackemc_tooltip_prefix=Stack EMC:
 pe.emc.storedemc_tooltip=Накопичено EMC:
 pe.emc.too_much=ЗАНАДТО БАГАТО
-pe.emc.postfix.0=Quintillion
+pe.emc.postfix.0=Трильйон
 pe.emc.postfix.1=квадрильйон
-pe.emc.postfix.2=Трильйон
+pe.emc.postfix.2=Quintillion
 
 pe.evertide.tooltip1=Натисніть %s, аби вистрілити водним снарядом
 pe.evertide.tooltip2=Працює як нескінченне відро води


### PR DESCRIPTION
Originally the EMC value label on the transmutation table would overflow into and past the forget slot as shown:

![screen shot 2018-12-02 at 12 04 08](https://user-images.githubusercontent.com/7097016/49344005-49683380-f637-11e8-9d93-70e3b78b4abf.png) 

However with modern modpacks such a stoneblock that includemods such as roost and RFDimensions, it is getting easier to surpass 1 billion EMC. To fix this I have added abbreviations once the EMC wealth surpasses 1 Billion to clean up the UI:

![screen shot 2018-12-02 at 13 38 38](https://user-images.githubusercontent.com/7097016/49344025-99df9100-f637-11e8-9aa8-939baa916da5.png)

My code is easily expandable as there are two parallel arrays describing the abbreviations within TransmutationEMCFormatter.java. The number of decimal places are decided through the DecimalFormatter within constants.