### PR TITLE
Fixed another bug from making EMC > int

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/slots/transmutation/SlotLock.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/slots/transmutation/SlotLock.java
@@ -40,7 +40,7 @@ public class SlotLock extends SlotItemHandler
 		if (stack.getItem() instanceof IItemEmc)
 		{
 			IItemEmc itemEmc = ((IItemEmc) stack.getItem());
-			long remainEmc = Constants.TILE_MAX_EMC - (int) Math.ceil(inv.provider.getEmc());
+			long remainEmc = Constants.TILE_MAX_EMC - (long) Math.ceil(inv.provider.getEmc());
 			
 			if (itemEmc.getStoredEmc(stack) >= remainEmc)
 			{


### PR DESCRIPTION
Same as #1827 but I missed this and found it while writing #1836 to allow the transmutation inventory to utilize klein stars as extra storage space.