### PR TITLE
Don't stop fuel upgrade if EMC cost is the same

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK1Tile.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/tiles/CollectorMK1Tile.java
@@ -210,7 +210,7 @@ public class CollectorMK1Tile extends TileEmc implements IEmcProvider, IEmcAccep
 			
 			long upgradeCost = EMCHelper.getEmcValue(result) - EMCHelper.getEmcValue(getUpgrading());
 			
-			if (upgradeCost > 0 && this.getStoredEmc() >= upgradeCost)
+			if (upgradeCost >= 0 && this.getStoredEmc() >= upgradeCost)
 			{
 				ItemStack upgrade = getUpgraded();
 


### PR DESCRIPTION
If for some reason two fuel items have the same EMC (for example if the EMC was manually set) it would previously stop. Instead of removing the part of the if statement checking upgrade cost. I changed it to `>=` just in case it somehow ends up negative (it shouldn't but it doesn't hurt to check)