### PR TITLE
Fallback to key's display name

### DIFF
--- a/src/main/java/moze_intel/projecte/utils/ClientKeyHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/ClientKeyHelper.java
@@ -35,12 +35,7 @@ public class ClientKeyHelper
      */
     public static String getKeyName(PEKeybind k)
     {
-        int keyCode = peToMc.get(k).getKeyCode();
-        if (keyCode > Keyboard.getKeyCount() || keyCode < 0)
-        {
-            return "INVALID KEY";
-        }
-        return Keyboard.getKeyName(keyCode);
+        return getKeyName(peToMc.get(k));
     }
 
     public static String getKeyName(KeyBinding k)
@@ -48,7 +43,7 @@ public class ClientKeyHelper
         int keyCode = k.getKeyCode();
         if (keyCode > Keyboard.getKeyCount() || keyCode < 0)
         {
-            return "INVALID KEY";
+            return k.getDisplayName();
         }
         return Keyboard.getKeyName(keyCode);
     }


### PR DESCRIPTION
If the button is not on the keyboard such as an extra mouse button, display the same text that would get displayed in the controls menu, rather than displaying "INVALID KEY".