### PR TITLE
Improvements to World Transmutation JEI integration

### DIFF
--- a/src/main/java/moze_intel/projecte/integration/jei/PEJeiPlugin.java
+++ b/src/main/java/moze_intel/projecte/integration/jei/PEJeiPlugin.java
@@ -14,7 +14,6 @@ import moze_intel.projecte.integration.jei.collectors.CollectorRecipeCategory;
 import moze_intel.projecte.integration.jei.mappers.JEICompatMapper;
 import moze_intel.projecte.integration.jei.mappers.JEIFuelMapper;
 import moze_intel.projecte.integration.jei.world_transmute.WorldTransmuteRecipeCategory;
-import moze_intel.projecte.utils.WorldTransmutations;
 import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.FMLCommonHandler;
@@ -45,14 +44,14 @@ public class PEJeiPlugin implements IModPlugin
     public void register(@Nonnull IModRegistry registry)
     {
         // todo finish this, add alchbag
-        registry.addRecipes(WorldTransmutations.getWorldTransmutations(), WorldTransmuteRecipeCategory.UID);
+        registry.addRecipes(WorldTransmuteRecipeCategory.getAllTransmutations(), WorldTransmuteRecipeCategory.UID);
         registry.getRecipeTransferRegistry().addRecipeTransferHandler(PhilosStoneContainer.class, VanillaRecipeCategoryUid.CRAFTING, 1, 9, 10, 36);
 
-        registry.addRecipeCatalyst(new ItemStack(ObjHandler.philosStone, 1), VanillaRecipeCategoryUid.CRAFTING);
-        registry.addRecipeCatalyst(new ItemStack(ObjHandler.philosStone, 1), WorldTransmuteRecipeCategory.UID);
-        registry.addRecipeCatalyst(new ItemStack(ObjHandler.collectorMK1, 1), CollectorRecipeCategory.UID);
-        registry.addRecipeCatalyst(new ItemStack(ObjHandler.collectorMK2, 1), CollectorRecipeCategory.UID);
-        registry.addRecipeCatalyst(new ItemStack(ObjHandler.collectorMK3, 1), CollectorRecipeCategory.UID);
+        registry.addRecipeCatalyst(new ItemStack(ObjHandler.philosStone), VanillaRecipeCategoryUid.CRAFTING);
+        registry.addRecipeCatalyst(new ItemStack(ObjHandler.philosStone), WorldTransmuteRecipeCategory.UID);
+        registry.addRecipeCatalyst(new ItemStack(ObjHandler.collectorMK1), CollectorRecipeCategory.UID);
+        registry.addRecipeCatalyst(new ItemStack(ObjHandler.collectorMK2), CollectorRecipeCategory.UID);
+        registry.addRecipeCatalyst(new ItemStack(ObjHandler.collectorMK3), CollectorRecipeCategory.UID);
 
         mappers.add(new JEIFuelMapper());
     }

