### PR TITLE
Fix a copy paste error

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/CollectorMK1Container.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/CollectorMK1Container.java
@@ -73,7 +73,7 @@ public class CollectorMK1Container extends LongContainer
 		PacketHandler.sendProgressBarUpdateLong(listener, this, 1, (long) tile.getStoredEmc());
 		PacketHandler.sendProgressBarUpdateInt(listener, this, 2, (int) (tile.getItemChargeProportion() * 8000));
 		PacketHandler.sendProgressBarUpdateInt(listener, this, 3, (int) (tile.getFuelProgress() * 8000));
-		PacketHandler.sendProgressBarUpdateInt(listener, this, 4, (int) (tile.getItemCharge() * 8000));
+		PacketHandler.sendProgressBarUpdateInt(listener, this, 4, (int) tile.getItemCharge());
 	}
 
 	@Nonnull


### PR DESCRIPTION
Unlike with `getItemChargeProportion` and `getFuelProgress`, `getItemCharge` is not a number between 0, and 1 even though it is a double. Initially when this line was [written](https://github.com/sinkillerj/ProjectE/commit/6dfbd6cac8f3c505697f41f1f9a645f955b2262a#diff-120d82f9c344e998969504c3c6fbbb3dR73) the 8000 got copy pasted here. But unlike the other two variables, this one does not get multiplied in other locations, or get divided by 8000 again on receiving.

I originally was going to include this fix in #1818, but I decided that it is probably better to keep it separate for readability.