### PR TITLE
Override correct method for block explosives.

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/blocks/NovaCataclysm.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/blocks/NovaCataclysm.java
@@ -35,7 +35,7 @@ public class NovaCataclysm extends BlockTNT
 	}
 
 	@Override
-	public void onBlockExploded(World world, @Nonnull BlockPos pos, @Nonnull Explosion explosion)
+	public void onExplosionDestroy(World world, @Nonnull BlockPos pos, @Nonnull Explosion explosion)
 	{
 		if (!world.isRemote)
 		{

--- a/src/main/java/moze_intel/projecte/gameObjs/blocks/NovaCatalyst.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/blocks/NovaCatalyst.java
@@ -35,7 +35,7 @@ public class NovaCatalyst extends BlockTNT
 	}
 	
 	@Override
-	public void onBlockExploded(World world, @Nonnull BlockPos pos, @Nonnull Explosion explosion)
+	public void onExplosionDestroy(World world, @Nonnull BlockPos pos, @Nonnull Explosion explosion)
 	{
 		if (!world.isRemote)
 		{


### PR DESCRIPTION
Tested and this works now. Default implementation of `onBlockExploded` (not overridden by BlockTNT but is in Block)
```
world.setBlockToAir(pos);
onExplosionDestroy(world, pos, explosion);
```

The issue was that when the blocks got blown up, they were never setting it to air so just infinitely exploded. Now it overrides the same method as BlockTNT overrides to spawn the tnt entity.