### PR TITLE
Handles changes to gamemode in regards to flight

### DIFF
--- a/src/main/java/moze_intel/projecte/handlers/InternalAbilities.java
+++ b/src/main/java/moze_intel/projecte/handlers/InternalAbilities.java
@@ -93,7 +93,7 @@ public final class InternalAbilities
 			wasFlyingGamemode = false;
 			wasFlying = false;
 		}
-		else //if (shouldPlayerFly())
+		else
 		{
 			if (!hadFlightItem)
 			{

--- a/src/main/java/moze_intel/projecte/handlers/InternalAbilities.java
+++ b/src/main/java/moze_intel/projecte/handlers/InternalAbilities.java
@@ -29,6 +29,9 @@ public final class InternalAbilities
 	private boolean swrgOverride = false;
 	private boolean gemArmorReady = false;
 	private boolean hadFlightItem = false;
+	private boolean wasFlyingGamemode = false;
+	private boolean isFlyingGamemode = false;
+	private boolean wasFlying = false;
 	private int projectileCooldown = 0;
 	private int gemChestCooldown = 0;
 
@@ -76,23 +79,40 @@ public final class InternalAbilities
 			gemChestCooldown--;
 		}
 
-		if (!shouldPlayerFly() && hadFlightItem)
+		if (!shouldPlayerFly())
 		{
-			if (player.capabilities.allowFlying)
+			if (hadFlightItem)
 			{
-				PlayerHelper.updateClientServerFlight(player, false);
+				if (player.capabilities.allowFlying)
+				{
+					PlayerHelper.updateClientServerFlight(player, false);
+				}
+
+				hadFlightItem = false;
 			}
-			
-			hadFlightItem = false;
+			wasFlyingGamemode = false;
+			wasFlying = false;
 		}
-		else if(shouldPlayerFly() && !hadFlightItem)
+		else //if (shouldPlayerFly())
 		{
-			if (!player.capabilities.allowFlying)
+			if (!hadFlightItem)
 			{
-				PlayerHelper.updateClientServerFlight(player, true);
+				if (!player.capabilities.allowFlying)
+				{
+					PlayerHelper.updateClientServerFlight(player, true);
+				}
+
+				hadFlightItem = true;
 			}
-			
-			hadFlightItem = true;
+			else if (wasFlyingGamemode && !isFlyingGamemode)
+			{
+				//Player was in a gamemode that allowed flight, but no longer is but they still should be allowed to fly
+				//Sync the fact to the client. Also passes wasFlying so that if they were flying previously,
+				//and are still allowed to the gamemode change doesn't force them out of it
+				PlayerHelper.updateClientServerFlight(player, true, wasFlying);
+			}
+			wasFlyingGamemode = isFlyingGamemode;
+			wasFlying = player.capabilities.isFlying;
 		}
 
 		if (!shouldPlayerResistFire())
@@ -140,7 +160,8 @@ public final class InternalAbilities
 			disableSwrgFlightOverride();
 		}
 
-		if (player.capabilities.isCreativeMode || player.isSpectator() || swrgOverride)
+		isFlyingGamemode = player.capabilities.isCreativeMode || player.isSpectator();
+		if (isFlyingGamemode || swrgOverride)
 		{
 			return true;
 		}

--- a/src/main/java/moze_intel/projecte/network/packets/SetFlyPKT.java
+++ b/src/main/java/moze_intel/projecte/network/packets/SetFlyPKT.java
@@ -8,25 +8,29 @@ import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 
 public class SetFlyPKT implements IMessage
 {
-	private boolean flag;
+	private boolean allowFlying;
+	private boolean isFlying;
 
 	public SetFlyPKT() {}
 
-	public SetFlyPKT(boolean value)
+	public SetFlyPKT(boolean allowFlying, boolean isFlying)
 	{
-		flag = value;
+		this.allowFlying = allowFlying;
+		this.isFlying = isFlying;
 	}
 
 	@Override
 	public void fromBytes(ByteBuf buf)
 	{
-		flag = buf.readBoolean();
+		allowFlying = buf.readBoolean();
+		isFlying = buf.readBoolean();
 	}
 
 	@Override
 	public void toBytes(ByteBuf buf)
 	{
-		buf.writeBoolean(flag);
+		buf.writeBoolean(allowFlying);
+		buf.writeBoolean(isFlying);
 	}
 
 	public static class Handler implements IMessageHandler<SetFlyPKT, IMessage>
@@ -34,16 +38,9 @@ public class SetFlyPKT implements IMessage
 		@Override
 		public IMessage onMessage(final SetFlyPKT message, MessageContext ctx)
 		{
-			Minecraft.getMinecraft().addScheduledTask(new Runnable() {
-				@Override
-				public void run() {
-					Minecraft.getMinecraft().player.capabilities.allowFlying = message.flag;
-
-					if (!message.flag)
-					{
-						Minecraft.getMinecraft().player.capabilities.isFlying = false;
-					}
-				}
+			Minecraft.getMinecraft().addScheduledTask(() -> {
+				Minecraft.getMinecraft().player.capabilities.allowFlying = message.allowFlying;
+				Minecraft.getMinecraft().player.capabilities.isFlying = message.isFlying;
 			});
 
 			return null;

--- a/src/main/java/moze_intel/projecte/utils/PlayerHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/PlayerHelper.java
@@ -169,15 +169,16 @@ public final class PlayerHelper
 		}
 	}
 
-	public static void updateClientServerFlight(EntityPlayerMP player, boolean state)
+	public static void updateClientServerFlight(EntityPlayerMP player, boolean allowFlying)
 	{
-		PacketHandler.sendTo(new SetFlyPKT(state), player);
-		player.capabilities.allowFlying = state;
+		updateClientServerFlight(player, allowFlying, allowFlying && player.capabilities.isFlying);
+	}
 
-		if (!state)
-		{
-			player.capabilities.isFlying = false;
-		}
+	public static void updateClientServerFlight(EntityPlayerMP player, boolean allowFlying, boolean isFlying)
+	{
+		PacketHandler.sendTo(new SetFlyPKT(allowFlying, isFlying), player);
+		player.capabilities.allowFlying = allowFlying;
+		player.capabilities.isFlying = isFlying;
 	}
 
 	public static void updateClientServerStepHeight(EntityPlayerMP player, float value)


### PR DESCRIPTION
This pull changes two things in regards to the flying checks.

- If the player was in a gamemode that allowed flying, and now they are not but `shouldPlayerFly()` is still true, it syncs the fact that they are allowed to fly to the client. (This allows players to not have to pickup the ring and put it back down to be able to fly again)
- If a player was in a gamemode that allowed flight, and no longer is set their `isFlying` to the same state as it was before. (Sometimes this has a micro drop of about 1/16 of a block before it makes them flying again, but this is preferable to them just not staying in flight at all)

The one quirk this change does not fix is if you are flying in survival and decide to run `/gamemode survival` then it will take you out of flight and you will still have to pickup the ring and put it back down to be able to start flying again.