--- a/src/main/java/moze_intel/projecte/integration/jei/world_transmute/WorldTransmuteEntry.java
+++ b/src/main/java/moze_intel/projecte/integration/jei/world_transmute/WorldTransmuteEntry.java
@@ -1,0 +1,153 @@
+package moze_intel.projecte.integration.jei.world_transmute;
+
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IRecipeWrapper;
+import moze_intel.projecte.utils.WorldTransmutations;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockStaticLiquid;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class WorldTransmuteEntry implements IRecipeWrapper
+{
+	private ItemStack inputItem = ItemStack.EMPTY;
+	private ItemStack leftOutputItem = ItemStack.EMPTY;
+	private ItemStack rightOutputItem = ItemStack.EMPTY;
+	private FluidStack inputFluid;
+	private FluidStack leftOutputFluid;
+	private FluidStack rightOutputFluid;
+	private boolean isValid = true;
+
+	public WorldTransmuteEntry(WorldTransmutations.Entry transmutationEntry)
+	{
+		Block inputBlock = transmutationEntry.input.getBlock();
+		IBlockState leftOutput = transmutationEntry.outputs.getLeft();
+		IBlockState rightOutput = transmutationEntry.outputs.getRight();
+
+		inputFluid = fluidFromBlock(inputBlock);
+		if (inputFluid == null)
+		{
+			inputItem = itemFromBlock(inputBlock, transmutationEntry.input);
+		}
+		if (leftOutput != null)
+		{
+			leftOutputFluid = fluidFromBlock(leftOutput.getBlock());
+			if (leftOutputFluid == null)
+			{
+				leftOutputItem = itemFromBlock(leftOutput.getBlock(), leftOutput);
+			}
+		}
+		if (rightOutput != null)
+		{
+			rightOutputFluid = fluidFromBlock(rightOutput.getBlock());
+			if (rightOutputFluid == null)
+			{
+				rightOutputItem = itemFromBlock(rightOutput.getBlock(), rightOutput);
+			}
+		}
+	}
+
+	private FluidStack fluidFromBlock(Block block)
+	{
+		if (block instanceof BlockStaticLiquid)
+		{
+			if (block == Blocks.WATER)
+			{
+				return new FluidStack(FluidRegistry.WATER, 1000);
+			}
+			else if (block == Blocks.LAVA)
+			{
+				return new FluidStack(FluidRegistry.LAVA, 1000);
+			}
+		}
+		return null;
+	}
+
+	private ItemStack itemFromBlock(Block block, IBlockState state)
+	{
+		ItemStack item = new ItemStack(block);
+		int dropped = block.damageDropped(state);
+		int meta = block.getMetaFromState(state);
+		if (item.getItem().getHasSubtypes() && meta <= dropped)
+		{
+			item = new ItemStack(block, 1, meta);
+		}
+		else if (dropped != 0 || meta != 0)
+		{
+			item = ItemStack.EMPTY;
+			isValid = false;
+		}
+		return item;
+	}
+
+	public boolean isRenderable()
+	{
+		if (!isValid)
+		{
+			return false;
+		}
+		boolean hasInput = inputFluid != null || !inputItem.isEmpty();
+		boolean hasLeftOutput = leftOutputFluid != null || !leftOutputItem.isEmpty();
+		boolean hasRightOutput = rightOutputFluid != null || !rightOutputItem.isEmpty();
+		return hasInput && (hasLeftOutput || hasRightOutput);
+	}
+
+	@Override
+	public void getIngredients(@Nonnull IIngredients ingredients) {
+		if (inputFluid != null)
+		{
+			ingredients.setInput(FluidStack.class, inputFluid);
+		}
+		if (!inputItem.isEmpty())
+		{
+			ingredients.setInput(ItemStack.class, inputItem);
+		}
+
+		List<FluidStack> fluidOutputs = new ArrayList<>();
+		if (leftOutputFluid != null)
+		{
+			fluidOutputs.add(leftOutputFluid);
+		}
+		if (rightOutputFluid != null)
+		{
+			fluidOutputs.add(rightOutputFluid);
+		}
+		if (!fluidOutputs.isEmpty())
+		{
+			ingredients.setOutputs(FluidStack.class, fluidOutputs);
+		}
+
+		List<ItemStack> outputList = new ArrayList<>();
+		if (!leftOutputItem.isEmpty())
+		{
+			outputList.add(leftOutputItem);
+		}
+		if (!rightOutputItem.isEmpty())
+		{
+			outputList.add(rightOutputItem);
+		}
+		if (!outputList.isEmpty())
+		{
+			ingredients.setOutputs(ItemStack.class, outputList);
+		}
+	}
+
+	@Override
+	@Nonnull
+	public java.util.List<String> getTooltipStrings(int mouseX, int mouseY)
+	{
+		if (mouseX > 67 && mouseX < 107 && mouseY > 18 && mouseY < 38)
+		{
+			return Collections.singletonList("Click in world, shift click for second output");
+		}
+		return Collections.emptyList();
+	}
+}

