### PR TITLE
Fixes Collector Category in Single Player

### DIFF
--- a/src/main/java/moze_intel/projecte/integration/jei/PEJeiPlugin.java
+++ b/src/main/java/moze_intel/projecte/integration/jei/PEJeiPlugin.java
@@ -64,7 +64,7 @@ public class PEJeiPlugin implements IModPlugin
 
     public static void refresh()
     {
-        if (FMLCommonHandler.instance().getEffectiveSide().isClient())
+        if (FMLCommonHandler.instance().getSide().isClient())
         {
             Minecraft.getMinecraft().addScheduledTask(() -> mappers.forEach(JEICompatMapper::refresh));
         }


### PR DESCRIPTION
When making changes I had forgotten to double check and test in single player. Apparently even with JEI it doesn't work on the released version. Current dev branch does not crash, but just does not display the Collector Category for fuel upgrades in JEI at all. This fixes that. I also tested a bunch of combinations of client + server as well to make sure this didn't break anything else.