### PR TITLE
Collectors accept emc from providers when upgrading/charging. Updated

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK1Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK1Tile.java
@@ -1,6 +1,7 @@
 package moze_intel.projecte.gameObjs.tiles;
 
 import moze_intel.projecte.api.item.IItemEmc;
+import moze_intel.projecte.api.tile.IEmcAcceptor;
 import moze_intel.projecte.api.tile.IEmcProvider;
 import moze_intel.projecte.emc.FuelMapper;
 import moze_intel.projecte.gameObjs.container.slots.SlotPredicates;
@@ -23,7 +24,7 @@ import net.minecraftforge.items.wrapper.RangedWrapper;
 import javax.annotation.Nonnull;
 import java.util.Map;
 
-public class CollectorMK1Tile extends TileEmc implements IEmcProvider
+public class CollectorMK1Tile extends TileEmc implements IEmcProvider, IEmcAcceptor
 {
 	private final ItemStackHandler input = new StackHandler(getInvSize());
 	private final ItemStackHandler auxSlots = new StackHandler(3);
@@ -229,6 +230,7 @@ public class CollectorMK1Tile extends TileEmc implements IEmcProvider
 		}
 		else
 		{
+			//Only send EMC when we are not upgrading fuel or charging an item
 			double toSend = this.getStoredEmc() < emcGen ? this.getStoredEmc() : emcGen;
 			this.sendToAllAcceptors(toSend);
 			this.sendRelayBonus();
@@ -371,5 +373,18 @@ public class CollectorMK1Tile extends TileEmc implements IEmcProvider
 		double toRemove = Math.min(currentEMC, toExtract);
 		removeEMC(toRemove);
 		return toRemove;
+	}
+
+	@Override
+	public double acceptEMC(@Nonnull EnumFacing side, double toAccept)
+	{
+		if (hasFuel || hasChargeableItem)
+		{
+			//Collector accepts EMC from providers if it has fuel/chargeable. Otherwise it sends it to providers
+			double toAdd = Math.min(maximumEMC - currentEMC, toAccept);
+			currentEMC += toAdd;
+			return toAdd;
+		}
+		return 0;
 	}
 }


### PR DESCRIPTION
This is basically the same as #1035, except that the target branch has been updated, and the acceptEMC method has been modified to more closely mirror the way the RelayMK1Tile calculates how much EMC is accepted.

I tested in Tekkit classic, and I can confirm that this ability was a feature of collectors. No exploit can happen from this, as the collector only transmits EMC when there is no fuel being upgraded, and no item charging. It also only accepts EMC when it has an item being upgraded, or there is an item charging.