--- a/src/main/java/moze_intel/projecte/integration/jei/world_transmute/WorldTransmuteEntry.java
+++ b/src/main/java/moze_intel/projecte/integration/jei/world_transmute/WorldTransmuteEntry.java
@@ -56,23 +56,25 @@ public class WorldTransmuteEntry implements IRecipeWrapper
 
 	private FluidStack fluidFromBlock(Block block)
 	{
-        if (block == Blocks.WATER)
-        {
-            return new FluidStack(FluidRegistry.WATER, 1000);
-        }
-        else if (block == Blocks.LAVA)
-        {
-            return new FluidStack(FluidRegistry.LAVA, 1000);
-        }
+		if (block == Blocks.WATER)
+		{
+			return new FluidStack(FluidRegistry.WATER, 1000);
+		}
+		else if (block == Blocks.LAVA)
+		{
+			return new FluidStack(FluidRegistry.LAVA, 1000);
+		}
 		return null;
 	}
 
 	private ItemStack itemFromBlock(Block block, IBlockState state)
 	{
-		try {
+		try
+		{
 			//We don't have a world or position, but try pick block anyways
 			return block.getPickBlock(state, null, null, null, null);
-		} catch (Exception e) {
+		} catch (Exception e)
+		{
 			//It failed, probably because of the null world and pos
 			ItemStack item = new ItemStack(block);
 			int dropped = block.damageDropped(state);
@@ -93,7 +95,8 @@ public class WorldTransmuteEntry implements IRecipeWrapper
 	}
 
 	@Override
-	public void getIngredients(@Nonnull IIngredients ingredients) {
+	public void getIngredients(@Nonnull IIngredients ingredients)
+	{
 		if (inputFluid != null)
 		{
 			ingredients.setInput(FluidStack.class, inputFluid);

--- a/src/main/java/moze_intel/projecte/integration/jei/world_transmute/WorldTransmuteEntry.java
+++ b/src/main/java/moze_intel/projecte/integration/jei/world_transmute/WorldTransmuteEntry.java
@@ -4,8 +4,8 @@ import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import moze_intel.projecte.utils.WorldTransmutations;
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockStaticLiquid;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -56,17 +56,14 @@ public class WorldTransmuteEntry implements IRecipeWrapper
 
 	private FluidStack fluidFromBlock(Block block)
 	{
-		if (block instanceof BlockStaticLiquid)
-		{
-			if (block == Blocks.WATER)
-			{
-				return new FluidStack(FluidRegistry.WATER, 1000);
-			}
-			else if (block == Blocks.LAVA)
-			{
-				return new FluidStack(FluidRegistry.LAVA, 1000);
-			}
-		}
+        if (block == Blocks.WATER)
+        {
+            return new FluidStack(FluidRegistry.WATER, 1000);
+        }
+        else if (block == Blocks.LAVA)
+        {
+            return new FluidStack(FluidRegistry.LAVA, 1000);
+        }
 		return null;
 	}
 
@@ -141,7 +138,7 @@ public class WorldTransmuteEntry implements IRecipeWrapper
 	{
 		if (mouseX > 67 && mouseX < 107 && mouseY > 18 && mouseY < 38)
 		{
-			return Collections.singletonList("Click in world, shift click for second output");
+			return Collections.singletonList(I18n.format("pe.nei.worldtransmute.description"));
 		}
 		return Collections.emptyList();
 	}

--- a/src/main/java/moze_intel/projecte/integration/jei/world_transmute/WorldTransmuteEntry.java
+++ b/src/main/java/moze_intel/projecte/integration/jei/world_transmute/WorldTransmuteEntry.java
@@ -2,6 +2,7 @@ package moze_intel.projecte.integration.jei.world_transmute;
 
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.IRecipeWrapper;
+import moze_intel.projecte.utils.ItemHelper;
 import moze_intel.projecte.utils.WorldTransmutations;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -76,13 +77,7 @@ public class WorldTransmuteEntry implements IRecipeWrapper
 		} catch (Exception e)
 		{
 			//It failed, probably because of the null world and pos
-			ItemStack item = new ItemStack(block);
-			int dropped = block.damageDropped(state);
-			if (item.getItem().getHasSubtypes() && dropped > 0)
-			{
-				return new ItemStack(block, 1, dropped);
-			}
-			return item;
+			return ItemHelper.stateToStack(state, 1);
 		}
 	}
 

--- a/src/main/java/moze_intel/projecte/integration/jei/world_transmute/WorldTransmuteRecipeCategory.java
+++ b/src/main/java/moze_intel/projecte/integration/jei/world_transmute/WorldTransmuteRecipeCategory.java
@@ -7,11 +7,13 @@ import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.IRecipeCategory;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import moze_intel.projecte.PECore;
+import moze_intel.projecte.utils.ItemHelper;
 import moze_intel.projecte.utils.WorldTransmutations;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
 import javax.annotation.Nonnull;
@@ -136,7 +138,23 @@ public class WorldTransmuteRecipeCategory implements IRecipeCategory
             WorldTransmuteEntry e = new WorldTransmuteEntry(entry);
             if (e.isRenderable())
             {
-                visible.add(e);
+                boolean alreadyHas;
+                FluidStack inputFluid = e.getInputFluid();
+                if (inputFluid != null)
+                {
+                    Fluid fluid = inputFluid.getFluid();
+                    alreadyHas = visible.stream().map(WorldTransmuteEntry::getInputFluid).anyMatch(otherInputFluid -> otherInputFluid != null && fluid == otherInputFluid.getFluid());
+                }
+                else
+                {
+                    ItemStack inputItem = e.getInputItem();
+                    alreadyHas = visible.stream().anyMatch(otherEntry -> ItemHelper.basicAreStacksEqual(inputItem, otherEntry.getInputItem()));
+                }
+                if (!alreadyHas)
+                {
+                    //Only add items that we haven't already had.
+                    visible.add(e);
+                }
             }
         });
         return visible;

--- a/src/main/java/moze_intel/projecte/integration/jei/world_transmute/WorldTransmuteRecipeCategory.java
+++ b/src/main/java/moze_intel/projecte/integration/jei/world_transmute/WorldTransmuteRecipeCategory.java
@@ -7,6 +7,7 @@ import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.IRecipeCategory;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import moze_intel.projecte.PECore;
+import moze_intel.projecte.utils.WorldTransmutations;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
@@ -15,6 +16,7 @@ import net.minecraftforge.fluids.FluidStack;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -122,5 +124,21 @@ public class WorldTransmuteRecipeCategory implements IRecipeCategory
     @Override
     public List<String> getTooltipStrings(int mouseX, int mouseY) {
         return Collections.emptyList();
+    }
+
+    public static List<WorldTransmuteEntry> getAllTransmutations()
+    {
+        List<WorldTransmutations.Entry> allWorldTransmutations = WorldTransmutations.getWorldTransmutations();
+        //All the ones that have a block state that can be rendered in JEI.
+        //For example only render one pumpkin to melon transmutation
+        List<WorldTransmuteEntry> visible = new ArrayList<>();
+        allWorldTransmutations.forEach(entry -> {
+            WorldTransmuteEntry e = new WorldTransmuteEntry(entry);
+            if (e.isRenderable())
+            {
+                visible.add(e);
+            }
+        });
+        return visible;
     }
 }

