### PR TITLE
Add CrT support for Philo Stone Entity Randomizer

### DIFF
--- a/src/main/java/moze_intel/projecte/integration/crafttweaker/EntityRandomizer.java
+++ b/src/main/java/moze_intel/projecte/integration/crafttweaker/EntityRandomizer.java
@@ -1,0 +1,84 @@
+package moze_intel.projecte.integration.crafttweaker;
+
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.entity.IEntityDefinition;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraftforge.fml.common.registry.EntityEntry;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenRegister
+@ZenClass("mods.projecte.EntityRandomizer")
+public class EntityRandomizer
+{
+    @ZenMethod
+    public static void addPeaceful(IEntityDefinition entityDefinition)
+    {
+        Class<? extends EntityLiving> living = getLiving(entityDefinition);
+        if (isLiving(living)) {
+            CraftTweakerAPI.apply(new EntityRandomizerAction.Add(living, entityDefinition.getName(), true));
+        }
+    }
+
+    @ZenMethod
+    public static void removePeaceful(IEntityDefinition entityDefinition)
+    {
+        Class<? extends EntityLiving> living = getLiving(entityDefinition);
+        if (isLiving(living)) {
+            CraftTweakerAPI.apply(new EntityRandomizerAction.Remove(living, entityDefinition.getName(), true));
+        }
+    }
+
+    @ZenMethod
+    public static void clearPeacefuls()
+    {
+        CraftTweakerAPI.apply(new EntityRandomizerAction.Clear(true));
+    }
+
+    @ZenMethod
+    public static void addMob(IEntityDefinition entityDefinition)
+    {
+        Class<? extends EntityLiving> living = getLiving(entityDefinition);
+        if (isLiving(living)) {
+            CraftTweakerAPI.apply(new EntityRandomizerAction.Add(living, entityDefinition.getName(), false));
+        }
+    }
+
+    @ZenMethod
+    public static void removeMob(IEntityDefinition entityDefinition)
+    {
+        Class<? extends EntityLiving> living = getLiving(entityDefinition);
+        if (isLiving(living)) {
+            CraftTweakerAPI.apply(new EntityRandomizerAction.Remove(living, entityDefinition.getName(), false));
+        }
+    }
+
+    @ZenMethod
+    public static void clearMobs()
+    {
+        CraftTweakerAPI.apply(new EntityRandomizerAction.Clear(false));
+    }
+
+    private static Class<? extends EntityLiving> getLiving(IEntityDefinition entityDefinition) {
+        if (entityDefinition == null) {
+            return null;
+        }
+        EntityEntry entry = (EntityEntry) entityDefinition.getInternal();
+        Class<? extends Entity> entityClass = entry.getEntityClass();
+        if (EntityLiving.class.isAssignableFrom(entityClass)) {
+            return (Class<? extends EntityLiving>) entityClass;
+        }
+        return null;
+    }
+
+    private static boolean isLiving(Class<? extends EntityLiving> living) {
+        if (living == null)
+        {
+            CraftTweakerAPI.logError("IEntityDefinition must be of a living entity.");
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/moze_intel/projecte/integration/crafttweaker/EntityRandomizerAction.java
+++ b/src/main/java/moze_intel/projecte/integration/crafttweaker/EntityRandomizerAction.java
@@ -1,0 +1,83 @@
+package moze_intel.projecte.integration.crafttweaker;
+
+import crafttweaker.IAction;
+import moze_intel.projecte.utils.WorldHelper;
+import net.minecraft.entity.EntityLiving;
+
+abstract class EntityRandomizerAction implements IAction {
+    final boolean peaceful;
+
+    EntityRandomizerAction(boolean peaceful) {
+        this.peaceful = peaceful;
+    }
+
+    static class Add extends EntityRandomizerAction {
+        private final Class<? extends EntityLiving> living;
+        private final String typeName;
+
+        Add(Class<? extends EntityLiving> living, String typeName, boolean peaceful) {
+            super(peaceful);
+            this.living = living;
+            this.typeName = typeName;
+        }
+
+        @Override
+        public void apply() {
+            if (this.peaceful) {
+                WorldHelper.addPeaceful(living);
+            } else {
+                WorldHelper.addMob(living);
+            }
+        }
+
+        @Override
+        public String describe() {
+            return "Added " + this.typeName + " to the " + (this.peaceful ? "peaceful" : "hostile") + " Philosopher Stone Entity Randomizer.";
+        }
+    }
+
+    static class Remove extends EntityRandomizerAction {
+        private final Class<? extends EntityLiving> living;
+        private final String typeName;
+
+        Remove(Class<? extends EntityLiving> living, String typeName, boolean peaceful) {
+            super(peaceful);
+            this.living = living;
+            this.typeName = typeName;
+        }
+
+        @Override
+        public void apply() {
+            if (this.peaceful) {
+                WorldHelper.removePeaceful(this.living);
+            } else {
+                WorldHelper.removeMob(this.living);
+            }
+        }
+
+        @Override
+        public String describe() {
+            return "Removed " + this.typeName + " from the " + (this.peaceful ? "peaceful" : "hostile") + " Philosopher Stone Entity Randomizer.";
+        }
+    }
+
+    static class Clear extends EntityRandomizerAction {
+        Clear(boolean peaceful) {
+            super(peaceful);
+        }
+
+        @Override
+        public void apply() {
+            if (this.peaceful) {
+                WorldHelper.clearPeacefuls();
+            } else {
+                WorldHelper.clearMobs();
+            }
+        }
+
+        @Override
+        public String describe() {
+            return "Cleared the " + (this.peaceful ? "peaceful" : "hostile") + " Philosopher Stone Entity Randomizer.";
+        }
+    }
+}

--- a/src/main/java/moze_intel/projecte/utils/CollectionHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/CollectionHelper.java
@@ -10,6 +10,10 @@ public final class CollectionHelper
 {
 	public static <T> T getRandomListEntry(List<T> list, T toExclude)
 	{
+		if (list.size() == 1 && list.contains(toExclude))
+		{
+			return toExclude;
+		}
 		T obj;
 
 		do

--- a/src/main/java/moze_intel/projecte/utils/WorldHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/WorldHelper.java
@@ -1,6 +1,5 @@
 package moze_intel.projecte.utils;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import moze_intel.projecte.PECore;
 import moze_intel.projecte.config.ProjectEConfig;
@@ -62,8 +61,7 @@ import java.util.Set;
  */
 public final class WorldHelper
 {
-	@SuppressWarnings("unchecked")
-	private static final ImmutableList<Class<? extends EntityLiving>> peacefuls = ImmutableList.of(
+	private static final List<Class<? extends EntityLiving>> peacefuls = Lists.newArrayList(
 			EntitySheep.class, EntityPig.class, EntityCow.class,
 			EntityMooshroom.class, EntityChicken.class, EntityBat.class,
 			EntityVillager.class, EntitySquid.class, EntityOcelot.class,
@@ -72,8 +70,7 @@ public final class WorldHelper
 			EntityLlama.class, EntityParrot.class
 	);
 
-	@SuppressWarnings("unchecked")
-	private static final ImmutableList<Class<? extends EntityLiving>> mobs = ImmutableList.of(
+	private static final List<Class<? extends EntityLiving>> mobs = Lists.newArrayList(
 			EntityZombie.class, EntitySkeleton.class, EntityCreeper.class,
 			EntitySpider.class, EntityEnderman.class, EntitySilverfish.class,
 			EntityPigZombie.class, EntityGhast.class, EntityBlaze.class,
@@ -105,6 +102,46 @@ public final class WorldHelper
 			return true;
 		}
 		return false;
+	}
+
+	public static boolean addPeaceful(Class<? extends EntityLiving> clazz)
+	{
+		if (!peacefuls.contains(clazz))
+		{
+			peacefuls.add(clazz);
+			return true;
+		}
+		return false;
+	}
+
+	public static boolean removePeaceful(Class<? extends EntityLiving> clazz)
+	{
+		return peacefuls.remove(clazz);
+	}
+
+	public static void clearPeacefuls()
+	{
+		peacefuls.clear();
+	}
+
+	public static boolean addMob(Class<? extends EntityLiving> clazz)
+	{
+		if (!mobs.contains(clazz))
+		{
+			mobs.add(clazz);
+			return true;
+		}
+		return false;
+	}
+
+	public static boolean removeMob(Class<? extends EntityLiving> clazz)
+	{
+		return mobs.remove(clazz);
+	}
+
+	public static void clearMobs()
+	{
+		mobs.clear();
 	}
 
 	public static void createLootDrop(List<ItemStack> drops, World world, BlockPos pos)


### PR DESCRIPTION
Added a safety check to avoid an infinite loop in CollectionHelper if the list is of size 1 containing the element to exclude. In that specific case it ignores the exclusion request,

I will also add documentation later to the CrT docs documenting the different options and how to use the methods.