### PR TITLE
Philo stone crafting QoL

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/PhilosStoneContainer.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/PhilosStoneContainer.java
@@ -59,15 +59,7 @@ public class PhilosStoneContainer extends Container
 
 		if (!this.worldObj.isRemote)
 		{
-			for (int i = 0; i < 9; ++i)
-			{
-				ItemStack itemstack = this.craftMatrix.removeStackFromSlot(i);
-
-				if (!itemstack.isEmpty())
-				{
-					player.dropItem(itemstack, false);
-				}
-			}
+			this.clearContainer(player, this.worldObj, this.craftMatrix);
 		}
 	}
 	

--- a/src/main/java/moze_intel/projecte/integration/jei/PEJeiPlugin.java
+++ b/src/main/java/moze_intel/projecte/integration/jei/PEJeiPlugin.java
@@ -48,6 +48,7 @@ public class PEJeiPlugin implements IModPlugin
         registry.addRecipes(WorldTransmutations.getWorldTransmutations(), WorldTransmuteRecipeCategory.UID);
         registry.getRecipeTransferRegistry().addRecipeTransferHandler(PhilosStoneContainer.class, VanillaRecipeCategoryUid.CRAFTING, 1, 9, 10, 36);
 
+        registry.addRecipeCatalyst(new ItemStack(ObjHandler.philosStone, 1), VanillaRecipeCategoryUid.CRAFTING);
         registry.addRecipeCatalyst(new ItemStack(ObjHandler.philosStone, 1), WorldTransmuteRecipeCategory.UID);
         registry.addRecipeCatalyst(new ItemStack(ObjHandler.collectorMK1, 1), CollectorRecipeCategory.UID);
         registry.addRecipeCatalyst(new ItemStack(ObjHandler.collectorMK2, 1), CollectorRecipeCategory.UID);


### PR DESCRIPTION
Shows the philosopher stone on the left hand side in JEI as a possible type of Crafting Table.
Also changes the PhiloStoneContainer to match how ContainerWorkbench works on closing. As of 1.12 when a Crafting grid is closed (2x2 player or 3x3 crafting table) it returns the items in the gui to the player rather than dropping them on the ground. This makes the philosopher's stone crafting grid do the same.