--- a/src/main/java/moze_intel/projecte/utils/WorldTransmutations.java
+++ b/src/main/java/moze_intel/projecte/utils/WorldTransmutations.java
@@ -1,27 +1,17 @@
 package moze_intel.projecte.utils;
 
-import com.google.common.collect.Lists;
-import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.block.*;
 import net.minecraft.block.properties.IProperty;
-import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.EnumDyeColor;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import net.minecraftforge.fluids.Fluid;
-import net.minecraftforge.fluids.FluidRegistry;
-import net.minecraftforge.fluids.FluidStack;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public final class WorldTransmutations
@@ -215,7 +205,7 @@ public final class WorldTransmutations
 		register(from.getDefaultState(), result.getDefaultState(), altResult == null ? null : altResult.getDefaultState());
 	}
 
-	public static class Entry implements IRecipeWrapper
+	public static class Entry
 	{
 		public final IBlockState input;
 		public final Pair<IBlockState, IBlockState> outputs;
@@ -224,148 +214,6 @@ public final class WorldTransmutations
 		{
 			this.input = from;
 			this.outputs = results;
-		}
-		//TODO: Fix logs, remove duplicate Pumpkin -> Melon (it has one for each facing)
-		@Override
-		public void getIngredients(IIngredients ingredients) {
-
-
-			if((this.input.getProperties().containsKey(BlockHorizontal.FACING) && this.input.getValue(BlockHorizontal.FACING) != EnumFacing.NORTH) ||
-                    this.input.getProperties().containsKey(BlockLog.LOG_AXIS) && this.input.getValue(BlockLog.LOG_AXIS) != BlockLog.EnumAxis.NONE)
-				return;
-
-			List<ItemStack> outputList = new ArrayList<>();
-
-			if(this.input.getBlock() instanceof BlockStaticLiquid || this.outputs.getLeft().getBlock() instanceof BlockStaticLiquid){
-				if(this.input.getBlock() == Blocks.WATER)
-					ingredients.setInput(FluidStack.class, new FluidStack(FluidRegistry.WATER, 1000));
-				else if (this.input.getBlock() == Blocks.LAVA)
-					ingredients.setInput(FluidStack.class, new FluidStack(FluidRegistry.LAVA, 1000));
-				else
-					ingredients.setInput(ItemStack.class, new ItemStack(this.input.getBlock()));
-
-				if(this.outputs.getLeft().getBlock() == Blocks.WATER)
-					ingredients.setOutput(FluidStack.class, new FluidStack(FluidRegistry.WATER, 1000));
-				else if (this.outputs.getLeft().getBlock() == Blocks.LAVA)
-					ingredients.setOutput(FluidStack.class, new FluidStack(FluidRegistry.LAVA, 1000));
-				else
-					ingredients.setOutput(ItemStack.class, new ItemStack(this.outputs.getLeft().getBlock()));
-			}
-
-
-			if(this.input.getProperties().containsKey(BlockColored.COLOR)){
-				ingredients.setInput(ItemStack.class, new ItemStack(this.input.getBlock(),1, this.input.getValue(BlockColored.COLOR).getMetadata()));
-				outputList.add(new ItemStack(this.outputs.getLeft().getBlock(), 1, this.outputs.getLeft().getValue(BlockColored.COLOR).getMetadata()));
-
-				if(this.outputs.getRight() != null)
-					outputList.add(new ItemStack(this.outputs.getRight().getBlock(), 1, this.outputs.getRight().getValue(BlockColored.COLOR).getMetadata()));
-			}
-			else if(this.input.getProperties().containsKey(BlockStone.VARIANT)){
-
-
-					ingredients.setInput(ItemStack.class, new ItemStack(this.input.getBlock(),1, this.input.getValue(BlockStone.VARIANT).getMetadata()));
-
-					if(this.outputs.getLeft().getBlock() == Blocks.COBBLESTONE || this.outputs.getLeft().getBlock() == Blocks.GRASS)
-						outputList.add(new ItemStack(this.outputs.getLeft().getBlock()));
-					else
-						outputList.add(new ItemStack(this.outputs.getLeft().getBlock(), 1, this.outputs.getLeft().getValue(BlockStone.VARIANT).getMetadata()));
-
-					if(this.outputs.getRight() != null){
-						if(this.outputs.getRight().getBlock() == Blocks.COBBLESTONE || this.outputs.getRight().getBlock() == Blocks.GRASS)
-							outputList.add(new ItemStack(this.outputs.getRight().getBlock()));
-						else
-							outputList.add(new ItemStack(this.outputs.getRight().getBlock(), 1, this.outputs.getRight().getValue(BlockStone.VARIANT).getMetadata()));
-					}
-
-
-
-			}
-			else if(this.input.getProperties().containsKey(BlockOldLog.VARIANT)){
-				ingredients.setInput(ItemStack.class, new ItemStack(this.input.getBlock(),1, this.input.getValue(BlockOldLog.VARIANT).getMetadata()));
-
-				if(this.outputs.getLeft().getProperties().containsKey(BlockOldLog.VARIANT))
-					outputList.add(new ItemStack(this.outputs.getLeft().getBlock(), 1, this.outputs.getLeft().getValue(BlockOldLog.VARIANT).getMetadata()));
-				else
-					outputList.add(new ItemStack(this.outputs.getLeft().getBlock(), 1, this.outputs.getLeft().getValue(BlockNewLog.VARIANT).getMetadata() - 4));
-
-				if(this.outputs.getRight() != null){
-					if(this.outputs.getRight().getProperties().containsKey(BlockOldLog.VARIANT))
-						outputList.add(new ItemStack(this.outputs.getRight().getBlock(), 1, this.outputs.getRight().getValue(BlockOldLog.VARIANT).getMetadata()));
-					else
-						outputList.add(new ItemStack(this.outputs.getRight().getBlock(), 1, this.outputs.getRight().getValue(BlockNewLog.VARIANT).getMetadata() - 4));
-				}
-
-			}
-			else if(this.input.getProperties().containsKey(BlockNewLog.VARIANT)){
-				ingredients.setInput(ItemStack.class, new ItemStack(this.input.getBlock(),1, this.input.getValue(BlockNewLog.VARIANT).getMetadata() - 4));
-
-				if(this.outputs.getLeft().getProperties().containsKey(BlockNewLog.VARIANT))
-					outputList.add(new ItemStack(this.outputs.getLeft().getBlock(), 1, this.outputs.getLeft().getValue(BlockNewLog.VARIANT).getMetadata() - 4));
-				else
-					outputList.add(new ItemStack(this.outputs.getLeft().getBlock(), 1, this.outputs.getLeft().getValue(BlockOldLog.VARIANT).getMetadata()));
-
-				if(this.outputs.getRight() != null){
-					if(this.outputs.getRight().getProperties().containsKey(BlockNewLog.VARIANT))
-						outputList.add(new ItemStack(this.outputs.getRight().getBlock(), 1, this.outputs.getRight().getValue(BlockNewLog.VARIANT).getMetadata() - 4));
-					else
-						outputList.add(new ItemStack(this.outputs.getRight().getBlock(), 1, this.outputs.getRight().getValue(BlockOldLog.VARIANT).getMetadata()));
-				}
-
-			}
-			else if(this.input.getProperties().containsKey(BlockOldLeaf.VARIANT)){
-				ingredients.setInput(ItemStack.class, new ItemStack(this.input.getBlock(),1, this.input.getValue(BlockOldLeaf.VARIANT).getMetadata()));
-
-				if(this.outputs.getLeft().getProperties().containsKey(BlockOldLeaf.VARIANT))
-					outputList.add(new ItemStack(this.outputs.getLeft().getBlock(), 1, this.outputs.getLeft().getValue(BlockOldLeaf.VARIANT).getMetadata()));
-				else
-					outputList.add(new ItemStack(this.outputs.getLeft().getBlock(), 1, this.outputs.getLeft().getValue(BlockNewLeaf.VARIANT).getMetadata()));
-				if(this.outputs.getRight() != null)
-					if(this.outputs.getRight().getProperties().containsKey(BlockOldLeaf.VARIANT))
-						outputList.add(new ItemStack(this.outputs.getRight().getBlock(), 1, this.outputs.getRight().getValue(BlockOldLeaf.VARIANT).getMetadata()));
-					else
-						outputList.add(new ItemStack(this.outputs.getRight().getBlock(), 1, this.outputs.getRight().getValue(BlockNewLeaf.VARIANT).getMetadata()));
-			}
-			else if(this.input.getProperties().containsKey(BlockNewLeaf.VARIANT)){
-				ingredients.setInput(ItemStack.class, new ItemStack(this.input.getBlock(),1, this.input.getValue(BlockNewLeaf.VARIANT).getMetadata()));
-
-				if(this.outputs.getLeft().getProperties().containsKey(BlockNewLeaf.VARIANT))
-					outputList.add(new ItemStack(this.outputs.getLeft().getBlock(), 1, this.outputs.getLeft().getValue(BlockNewLeaf.VARIANT).getMetadata()));
-				else
-					outputList.add(new ItemStack(this.outputs.getLeft().getBlock(), 1, this.outputs.getLeft().getValue(BlockOldLeaf.VARIANT).getMetadata()));
-				if(this.outputs.getRight() != null){
-					if(this.outputs.getRight().getProperties().containsKey(BlockNewLeaf.VARIANT))
-						outputList.add(new ItemStack(this.outputs.getRight().getBlock(), 1, this.outputs.getRight().getValue(BlockNewLeaf.VARIANT).getMetadata()));
-					else
-						outputList.add(new ItemStack(this.outputs.getRight().getBlock(), 1, this.outputs.getRight().getValue(BlockNewLeaf.VARIANT).getMetadata()));
-				}
-
-			}
-			else if(this.input.getProperties().containsKey(BlockSapling.TYPE)){
-				ingredients.setInput(ItemStack.class, new ItemStack(this.input.getBlock(),1, this.input.getValue(BlockSapling.TYPE).getMetadata()));
-				outputList.add(new ItemStack(this.outputs.getLeft().getBlock(), 1, this.outputs.getLeft().getValue(BlockSapling.TYPE).getMetadata()));
-
-				if(this.outputs.getRight() != null)
-					outputList.add(new ItemStack(this.outputs.getRight().getBlock(), 1, this.outputs.getRight().getValue(BlockSapling.TYPE).getMetadata()));
-			}
-			else{
-				ingredients.setInput(ItemStack.class, new ItemStack(this.input.getBlock()));
-				outputList.add(new ItemStack(this.outputs.getLeft().getBlock()));
-
-				if(this.outputs.getRight() != null)
-					outputList.add(new ItemStack(this.outputs.getRight().getBlock()));
-			}
-
-			ingredients.setOutputs(ItemStack.class, outputList);
-		}
-
-		@Override
-		public java.util.List<String> getTooltipStrings(int mouseX, int mouseY) {
-
-			if(mouseX > 67 && mouseX < 107)
-				if(mouseY > 18 && mouseY < 38)
-					return Collections.singletonList("Click in world, shift click for second output");
-
-			return Collections.emptyList();
 		}
 	}
 }

--- a/src/main/resources/assets/projecte/lang/en_us.lang
+++ b/src/main/resources/assets/projecte/lang/en_us.lang
@@ -370,6 +370,7 @@ pe.zero.pedestal3=Activates every %s
 pe.debug.metainvalid.name=Invalid metadata set
 
 pe.nei.worldtransmute=World Transmutation
+pe.nei.worldtransmute.description=Click in world, shift click for second output
 pe.nei.philo=Philosopher's Stone Smelting
 pe.nei.collector=Collector Fuel Upgrades
 


### PR DESCRIPTION
Moves the JEI recipe wrapper for world transmutation out of the WorldTransmutations class so as to not cause crashes without JEI installed. This could have been done with the Optional interface, except I decided to also revamp the recipe category so that it is more programatic for generating the list of items, rather than having lots of hard coded conditions. It also no longer shows a bunch of blank entries for transmutaions of alternate states of blocks (such as rotated logs or pumpkins).