### PR TITLE
Prevent crash if there is no tag for ItemMode

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/ItemMode.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/ItemMode.java
@@ -46,7 +46,7 @@ public abstract class ItemMode extends ItemPE implements IModeChanger, IItemChar
 	protected void changeMode(ItemStack stack)
 	{
 		byte newMode = (byte) (getMode(stack) + 1);
-		stack.getTagCompound().setByte(TAG_MODE, (newMode > numModes - 1 ? 0 : newMode));
+		ItemHelper.getOrCreateCompound(stack).setByte(TAG_MODE, (newMode > numModes - 1 ? 0 : newMode));
 	}
 	
 	@Override

--- a/src/main/java/moze_intel/projecte/gameObjs/items/ItemMode.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/ItemMode.java
@@ -2,6 +2,7 @@ package moze_intel.projecte.gameObjs.items;
 
 import moze_intel.projecte.api.item.IItemCharge;
 import moze_intel.projecte.api.item.IModeChanger;
+import moze_intel.projecte.utils.ItemHelper;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.EntityPlayer;


### PR DESCRIPTION
I was unable to reproduce the crash in #1675, but this should be a preventive measure to fix it crashing if somehow the tag compound becomes null.