### PR TITLE
Go past MAX_LONG for calculating stack EMC Tooltip

### DIFF
--- a/src/main/java/moze_intel/projecte/events/ToolTipEvent.java
+++ b/src/main/java/moze_intel/projecte/events/ToolTipEvent.java
@@ -81,7 +81,7 @@ public class ToolTipEvent
 				{
 					event.getToolTip().add(TextFormatting.YELLOW + I18n.format("pe.emc.stackemc_tooltip_prefix") + " " +
 							TextFormatting.WHITE + Constants.EMC_FORMATTER.format(BigInteger.valueOf(value).multiply(BigInteger.valueOf(current.getCount()))) +
-							TextFormatting.BLUE + EMCHelper.getEmcSellStringBig(current, current.getCount()));
+							TextFormatting.BLUE + EMCHelper.getEmcSellString(current, current.getCount()));
 				}
 
 				if (GuiScreen.isShiftKeyDown()

--- a/src/main/java/moze_intel/projecte/events/ToolTipEvent.java
+++ b/src/main/java/moze_intel/projecte/events/ToolTipEvent.java
@@ -24,6 +24,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.oredict.OreDictionary;
 
+import java.math.BigInteger;
 import java.util.List;
 
 @Mod.EventBusSubscriber(value = Side.CLIENT, modid = PECore.MODID)
@@ -78,21 +79,9 @@ public class ToolTipEvent
 
 				if (current.getCount() > 1)
 				{
-					long total;
-					try
-					{
-						total = LongMath.checkedMultiply(value, current.getCount());
-						if (total < 0 || total <= value)
-						{
-							event.getToolTip().add(TextFormatting.YELLOW + I18n.format("pe.emc.stackemc_tooltip_prefix") + " " + TextFormatting.OBFUSCATED + I18n.format("pe.emc.too_much"));
-						}
-						else
-						{
-							event.getToolTip().add(TextFormatting.YELLOW + I18n.format("pe.emc.stackemc_tooltip_prefix") + " " + TextFormatting.WHITE + Constants.EMC_FORMATTER.format(value * current.getCount()) + TextFormatting.BLUE + EMCHelper.getEmcSellString(current, current.getCount()));
-						}
-					} catch (ArithmeticException e) {
-						event.getToolTip().add(TextFormatting.YELLOW + I18n.format("pe.emc.stackemc_tooltip_prefix") + " " + TextFormatting.OBFUSCATED + I18n.format("pe.emc.too_much"));
-					}
+					event.getToolTip().add(TextFormatting.YELLOW + I18n.format("pe.emc.stackemc_tooltip_prefix") + " " +
+							TextFormatting.WHITE + Constants.EMC_FORMATTER.format(BigInteger.valueOf(value).multiply(BigInteger.valueOf(current.getCount()))) +
+							TextFormatting.BLUE + EMCHelper.getEmcSellStringBig(current, current.getCount()));
 				}
 
 				if (GuiScreen.isShiftKeyDown()

--- a/src/main/java/moze_intel/projecte/utils/EMCHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/EMCHelper.java
@@ -18,6 +18,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 
+import java.math.BigInteger;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -305,6 +306,18 @@ public final class EMCHelper
 		long emc = EMCHelper.getEmcSellValue(stack);
 
 		return " (" + Constants.EMC_FORMATTER.format((emc * stackSize)) + ")";
+	}
+
+	public static String getEmcSellStringBig(ItemStack stack, int stackSize)
+	{
+		if (EMCMapper.covalenceLoss == 1.0)
+		{
+			return " ";
+		}
+
+		BigInteger emc = BigInteger.valueOf(EMCHelper.getEmcSellValue(stack));
+
+		return " (" + Constants.EMC_FORMATTER.format(emc.multiply(BigInteger.valueOf(stackSize))) + ")";
 	}
 
 	public static int getKleinStarMaxEmc(ItemStack stack)

--- a/src/main/java/moze_intel/projecte/utils/EMCHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/EMCHelper.java
@@ -303,18 +303,6 @@ public final class EMCHelper
 			return " ";
 		}
 
-		long emc = EMCHelper.getEmcSellValue(stack);
-
-		return " (" + Constants.EMC_FORMATTER.format((emc * stackSize)) + ")";
-	}
-
-	public static String getEmcSellStringBig(ItemStack stack, int stackSize)
-	{
-		if (EMCMapper.covalenceLoss == 1.0)
-		{
-			return " ";
-		}
-
 		BigInteger emc = BigInteger.valueOf(EMCHelper.getEmcSellValue(stack));
 
 		return " (" + Constants.EMC_FORMATTER.format(emc.multiply(BigInteger.valueOf(stackSize))) + ")";


### PR DESCRIPTION
Shows numbers past MAX_LONG instead of obfuscated text for when the stack size is bigger than max long. This way people do not have to manually calculate how much EMC they have in a stack. Also given the tooltip is just a string it doesn't cause any other calculations to break by changing how the string is calculated.
![image](https://user-images.githubusercontent.com/1203288/53687117-945d1a00-3cfe-11e9-91da-821e1a720a22.png)
