### PR TITLE
Fixed some items with NBT showing up multiple times in Transmutation GUI

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
@@ -170,7 +170,7 @@ public class TransmutationInventory extends CombinedInvWrapper
 
 			if (lockCopy.hasTagCompound() && !NBTWhitelist.shouldDupeWithNBT(lockCopy))
 			{
-				lockCopy.setTagCompound(new NBTTagCompound());
+				lockCopy.setTagCompound(null);
 			}
 			
 			Iterator<ItemStack> iter = knowledge.iterator();

--- a/src/main/java/moze_intel/projecte/impl/KnowledgeImpl.java
+++ b/src/main/java/moze_intel/projecte/impl/KnowledgeImpl.java
@@ -168,7 +168,7 @@ public final class KnowledgeImpl {
 
             while (iter.hasNext())
             {
-                if (ItemStack.areItemStacksEqual(stack, iter.next()))
+                if (ItemHelper.basicAreStacksEqual(stack, iter.next()))
                 {
                     iter.remove();
                     removed = true;
@@ -256,6 +256,7 @@ public final class KnowledgeImpl {
 
         private void pruneDuplicateKnowledge()
         {
+            ItemHelper.removeEmptyTags(knowledge);
             ItemHelper.compactItemListNoStacksize(knowledge);
             for (ItemStack s : knowledge)
             {

--- a/src/main/java/moze_intel/projecte/utils/ItemHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/ItemHelper.java
@@ -103,6 +103,20 @@ public final class ItemHelper
 		list.sort(Comparators.ITEMSTACK_ASCENDING);
 	}
 
+	/**
+	 * Removes all empty tags from any items in the list.
+	 */
+	public static void removeEmptyTags(List<ItemStack> list)
+	{
+		for (ItemStack s : list)
+		{
+			if (!s.isEmpty() && s.hasTagCompound() && s.getTagCompound().isEmpty())
+			{
+				s.setTagCompound(null);
+			}
+		}
+	}
+
 	public static boolean containsItemStack(List<ItemStack> list, ItemStack toSearch)
 	{
 		for (ItemStack stack : list) {


### PR DESCRIPTION
Bugs with items showing up more than once (such as the philo stone, klein stars, batteries from mods, etc)
Closes #1642 
Closes #1756 
Closes #1790 

Unlearning bug due to the NBT handling not properly seeing a match and causing it to bug out until a restart.
Closes #1783 