### PR TITLE
Display mode on Philosopher Stone

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/PhilosophersStone.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/PhilosophersStone.java
@@ -118,8 +118,8 @@ public class PhilosophersStone extends ItemMode implements IProjectileShooter, I
 	@SideOnly(Side.CLIENT)
 	public void addInformation(ItemStack stack, World world, List<String> list, ITooltipFlag flags)
 	{
-		list.add(I18n.format("pe.philstone.tooltip1", ClientKeyHelper.getKeyName(PEKeybind.EXTRA_FUNCTION)));
 		super.addInformation(stack, world, list, flags);
+		list.add(I18n.format("pe.philstone.tooltip1", ClientKeyHelper.getKeyName(PEKeybind.EXTRA_FUNCTION)));
 	}
 
 	public static Set<BlockPos> getAffectedPositions(World world, BlockPos pos, EntityPlayer player, EnumFacing sideHit, int mode, int charge)

--- a/src/main/java/moze_intel/projecte/gameObjs/items/PhilosophersStone.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/PhilosophersStone.java
@@ -119,6 +119,7 @@ public class PhilosophersStone extends ItemMode implements IProjectileShooter, I
 	public void addInformation(ItemStack stack, World world, List<String> list, ITooltipFlag flags)
 	{
 		list.add(I18n.format("pe.philstone.tooltip1", ClientKeyHelper.getKeyName(PEKeybind.EXTRA_FUNCTION)));
+		super.addInformation(stack, world, list, flags);
 	}
 
 	public static Set<BlockPos> getAffectedPositions(World world, BlockPos pos, EntityPlayer player, EnumFacing sideHit, int mode, int charge)


### PR DESCRIPTION
Until I was looking at the formatting and to see if ItemMode supported localizing the mode names for #1824, I was not aware that the Philosopher's Stone even had modes. This makes it more clear by adding the current mode back into the tooltip. My guess is this was lost when it was overwritten to display the information about opening the crafting grid.