### PR TITLE
Added ability to register items with NBTs and allowed for storing custom EMC in separate files

### DIFF
--- a/src/main/java/moze_intel/projecte/api/proxy/IItemNBTEmcCalculator.java
+++ b/src/main/java/moze_intel/projecte/api/proxy/IItemNBTEmcCalculator.java
@@ -1,0 +1,80 @@
+package moze_intel.projecte.api.proxy;
+
+import java.util.Collection;
+
+import org.apache.commons.math3.fraction.BigFraction;
+
+import moze_intel.projecte.emc.arithmetics.IValueArithmetic;
+import net.minecraft.item.ItemStack;
+
+/**Interface that allows for calculating custom EMC values for non-defined entries at request time.
+ * 
+ * This interface allows for both creating new EMC values for existing items based on their NBT tags,
+ * as well as provide modifiers to the value if certain NBT Tags are present (such as enchantments)
+ * */
+
+public interface IItemNBTEmcCalculator{
+	
+	public static enum Operation{
+		OP_ADD{
+			public BigFraction operate(BigFraction originalEMC, BigFraction modifier){
+				return originalEMC.add(modifier);
+			}
+		},
+		OP_SUBTRACT{
+			public BigFraction operate(BigFraction modifier, BigFraction originalEMC){
+				return originalEMC.subtract(modifier);
+			}
+		},
+		OP_MUlTIPLY{
+			public BigFraction operate(BigFraction modifier, BigFraction originalEMC){
+				return originalEMC.multiply(modifier);
+			}
+		},
+		OP_DIVIDE{
+			public BigFraction operate(BigFraction modifier, BigFraction originalEMC){
+				return originalEMC.divide(modifier);
+			}
+		},
+		OP_SET{
+			public BigFraction operate(BigFraction modifier, BigFraction originalEMC){
+				return modifier;
+			}
+		},
+		OP_NONE;
+		
+		public BigFraction operate(long originalEMC, BigFraction modifier){
+			return operate(new BigFraction(originalEMC), modifier);
+		}
+		public BigFraction operate(BigFraction originalEMC, BigFraction modifier){
+			return BigFraction.ZERO;
+		}
+	}
+	
+	
+	/**Method used to determine if an ItemStack will be passed on to the plugin
+	 * String should be a either:
+	 * - A ResourceLocator for an item, optionally followed by "|" and a meta value or "*" for wildcard;
+	 * - A mod name followed by ":*" to filter any item from that mod ("minecraft:*" for only vanilla items);
+	 * - "*" to filter any item from any mod
+	 * @return A colection of the above-formatted strings indicating where the plugin operates.*/
+	public Collection<String> allowedItems();
+	
+	/**If the itemStack provided is one of the items this plugin operates on.
+	 * @param input The itemstack to be calculated
+	 * @return true if the item EMC can be modified by this plugin. */
+	public boolean canProcessItem(ItemStack input);
+	
+	/**If this plugin provides an override to the Item's EMC value, or modifies it with one of 
+	 * 4 operations.
+	 * @param input The item to be analyzed
+	 * @return the operation to be used, as defined in Operations.*/
+	public Operation getOperation(ItemStack input); 
+	
+	/**Calculates either the new EMC for this item (if setsEMC == true) or calculates a modifier to the
+	 * item's value based on its NBT tags.
+	 * @param input The itemstack to be calculated
+	 * @return long value of EMC */
+	public BigFraction getEMC(final ItemStack input);
+	
+}

--- a/src/main/java/moze_intel/projecte/api/proxy/IItemNBTFilter.java
+++ b/src/main/java/moze_intel/projecte/api/proxy/IItemNBTFilter.java
@@ -1,0 +1,30 @@
+package moze_intel.projecte.api.proxy;
+
+import java.util.Collection;
+
+import net.minecraft.item.ItemStack;
+
+/**Interface that allows for filtering certain item NBT components.*/
+
+public interface IItemNBTFilter {
+	
+	/**If the itemStack provided is one of the items this plugin filters.
+	 * @param input The itemstack to be filtered
+	 * @return true if the item can be filtered by this plugin */
+	public boolean canFilterStack(ItemStack input);
+	
+	
+	/**Removes plugin-defined NBT tags from the ItemStack. The input must not be modified.
+	 * Use input.copy() and work on that.
+	 * @param input The itemstack to be filtered
+	 * @return a new ItemStack with the target NBT Tags removed or added */
+	public ItemStack getFilteredItemStack(final ItemStack input);
+	
+	/**Method used to determine if an ItemStack will be passed on to the plugin
+	 * String should be a either:
+	 * - A ResourceLocator for an item, optionally followed by "|" and a meta value or "*" for wildcard;
+	 * - A mod name followed by ":*" to filter any item from that mod ("minecraft:*" for only vanilla items);
+	 * - "*" to filter any item from any mod
+	 * @return A colection of the above-formatted strings indicating where the plugin operates.*/
+	public Collection<String> allowedItems();
+}

--- a/src/main/java/moze_intel/projecte/config/CustomEMCParser.java
+++ b/src/main/java/moze_intel/projecte/config/CustomEMCParser.java
@@ -4,28 +4,39 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.annotations.SerializedName;
+
 import moze_intel.projecte.PECore;
+import moze_intel.projecte.emc.json.NSSFluid;
 import moze_intel.projecte.emc.json.NSSItem;
+import moze_intel.projecte.emc.json.NSSItemWithNBT;
 import moze_intel.projecte.emc.json.NSSOreDictionary;
 import moze_intel.projecte.emc.json.NormalizedSimpleStack;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 public final class CustomEMCParser
 {
 	private static final Gson GSON = new GsonBuilder().registerTypeAdapter(NormalizedSimpleStack.class, NormalizedSimpleStack.Serializer.INSTANCE).setPrettyPrinting().create();
 	private static final File CONFIG = new File(PECore.CONFIG_DIR, "custom_emc.json");
 
+	private static final File CONFIG_DIR = new File(PECore.CONFIG_DIR, "custom_emc");
+	
 	public static class CustomEMCFile
 	{
 		public final List<CustomEMCEntry> entries;
@@ -34,13 +45,27 @@ public final class CustomEMCParser
 		{
 			this.entries = entries;
 		}
+		
+		public CustomEMCFile withCleanEntries(){			
+			for(int i = 0; i < entries.size(); i++){
+				for(int k = 0; k < i; k++){
+					if(entries.get(k).nss.equals(entries.get(i).nss)){
+						entries.remove(k);
+						k--;
+						i--;
+					}
+				}
+			}
+			return this;
+		}
 	}
 
 	public static class CustomEMCEntry
 	{
 		@SerializedName("item")
 		public final NormalizedSimpleStack nss;
-		public final long emc;
+		public long emc;
+		
 
 		private CustomEMCEntry(NormalizedSimpleStack nss, long emc)
 		{
@@ -64,14 +89,93 @@ public final class CustomEMCParser
 			return result;
 		}
 	}
-
-	public static CustomEMCFile currentEntries;
+	
+	public static HashMap<String, List<CustomEMCEntry>> customEMCEntries = new HashMap<>();
+	
 	private static boolean dirty = false;
 
 	public static void init()
 	{
+		if(ProjectEConfig.misc.separateCustomEMC){
+			if(!CONFIG_DIR.exists()){
+				cloneAndDumpEMCMappings();
+			}else{
+				for(File f: CONFIG_DIR.listFiles()){
+					if(f.getName().endsWith(".json")){
+						CustomEMCFile currentEntries = null;
+						try (BufferedReader reader = new BufferedReader(new FileReader(f))) {
+							currentEntries = GSON.fromJson(reader, CustomEMCFile.class);
+							currentEntries.entries.removeIf(e -> e.nss == null || e.emc < 0 || !(e.nss instanceof NSSItem ||e.nss instanceof NSSItemWithNBT || e.nss instanceof NSSOreDictionary));
+						} catch (IOException | JsonParseException e) {
+							PECore.LOGGER.fatal("Couldn't read custom emc file");
+							e.printStackTrace();
+							currentEntries = new CustomEMCFile(new ArrayList<>());
+						}
+						currentEntries = currentEntries.withCleanEntries();
+						if(f.getName().equalsIgnoreCase("$OreDict.json")){
+							getMod("$OreDict").addAll(currentEntries.entries);
+						}else{
+							createMapFromEntries(currentEntries.entries);
+						}
+					}
+				}
+				return;
+			}
+		}else{
+			createMapFromEntries(readOriginalConfigFile().entries);
+		}
 		flush();
+	}
 
+	private static void cloneAndDumpEMCMappings() {
+		CustomEMCFile totalEntries = readOriginalConfigFile();
+		createMapFromEntries(totalEntries.entries);
+		flush();
+		return;
+	}
+
+	private static void createMapFromEntries(List<CustomEMCEntry> entries){
+		for(CustomEMCEntry entry: entries){
+			if(entry.nss instanceof NSSOreDictionary){
+				getMod("$OreDict").add(entry);
+			}else if (entry.nss instanceof NSSFluid){
+				NSSFluid fluid = (NSSFluid)entry.nss;
+				String[] names = fluid.name.split(":");
+				if(names.length == 1){
+					getMod("minecraft").add(entry);
+				}else{
+					getMod(names[0]).add(entry);
+				}
+			}else if (entry.nss instanceof NSSItem){
+				NSSItem item = (NSSItem)entry.nss;
+				String[] names = item.itemName.split(":");
+				if(names.length == 1){
+					getMod("minecraft").add(entry);
+				}else{
+					getMod(names[0]).add(entry);
+				}
+			}else if (entry.nss instanceof NSSItemWithNBT){
+				NSSItemWithNBT item = (NSSItemWithNBT)entry.nss;
+				String[] names = item.itemName.split(":");
+				if(names.length == 1){
+					getMod("minecraft").add(entry);
+				}else{
+					getMod(names[0]).add(entry);
+				}
+			}
+		}
+	}
+	
+	public static List<CustomEMCEntry> getMod(String key) {
+		if(customEMCEntries == null){
+			customEMCEntries = new HashMap();
+		}if(!customEMCEntries.containsKey(key)){
+			customEMCEntries.put(key, new ArrayList<CustomEMCEntry>());
+		}
+		return customEMCEntries.get(key);
+	}
+
+	private static CustomEMCFile readOriginalConfigFile() {
 		if (!CONFIG.exists())
 		{
 			try
@@ -86,15 +190,16 @@ public final class CustomEMCParser
 				PECore.LOGGER.fatal("Exception in file I/O: couldn't create custom configuration files.");
 			}
 		}
-
+		CustomEMCFile currentEntries = null;
 		try (BufferedReader reader = new BufferedReader(new FileReader(CONFIG))) {
 			currentEntries = GSON.fromJson(reader, CustomEMCFile.class);
-			currentEntries.entries.removeIf(e -> e.nss == null || e.emc < 0 || !(e.nss instanceof NSSItem || e.nss instanceof NSSOreDictionary));
+			currentEntries.entries.removeIf(e -> e.nss == null || e.emc < 0 || !(e.nss instanceof NSSItem ||e.nss instanceof NSSItemWithNBT|| e.nss instanceof NSSOreDictionary));
 		} catch (IOException | JsonParseException e) {
 			PECore.LOGGER.fatal("Couldn't read custom emc file");
 			e.printStackTrace();
 			currentEntries = new CustomEMCFile(new ArrayList<>());
 		}
+		return currentEntries.withCleanEntries();
 	}
 
 	private static NormalizedSimpleStack getNss(String str, int meta)
@@ -113,62 +218,181 @@ public final class CustomEMCParser
 	{
 		NormalizedSimpleStack nss = getNss(toAdd, meta);
 		CustomEMCEntry entry = new CustomEMCEntry(nss, emc);
-
-		int setAt = -1;
-
-		for (int i = 0; i < currentEntries.entries.size(); i++)
-		{
-			if (currentEntries.entries.get(i).nss.equals(nss))
-			{
-				setAt = i;
-				break;
+		List<CustomEMCEntry> mod = null;
+		if(nss instanceof NSSOreDictionary){
+			mod = getMod("$OreDict");
+		}else{
+			String[] s = toAdd.split(":");
+			mod = getMod(s[0]);
+		}
+		
+		for(CustomEMCEntry entry2:mod){
+			if(entry2.nss.equals(nss)){
+				entry2.emc = emc;
+				dirty = true;
+				flush();
+				return true;
 			}
 		}
-
-		if (setAt == -1)
-		{
-			currentEntries.entries.add(entry);
-		} else
-		{
-			currentEntries.entries.set(setAt, entry);
-		}
-
+		mod.add(entry);
 		dirty = true;
+		flush();
+		return true;
+	}
+	
+	public static boolean addWithNBTToFile(ItemStack itm, long emc)
+	{
+		return addWithNBTToFile(itm, NSSItemWithNBT.NO_IGNORES, emc);
+	}
+	
+	public static boolean addWithNBTToFile(ItemStack itm, String[]ignores, long emc)
+	{
+		NSSItemWithNBT nssNBT = (NSSItemWithNBT) NSSItemWithNBT.create(itm, ignores);
+		String mod = itm.getItem().getRegistryName().getNamespace();
+		List<CustomEMCEntry> entries = getMod(mod);
+		CustomEMCEntry entry = new CustomEMCEntry(nssNBT, emc);
+		for(CustomEMCEntry entry2: getMod(mod)){
+			if(entry2.nss.equals(nssNBT)){
+				entry2.emc = emc;
+				dirty = true;
+				flush();
+				return true;
+			}
+		}
+		getMod(mod).add(entry);
+		dirty = true;
+		flush();
 		return true;
 	}
 
+	public static boolean removeWithNBTFromFile(ItemStack toRemove)
+	{
+		return removeWithNBTFromFile(toRemove, NSSItemWithNBT.NO_IGNORES);
+	}
+	
+	public static boolean removeWithNBTFromFile(ItemStack toRemove,
+			String[] ignores) {
+		NSSItemWithNBT nssNBT = (NSSItemWithNBT) NSSItemWithNBT.create(toRemove, ignores);
+		String mod = toRemove.getItem().getRegistryName().getNamespace();
+		List<CustomEMCEntry> entries = getMod(mod);
+		if(entries.isEmpty()){
+			return false;
+		}
+		int idx = 0;
+		for(CustomEMCEntry entry: entries){
+			if(entry.nss instanceof NSSItemWithNBT){
+				if(((NSSItemWithNBT)entry.nss).equalsEvenPartially(nssNBT)){
+					break;	
+				}
+			}
+			idx++;
+		}
+		if(idx >= entries.size())
+			return false;
+		entries.remove(idx);
+		return true;
+	}
+	
 	public static boolean removeFromFile(String toRemove, int meta)
 	{
 		NormalizedSimpleStack nss = getNss(toRemove, meta);
-		Iterator<CustomEMCEntry> iter = currentEntries.entries.iterator();
-
-		boolean removed = false;
-		while (iter.hasNext())
-		{
-			if (iter.next().nss.equals(nss))
-			{
-				iter.remove();
-				dirty = true;
-				removed = true;
-			}
+		List<CustomEMCEntry> entries = null; 
+		if(nss instanceof NSSOreDictionary){			
+			entries = getMod("$OreDict");
+		}else{
+			String[] s = toRemove.split(":");
+			entries = getMod(s[0]);
 		}
-
-		return removed;
+		int idx = 0;
+		for(CustomEMCEntry entry: entries){
+			if(nss.equals(entry.nss)){
+				break;
+			}
+			idx++;
+		}
+		
+		if(idx >= entries.size())
+			return false;
+		entries.remove(idx);
+		return true;
 	}
 
 	private static void flush()
 	{
+		if(ProjectEConfig.misc.separateCustomEMC && !CONFIG_DIR.exists())
+			dirty = true;
+		if(!ProjectEConfig.misc.separateCustomEMC && CONFIG_DIR.exists())
+			dirty = true;
 		if (dirty)
 		{
-			try
-			{
-				Files.write(GSON.toJson(currentEntries), CONFIG, Charsets.UTF_8);
-			} catch (IOException e) {
-				e.printStackTrace();
+			if(ProjectEConfig.misc.separateCustomEMC){
+				if(customEMCEntries.isEmpty())
+					return;
+				if(!CONFIG_DIR.exists()){
+					CONFIG_DIR.mkdir();
+					if(!CONFIG_DIR.exists()){
+						PECore.LOGGER.fatal("Couldn't create custom emc directory. Dumping to file instead.");
+						ProjectEConfig.misc.separateCustomEMC = false;
+						flush();
+						return;
+					}
+				}
+				if(customEMCEntries.containsKey("$OreDict")){
+					File f = new File(CONFIG_DIR, "$OreDict.json");
+					try
+					{
+						Files.write(GSON.toJson(new CustomEMCFile(customEMCEntries.get("$OreDict")).withCleanEntries()), f , Charsets.UTF_8);
+					} catch (IOException e) {
+						e.printStackTrace();
+					}
+				}
+				for(String k: customEMCEntries.keySet()){
+					if(!k.equalsIgnoreCase("$OreDict")){
+						File f = new File(CONFIG_DIR, k+".json");
+						try
+						{
+							Files.write(GSON.toJson(new CustomEMCFile(customEMCEntries.get(k)).withCleanEntries()), f , Charsets.UTF_8);
+						} catch (IOException e) {
+							e.printStackTrace();
+						}
+					}
+				}
+				dirty = false;
+				return;
+			}else{
+				if(CONFIG_DIR.exists()){
+					delTree(CONFIG_DIR);
+				}
+				try
+				{
+					Files.write(GSON.toJson(getAllEntriesInSingleFile().withCleanEntries()), CONFIG, Charsets.UTF_8);
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
 			}
 
 			dirty = false;
 		}
+	}
+
+	private static void delTree(File dir) {
+		for(File f: dir.listFiles()){
+			if(f.isDirectory())
+				delTree(f);
+			else
+				f.delete();
+		}
+		dir.delete();
+	}
+
+	private static CustomEMCFile getAllEntriesInSingleFile() {
+		if(customEMCEntries.isEmpty())
+			return new CustomEMCFile(new ArrayList<>());
+		ArrayList<CustomEMCEntry> entries = new ArrayList<>();
+		for(String k : customEMCEntries.keySet()){
+			entries.addAll(customEMCEntries.get(k));
+		}
+		return new CustomEMCFile(entries);
 	}
 
 	private static void writeDefaultFile()
@@ -184,4 +408,6 @@ public final class CustomEMCParser
 			e.printStackTrace();
 		}
 	}
+
+	
 }

--- a/src/main/java/moze_intel/projecte/config/CustomEMCParser.java
+++ b/src/main/java/moze_intel/projecte/config/CustomEMCParser.java
@@ -409,5 +409,25 @@ public final class CustomEMCParser
 		}
 	}
 
+	public static boolean containsItem(NormalizedSimpleStack stack) {
+		String path = null;
+		if(stack instanceof NSSOreDictionary){
+			path = "$OreDict";
+		}else if (stack instanceof NSSItem){
+			path = ((NSSItem)stack).itemName.split(":")[0];
+		}else if (stack instanceof NSSItemWithNBT){
+			path = ((NSSItemWithNBT)stack).itemName.split(":")[0];
+		}
+		if(customEMCEntries.containsKey(path)){
+			for(CustomEMCEntry entry: customEMCEntries.get(path)){
+				if(entry.nss.equals(stack)){
+					return true;
+				}
+			}
+		}
+		return false;
+		
+	}
+
 	
 }

--- a/src/main/java/moze_intel/projecte/config/CustomEMCParser.java
+++ b/src/main/java/moze_intel/projecte/config/CustomEMCParser.java
@@ -96,6 +96,7 @@ public final class CustomEMCParser
 
 	public static void init()
 	{
+		customEMCEntries.clear();
 		if(ProjectEConfig.misc.separateCustomEMC){
 			if(!CONFIG_DIR.exists()){
 				cloneAndDumpEMCMappings();

--- a/src/main/java/moze_intel/projecte/config/ProjectEConfig.java
+++ b/src/main/java/moze_intel/projecte/config/ProjectEConfig.java
@@ -70,9 +70,6 @@ public final class ProjectEConfig
 
 		@Config.Comment("Separate custom EMC into one file per mod")
 		public boolean separateCustomEMC = false;
-
-		@Config.Comment("If Enchantment books destroyed at the transmutation table should be learned with enchantments")
-		public boolean learnEnchantBooks = true;
 		
 		@Config.Comment("If Enchanted items destroyed at the transmutation table should be learned with enchantments")
 		public boolean learnEnchantedItems = true;

--- a/src/main/java/moze_intel/projecte/config/ProjectEConfig.java
+++ b/src/main/java/moze_intel/projecte/config/ProjectEConfig.java
@@ -68,6 +68,15 @@ public final class ProjectEConfig
 		@Config.Comment("Enable a more verbose debug logging")
 		public boolean debugLogging = false;
 
+		@Config.Comment("Separate custom EMC into one file per mod")
+		public boolean separateCustomEMC = false;
+
+		@Config.Comment("If Enchantment books destroyed at the transmutation table should be learned with enchantments")
+		public boolean learnEnchantBooks = true;
+		
+		@Config.Comment("If Enchanted items destroyed at the transmutation table should be learned with enchantments")
+		public boolean learnEnchantedItems = true;
+		
 		@Config.Comment("Show item Ore Dictionary names in tooltips (useful for custom EMC registration)")
 		public boolean odToolTips = false;
 

--- a/src/main/java/moze_intel/projecte/emc/EMCMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/EMCMapper.java
@@ -16,6 +16,7 @@ import moze_intel.projecte.emc.json.NSSItemWithNBT;
 import moze_intel.projecte.emc.json.NormalizedSimpleStack;
 import moze_intel.projecte.emc.mappers.APICustomConversionMapper;
 import moze_intel.projecte.emc.mappers.APICustomEMCMapper;
+import moze_intel.projecte.emc.mappers.BrewingMapper;
 import moze_intel.projecte.emc.mappers.CraftingMapper;
 import moze_intel.projecte.emc.mappers.CustomEMCMapper;
 import moze_intel.projecte.emc.mappers.IEMCMapper;
@@ -59,6 +60,7 @@ public final class EMCMapper
 				new CraftingMapper(),
 				new moze_intel.projecte.emc.mappers.FluidMapper(),
 				new SmeltingMapper(),
+				new BrewingMapper(),
 				new APICustomConversionMapper()
 		);
 		SimpleGraphMapper<NormalizedSimpleStack, BigFraction, IValueArithmetic<BigFraction>> mapper = new SimpleGraphMapper<>(new HiddenBigFractionArithmetic());

--- a/src/main/java/moze_intel/projecte/emc/EMCMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/EMCMapper.java
@@ -12,6 +12,7 @@ import moze_intel.projecte.emc.collector.IExtendedMappingCollector;
 import moze_intel.projecte.emc.collector.WildcardSetValueFixCollector;
 import moze_intel.projecte.emc.generators.IValueGenerator;
 import moze_intel.projecte.emc.json.NSSItem;
+import moze_intel.projecte.emc.json.NSSItemWithNBT;
 import moze_intel.projecte.emc.json.NormalizedSimpleStack;
 import moze_intel.projecte.emc.mappers.APICustomConversionMapper;
 import moze_intel.projecte.emc.mappers.APICustomEMCMapper;
@@ -29,10 +30,12 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.oredict.OreDictionary;
+
 import org.apache.commons.math3.fraction.BigFraction;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -42,6 +45,7 @@ import java.util.Map;
 public final class EMCMapper 
 {
 	public static final Map<SimpleStack, Long> emc = new LinkedHashMap<>();
+	public static final Map<String, List<NSSItemWithNBT>> nssWithNBTCache = new LinkedHashMap<>();
 
 	public static double covalenceLoss = ProjectEConfig.difficulty.covalenceLoss;
 
@@ -134,13 +138,19 @@ public final class EMCMapper
 
 
 		for (Map.Entry<NormalizedSimpleStack, Long> entry: graphMapperValues.entrySet()) {
-			NSSItem normStackItem = (NSSItem)entry.getKey();
-			Item obj = Item.REGISTRY.getObject(new ResourceLocation(normStackItem.itemName));
+			NormalizedSimpleStack normStackItem = entry.getKey();
+			String name = (normStackItem instanceof NSSItem) ? ((NSSItem)normStackItem).itemName: 
+						  (normStackItem instanceof NSSItemWithNBT) ? ((NSSItemWithNBT)normStackItem).itemName: null;
+			Item obj = Item.REGISTRY.getObject(new ResourceLocation(name));
 			if (obj != null)
 			{
-				emc.put(new SimpleStack(obj.getRegistryName(), normStackItem.damage), entry.getValue());
+				if (normStackItem instanceof NSSItemWithNBT){
+					insertNSSWithNBTintoEMCMap((NSSItemWithNBT) normStackItem, entry.getValue());
+				} else if(normStackItem instanceof NSSItem){
+					emc.put(new SimpleStack(obj.getRegistryName(), ((NSSItem)normStackItem).damage), entry.getValue());
+				}
 			} else {
-				PECore.LOGGER.warn("Could not add EMC value for {}|{}. Can not get ItemID!", normStackItem.itemName, normStackItem.damage);
+				PECore.LOGGER.warn("Could not add EMC value for {}|{}. Can not get ItemID!", name);
 			}
 		}
 
@@ -150,23 +160,101 @@ public final class EMCMapper
 		PECore.refreshJEI();
 	}
 
+	public static void insertNSSWithNBTintoEMCMap(NSSItemWithNBT normStackItem, long value) {
+		SimpleStack itm = new SimpleStack(new ResourceLocation(normStackItem.itemName), normStackItem.damage, normStackItem.nbt);
+		putInNSSNBTCache((NSSItemWithNBT) normStackItem);
+		emc.put(itm, value);
+	}
+
+	public static void insertSimpleStackWithNBTintoEMCMap(SimpleStack itm, long value) {
+		putInNSSNBTCache(new NSSItemWithNBT(itm.id.toString(), itm.damage, itm.tag, NSSItemWithNBT.NO_IGNORES));
+		emc.put(itm, value);
+	}
+	
+	private static void putInNSSNBTCache(NSSItemWithNBT normStackItem) {
+		if(normStackItem.nbt == null || normStackItem.nbt.isEmpty()){
+			return;
+		}
+		String key = normStackItem.itemName;
+		if(!nssWithNBTCache.containsKey(key)){
+			nssWithNBTCache.put(key, new ArrayList<>());
+		}
+		for(NSSItemWithNBT itm: nssWithNBTCache.get(key)){
+			if(itm.damage == normStackItem.damage && normStackItem.nbt.equals(itm.nbt)){
+				return;
+			}
+		}
+		nssWithNBTCache.get(key).add(normStackItem);		
+	}
+
 	private static void filterEMCMap(Map<NormalizedSimpleStack, Long> map) {
-		map.entrySet().removeIf(e -> !(e.getKey() instanceof NSSItem)
-										|| ((NSSItem) e.getKey()).damage == OreDictionary.WILDCARD_VALUE
+		map.entrySet().removeIf(e -> !((e.getKey() instanceof NSSItem)||(e.getKey() instanceof NSSItemWithNBT))
+										|| ((e.getKey() instanceof NSSItem) && ((NSSItem) e.getKey()).damage == OreDictionary.WILDCARD_VALUE)
 										|| e.getValue() <= 0);
 	}
 
 	public static boolean mapContains(SimpleStack key)
 	{
+		if(key.tag != null){
+			return mapContainsWithNBT(key) || emc.containsKey(key); 
+		}
 		return emc.containsKey(key);
 	}
 
 	public static long getEmcValue(SimpleStack stack)
 	{
+		if(stack.tag != null){
+			return getEmcValueWithNBT(stack);
+		}
 		return emc.get(stack);
+	}
+	
+	public static long getEmcValueWithNBT(SimpleStack stack){
+		SimpleStack stack2 = stack;
+		if(stack.tag != null && !stack.tag.isEmpty()){
+			NSSItemWithNBT represent = getRepresentativeTag(stack);
+			if(represent != null){
+				stack2 = represent.toSimpleStack();
+			}
+		}
+		return emc.get(stack2);
 	}
 
 	public static void clearMaps() {
 		emc.clear();
+		nssWithNBTCache.clear();
 	}
+
+	public static boolean mapContainsWithNBT(SimpleStack withNBT) {
+		if(nssWithNBTCache.containsKey(withNBT.id.toString())){
+			for(NSSItemWithNBT itm: nssWithNBTCache.get(withNBT.id.toString())){
+				if(itm.ignoreDamage || itm.damage == withNBT.damage){
+					if(NSSItemWithNBT.isNBTContained(itm.nbt,withNBT.tag)){
+						return true;	
+					}
+				}
+			}
+		}
+		return false;
+	}
+	
+	public static NSSItemWithNBT getRepresentativeTag(SimpleStack withNBT){
+		NSSItemWithNBT mostSimilar = null;
+		int maxSimilarity = 0;
+		if(nssWithNBTCache.containsKey(withNBT.id.toString())){
+			for(NSSItemWithNBT itm: nssWithNBTCache.get(withNBT.id.toString())){
+				if(itm.ignoreDamage || itm.damage == withNBT.damage){
+					if(NSSItemWithNBT.isNBTContained(itm.nbt,withNBT.tag)){
+						int newSim = NSSItemWithNBT.NBTSimilarity(itm.nbt,withNBT.tag);
+						if(maxSimilarity < newSim) {
+							maxSimilarity = newSim;
+							mostSimilar = itm;
+						}
+					}
+				}
+			}
+		}
+		return mostSimilar;
+	}
+	
 }

--- a/src/main/java/moze_intel/projecte/emc/EMCMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/EMCMapper.java
@@ -226,10 +226,15 @@ public final class EMCMapper
 	}
 
 	public static boolean mapContainsWithNBT(SimpleStack withNBT) {
+		return mapContainsWithNBT(withNBT, true);
+	}
+	
+	public static boolean mapContainsWithNBT(SimpleStack withNBT, boolean partialResults) {
 		if(nssWithNBTCache.containsKey(withNBT.id.toString())){
 			for(NSSItemWithNBT itm: nssWithNBTCache.get(withNBT.id.toString())){
 				if(itm.ignoreDamage || itm.damage == withNBT.damage){
-					if(NSSItemWithNBT.isNBTContained(itm.nbt,withNBT.tag)){
+					if((partialResults && NSSItemWithNBT.isNBTContained(itm.nbt,withNBT.tag))||
+							itm.nbt.equals(withNBT.tag)){
 						return true;	
 					}
 				}
@@ -256,5 +261,7 @@ public final class EMCMapper
 		}
 		return mostSimilar;
 	}
+
+	
 	
 }

--- a/src/main/java/moze_intel/projecte/emc/SimpleStack.java
+++ b/src/main/java/moze_intel/projecte/emc/SimpleStack.java
@@ -1,6 +1,8 @@
 package moze_intel.projecte.emc;
 
+import moze_intel.projecte.emc.json.NSSItem;
 import moze_intel.projecte.emc.json.NSSItemWithNBT;
+import moze_intel.projecte.emc.json.NormalizedSimpleStack;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -34,17 +36,7 @@ public class SimpleStack
 	
 	public SimpleStack(ItemStack stack)
 	{
-		if (stack.isEmpty())
-		{
-			id = new ResourceLocation("minecraft", "air");
-			damage = 0;
-		}
-		else
-		{
-			id = stack.getItem().getRegistryName();
-			damage = stack.getItemDamage();
-		}
-		tag = null;
+		this(stack, NSSItemWithNBT.NO_IGNORES);
 	}
 	
 	public SimpleStack(ItemStack stack, String[] ignores)
@@ -56,10 +48,18 @@ public class SimpleStack
 			tag = null;
 			return;
 		}
-		NSSItemWithNBT itm = (NSSItemWithNBT) NSSItemWithNBT.create(stack, ignores);
-		id = new ResourceLocation(itm.itemName);
-		damage = itm.damage;
-		tag = itm.nbt;
+		NormalizedSimpleStack itm2 = NSSItemWithNBT.create(stack, ignores);
+		if(itm2 instanceof NSSItem){
+			NSSItem itm = (NSSItem) itm2;
+			id = new ResourceLocation(itm.itemName);
+			damage = itm.damage;
+			tag = null;
+		}else {
+			NSSItemWithNBT itm = (NSSItemWithNBT) itm2;
+			id = new ResourceLocation(itm.itemName);
+			damage = itm.damage;
+			tag = itm.nbt;
+		}
 	}
 
 	public SimpleStack withMeta(int meta)

--- a/src/main/java/moze_intel/projecte/emc/collector/WildcardSetValueFixCollector.java
+++ b/src/main/java/moze_intel/projecte/emc/collector/WildcardSetValueFixCollector.java
@@ -1,6 +1,7 @@
 package moze_intel.projecte.emc.collector;
 
 import moze_intel.projecte.emc.json.NSSItem;
+import moze_intel.projecte.emc.json.NSSItemWithNBT;
 import moze_intel.projecte.emc.json.NormalizedSimpleStack;
 import moze_intel.projecte.emc.arithmetics.IValueArithmetic;
 import net.minecraftforge.oredict.OreDictionary;
@@ -20,7 +21,7 @@ public class WildcardSetValueFixCollector<V extends Comparable<V>, A extends IVa
 	}
 
 	private boolean isWildCard(NormalizedSimpleStack nss) {
-		return nss instanceof NSSItem && ((NSSItem) nss).damage == OreDictionary.WILDCARD_VALUE;
+		return (nss instanceof NSSItem && ((NSSItem) nss).damage == OreDictionary.WILDCARD_VALUE);
 	}
 
 	@Override

--- a/src/main/java/moze_intel/projecte/emc/json/NSSItem.java
+++ b/src/main/java/moze_intel/projecte/emc/json/NSSItem.java
@@ -71,6 +71,10 @@ public class NSSItem implements NormalizedSimpleStack {
 			NSSItem other = (NSSItem) obj;
 
 			return this.itemName.equals(other.itemName) && this.damage == other.damage;
+		}if(obj instanceof NSSItemWithNBT){
+			NSSItemWithNBT other = (NSSItemWithNBT) obj;
+			return this.itemName.equals(other.itemName) && this.damage == other.damage &&
+					(other.nbt == null || other.nbt.isEmpty());
 		}
 
 		return false;

--- a/src/main/java/moze_intel/projecte/emc/json/NSSItemWithNBT.java
+++ b/src/main/java/moze_intel/projecte/emc/json/NSSItemWithNBT.java
@@ -1,0 +1,234 @@
+package moze_intel.projecte.emc.json;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import com.google.gson.Gson;
+
+import moze_intel.projecte.PECore;
+import moze_intel.projecte.emc.SimpleStack;
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTException;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagEnd;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.util.Constants.NBT;
+import net.minecraftforge.oredict.OreDictionary;
+
+public class NSSItemWithNBT implements NormalizedSimpleStack {
+	
+	public static final String[] NO_IGNORES = new String[0];
+	public static final String[] JUST_IGNORE_DAMAGE = new String[]{"$Damage"};
+	public final String itemName;
+	public final int damage;
+	public final boolean ignoreDamage;
+	public final NBTTagCompound nbt;
+
+	public NSSItemWithNBT(String itemName, int damage) {
+		this(itemName, damage, new NBTTagCompound());
+	}
+	
+	public NSSItemWithNBT(String itemName, int damage, NBTTagCompound tag) {
+		this(itemName, damage, tag, NO_IGNORES);
+	}
+	
+	public NSSItemWithNBT(String itemName, int damage, NBTTagCompound tag, String[] nbtsToIgnore) {
+		this.itemName = itemName;
+		this.damage = damage;
+		nbt = tag.copy();
+		boolean dmgIgn = false;
+		for(String s: nbtsToIgnore){
+			if(s.equalsIgnoreCase("$Damage")){
+				dmgIgn = true;
+			}else{
+				NBTTagCompound toChange = tag;
+				String[] tree = s.split("::");
+				for(int i = 0; i < tree.length-1; i++){
+					tag.getTag(tree[i]);
+				}
+				tag.removeTag(tree[tree.length -1]);
+			}
+		}
+		ignoreDamage = dmgIgn;
+		if (tag.getKeySet().isEmpty())
+			tag = null;
+	}
+	
+	public static NormalizedSimpleStack create(ItemStack stack) {
+		if (stack.isEmpty()) return null;
+		return create(stack.getItem(), stack.getItemDamage(), stack.getTagCompound(), NO_IGNORES);
+	}
+	public static NormalizedSimpleStack create(ItemStack stack, String[] NBTToIgnore) {
+		if (stack.isEmpty()) return null;
+		return create(stack.getItem(), stack.getItemDamage(), stack.getTagCompound(), NBTToIgnore);
+	}
+
+	private static NormalizedSimpleStack create(Item item, int meta, NBTTagCompound tag, String[] NBTToIgnore) {
+
+		return create(item.getRegistryName(), meta, tag, NBTToIgnore);
+	}
+
+	private static NormalizedSimpleStack create(ResourceLocation uniqueIdentifier, int damage, NBTTagCompound tag, String[] NBTtoIgnore) {
+		if (uniqueIdentifier == null) return null;
+		return create(uniqueIdentifier.toString(), damage, tag, NBTtoIgnore);
+	}
+
+	public static NormalizedSimpleStack create(String itemName, int damage, NBTTagCompound tag, String[] NBTtoIgnore) {
+		NormalizedSimpleStack normStack;
+		try {
+			if(tag == null)
+				normStack = new NSSItemWithNBT(itemName, damage);
+			else
+				normStack = new NSSItemWithNBT(itemName, damage, tag, NBTtoIgnore);
+		} catch (Exception e) {
+			PECore.LOGGER.fatal("Could not create NSSItemWithNBT: {}", e.getMessage());
+			return null;
+		}
+		return normStack;
+	}
+
+	@Override
+	public int hashCode() {
+		return itemName.hashCode() ^ damage;
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof NSSItemWithNBT) {
+			NSSItemWithNBT other = (NSSItemWithNBT) obj;
+			if(this.itemName.equals(other.itemName) && this.damage == other.damage){
+				if(this.nbt == null)
+					return other.nbt == null;
+				if(other.nbt == null)
+					return false;
+				return this.nbt.toString().equalsIgnoreCase(other.nbt.toString());
+			}
+			return false;
+		}
+
+		return false;
+	}
+
+	@Override
+	public String json() {
+		String orgFormat = String.format("%s|%s", itemName, damage == OreDictionary.WILDCARD_VALUE ? "*" : damage);
+		if(nbt == null || nbt.isEmpty())
+			return orgFormat;
+		String nbtFormat = NBTToParseableString(nbt);
+		return orgFormat + "|"+nbtFormat;
+	}
+
+	public static String NBTToParseableString(NBTTagCompound nbt2) {
+		return nbt2.toString();
+	}
+	
+	@Override
+	public String toString() {
+		return String.format("%s:%s", itemName, damage == OreDictionary.WILDCARD_VALUE ? "*" : damage);
+	}
+
+	public boolean equalsEvenPartially(Object obj) {
+		if (obj instanceof NSSItemWithNBT) {
+			NSSItemWithNBT other = (NSSItemWithNBT) obj;
+			if(this.itemName.equals(other.itemName) && this.damage == other.damage){
+				if(this.nbt == null)
+					return other.nbt == null;
+				if(other.nbt == null)
+					return false;
+				for(String key: this.nbt.getKeySet()){
+					if(!other.nbt.hasKey(key))
+						return false;
+					if(other.nbt.getTag(key).getClass() != this.nbt.getTag(key).getClass())
+						return false;
+					if(this.nbt.getTag(key) instanceof NBTTagCompound){
+						if(!NSSItemWithNBT.isNBTContained(this.nbt.getCompoundTag(key), other.nbt.getCompoundTag(key))){
+							return false;
+						}
+					}else{
+						if(!this.nbt.getTag(key).equals(other.nbt.getTag(key)))
+							return false;
+					}
+					
+				}
+				return true;
+			}
+			return false;
+		}
+
+		return false;
+	}
+
+	public SimpleStack toSimpleStack() {
+		int dam = damage;
+		if(ignoreDamage)
+			dam = 0;
+		if(nbt == null){
+			return new SimpleStack(new ResourceLocation(itemName),dam);
+		}else{
+			return new SimpleStack(new ResourceLocation(itemName),dam, nbt);
+		}
+	}
+	
+	public static boolean isNBTContained(NBTTagCompound containerTag,
+			NBTTagCompound containeeTag) {
+		if(containerTag == null && containeeTag == null)
+			return true;
+		if(containeeTag == null)
+			return false;
+		for(String key: containerTag.getKeySet()){
+			if(!containeeTag.hasKey(key))
+				return false;
+			if(containerTag.getTag(key).getClass() != containeeTag.getTag(key).getClass())
+				return false;
+			if(containerTag.getTag(key) instanceof NBTTagCompound){
+				if(!isNBTContained(containerTag.getCompoundTag(key), containeeTag.getCompoundTag(key))){
+					return false;
+				}
+			}else{
+				if(!containerTag.getTag(key).equals(containeeTag.getTag(key)))
+					return false;
+			}
+		}
+		return true;
+	}
+
+	/**Simple metric for measuring the similarity between two NBTTags.
+	 * Similarity is determined as the sum of tag keys of the container tag present,
+	 * in the containee tag, +1 if they are of same classes and +1 if they are equal,
+	 * with a bonus of +similarity of every NBTTagCompund that are contained in both.*/
+	public static int NBTSimilarity(NBTTagCompound containerTag,
+			NBTTagCompound containeeTag) {
+		int simi = 0;
+		if(containerTag.isEmpty())
+			return 1;
+		for(String key: containerTag.getKeySet()){
+			if(containeeTag.hasKey(key)){
+				simi++;
+			}else{
+				return 0;
+			}
+			if(containerTag.getTag(key).getClass() == containeeTag.getTag(key).getClass()){
+				simi++;
+			}else{
+				return 0;
+			}
+			if(containerTag.getTag(key) instanceof NBTTagCompound){
+				int newSimi = NBTSimilarity(containerTag.getCompoundTag(key), containeeTag.getCompoundTag(key));
+				if (newSimi <= 0)
+					return 0;
+				simi += newSimi;
+			}else if(containerTag.getTag(key).equals(containeeTag.getTag(key))){
+					simi++;
+			}else{
+				return 0;
+			}
+		}
+		return simi;
+	}
+	
+}

--- a/src/main/java/moze_intel/projecte/emc/json/NSSItemWithNBT.java
+++ b/src/main/java/moze_intel/projecte/emc/json/NSSItemWithNBT.java
@@ -81,8 +81,8 @@ public class NSSItemWithNBT implements NormalizedSimpleStack {
 	public static NormalizedSimpleStack create(String itemName, int damage, NBTTagCompound tag, String[] NBTtoIgnore) {
 		NormalizedSimpleStack normStack;
 		try {
-			if(tag == null)
-				normStack = new NSSItemWithNBT(itemName, damage);
+			if(tag == null || tag.isEmpty())
+				normStack = new NSSItem(itemName, damage);
 			else
 				normStack = new NSSItemWithNBT(itemName, damage, tag, NBTtoIgnore);
 		} catch (Exception e) {
@@ -94,7 +94,7 @@ public class NSSItemWithNBT implements NormalizedSimpleStack {
 
 	@Override
 	public int hashCode() {
-		return itemName.hashCode() ^ damage;
+		return itemName.hashCode() ^ damage ^nbt.toString().hashCode();
 	}
 	
 	@Override
@@ -109,6 +109,10 @@ public class NSSItemWithNBT implements NormalizedSimpleStack {
 				return this.nbt.toString().equalsIgnoreCase(other.nbt.toString());
 			}
 			return false;
+		}else if(obj instanceof NSSItem){
+			NSSItem other = (NSSItem) obj;
+			return this.itemName.equals(other.itemName) && this.damage == other.damage &&
+				((this.nbt == null || this.nbt.isEmpty()));
 		}
 
 		return false;
@@ -129,7 +133,7 @@ public class NSSItemWithNBT implements NormalizedSimpleStack {
 	
 	@Override
 	public String toString() {
-		return String.format("%s:%s", itemName, damage == OreDictionary.WILDCARD_VALUE ? "*" : damage);
+		return String.format("%s:%s", itemName, damage == OreDictionary.WILDCARD_VALUE ? "*" : damage) + "|" +nbt.toString();
 	}
 
 	public boolean equalsEvenPartially(Object obj) {

--- a/src/main/java/moze_intel/projecte/emc/mappers/APICustomEMCMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/APICustomEMCMapper.java
@@ -2,8 +2,10 @@ package moze_intel.projecte.emc.mappers;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+
 import moze_intel.projecte.PECore;
 import moze_intel.projecte.emc.json.NSSItem;
+import moze_intel.projecte.emc.json.NSSItemWithNBT;
 import moze_intel.projecte.emc.json.NormalizedSimpleStack;
 import moze_intel.projecte.emc.collector.IMappingCollector;
 import moze_intel.projecte.impl.ConversionProxyImpl;
@@ -46,6 +48,26 @@ public class APICustomEMCMapper implements IEMCMapper<NormalizedSimpleStack, Lon
 		modMap.put(NSSItem.create(stack), emcValue);
 	}
 
+	public void registerCustomEMCWithNBT(ItemStack stack, long emcValue) {
+		registerCustomEMCWithNBT(stack, NSSItemWithNBT.NO_IGNORES, emcValue);
+	}
+	
+	public void registerCustomEMCWithNBT(ItemStack stack,String[] ignores, long emcValue) {
+		if (stack.isEmpty()) return;
+		if (emcValue < 0) emcValue = 0;
+		ModContainer activeMod = Loader.instance().activeModContainer();
+		String modId = activeMod == null ? null : activeMod.getModId();
+		Map<NormalizedSimpleStack, Long> modMap;
+		if (customEMCforMod.containsKey(modId)) {
+			modMap = customEMCforMod.get(modId);
+		} else {
+			modMap = new HashMap<>();
+			customEMCforMod.put(modId, modMap);
+		}
+		modMap.put(NSSItemWithNBT.create(stack, ignores), emcValue);
+	}
+
+	
 	public void registerCustomEMC(Object o, long emcValue) {
 		NormalizedSimpleStack stack = ConversionProxyImpl.instance.objectToNSS(o);
 		if (stack == null) return;
@@ -156,7 +178,10 @@ public class APICustomEMCMapper implements IEMCMapper<NormalizedSimpleStack, Lon
 		{
 			NSSItem item = (NSSItem)stack;
 			itemName = item.itemName;
-		} else {
+		} else if (stack instanceof NSSItemWithNBT){
+			NSSItemWithNBT item = (NSSItemWithNBT)stack;
+			itemName = item.itemName;
+		}else {
 			itemName = "IntermediateFakeItemsUsedInRecipes:";
 		}
 		String modForItem = itemName.substring(0, itemName.indexOf(':'));

--- a/src/main/java/moze_intel/projecte/emc/mappers/BrewingMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/BrewingMapper.java
@@ -1,0 +1,184 @@
+package moze_intel.projecte.emc.mappers;
+
+import moze_intel.projecte.PECore;
+import moze_intel.projecte.emc.IngredientMap;
+import moze_intel.projecte.emc.SimpleGraphMapper;
+import moze_intel.projecte.emc.SimpleStack;
+import moze_intel.projecte.emc.json.NSSFake;
+import moze_intel.projecte.emc.json.NSSItem;
+import moze_intel.projecte.emc.json.NSSItemWithNBT;
+import moze_intel.projecte.emc.json.NormalizedSimpleStack;
+import moze_intel.projecte.emc.arithmetics.HiddenBigFractionArithmetic;
+import moze_intel.projecte.emc.collector.IMappingCollector;
+import moze_intel.projecte.emc.collector.LongToBigFractionCollector;
+import moze_intel.projecte.emc.collector.MappingCollector;
+import moze_intel.projecte.emc.collector.WildcardSetValueFixCollector;
+import moze_intel.projecte.gameObjs.customRecipes.RecipeShapelessHidden;
+import moze_intel.projecte.gameObjs.customRecipes.RecipeShapelessKleinStar;
+import net.minecraft.init.Items;
+import net.minecraft.init.PotionTypes;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemLingeringPotion;
+import net.minecraft.item.ItemPotion;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.CraftingManager;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.item.crafting.ShapedRecipes;
+import net.minecraft.item.crafting.ShapelessRecipes;
+import net.minecraft.potion.PotionHelper;
+import net.minecraft.potion.PotionType;
+import net.minecraft.potion.PotionUtils;
+import net.minecraft.util.datafix.fixes.PotionItems;
+import net.minecraftforge.common.brewing.BrewingRecipeRegistry;
+import net.minecraftforge.common.brewing.IBrewingRecipe;
+import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
+import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.oredict.ShapedOreRecipe;
+import net.minecraftforge.oredict.ShapelessOreRecipe;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class BrewingMapper implements IEMCMapper<NormalizedSimpleStack, Long> {
+
+	private static final String[] POTION_TYPE_CONVERSIONS = new String[]{"field_185213_a", "POTION_TYPE_CONVERSIONS"};
+    private static final String[] POTION_ITEM_CONVERSIONS = new String[]{"field_185214_b", "POTION_ITEM_CONVERSIONS"};
+	
+	@Override
+	public void addMappings(IMappingCollector<NormalizedSimpleStack, Long> mapper, final Configuration config) {
+		int ItemCount = 0;
+		int TypeCount = 0;
+		/*First, let's add a conversion between bottle of water(potion) and a known EMC value (empty bottle)*/
+		ItemStack bottleOfWater = PotionUtils.addPotionToItemStack(new ItemStack(Items.POTIONITEM), PotionTypes.WATER);
+		ArrayList<NormalizedSimpleStack> recipeValues = new ArrayList<>();
+		recipeValues.add(NSSItem.create(new ItemStack(Items.GLASS_BOTTLE)));
+		mapper.addConversion(1, NSSItemWithNBT.create(bottleOfWater), recipeValues);
+		
+		/*What follows seems really ineficient, but is the best we can do*/
+		 List<Object> itemConversions = ReflectionHelper.getPrivateValue(PotionHelper.class, null, POTION_ITEM_CONVERSIONS);
+	     List<Object> typeConversions = ReflectionHelper.getPrivateValue(PotionHelper.class, null, POTION_TYPE_CONVERSIONS);
+
+	     //Collection of potion items (classes of potions) for later adding all classes to all types
+	     HashSet<Item> potionItems = new HashSet<>();
+	     HashSet<PotionType> potionTypes = new HashSet<>();
+	     potionItems.add(bottleOfWater.getItem());
+	     List<ItemStack[]> potionItemsConverters = new ArrayList<>();
+	     
+	     //First, find all potion Class recipes (Potion to Splash, Splash to Lingering)
+	     for(Object obj : itemConversions){
+	    	 try{
+	    	 Field input = ReflectionHelper.findField(obj.getClass(), "input", "field_185198_a");
+	    	 Field reagent =ReflectionHelper.findField(obj.getClass(), "reagent", "field_185199_b");
+	    	 Field output =ReflectionHelper.findField(obj.getClass(), "output", "field_185198_c");
+	    	 
+	    	 net.minecraftforge.registries.IRegistryDelegate<Item> in = (net.minecraftforge.registries.IRegistryDelegate<Item>)input.get(obj);
+	    	 Ingredient reag = (Ingredient)reagent.get(obj);
+	    	 net.minecraftforge.registries.IRegistryDelegate<Item> out = (net.minecraftforge.registries.IRegistryDelegate<Item>)output.get(obj);
+	    	 potionItems.add(in.get());
+	    	 potionItems.add(out.get());
+	    	 for(ItemStack reagItmStack: reag.getMatchingStacks()){
+	    		 recipeValues = new ArrayList<>();
+	    		 potionItemsConverters.add(new ItemStack[]{new ItemStack(in.get(), 3),reagItmStack, new ItemStack(out.get(),3)});
+	    		 recipeValues.add(NSSItemWithNBT.create(reagItmStack));
+	    		 recipeValues.add(NSSItemWithNBT.create(new ItemStack(in.get())));
+	    		 recipeValues.add(NSSItemWithNBT.create(new ItemStack(in.get())));
+	    		 recipeValues.add(NSSItemWithNBT.create(new ItemStack(in.get())));
+	    		 mapper.addConversion(3, NSSItemWithNBT.create(new ItemStack(out.get())), recipeValues);
+	    		 ItemCount++;
+	    	 }
+	    	 }catch (Exception ex){
+	    		 PECore.LOGGER.error("Brewing mapper: could not find fields "+ ex.getMessage());
+	    		 return;
+	    	 }
+	     }
+	     //next, find all brewing recipes that create actual potions of the same class
+	     for(Object obj : typeConversions){
+	    	 try{
+	    	 Field input = ReflectionHelper.findField(obj.getClass(), "input", "field_185198_a");
+	    	 Field reagent =ReflectionHelper.findField(obj.getClass(), "reagent", "field_185199_b");
+	    	 Field output =ReflectionHelper.findField(obj.getClass(), "output", "field_185200_c");
+	    	 
+	    	 net.minecraftforge.registries.IRegistryDelegate<PotionType> in = (net.minecraftforge.registries.IRegistryDelegate<PotionType>)input.get(obj);
+	    	 Ingredient reag = (Ingredient)reagent.get(obj);
+	    	 net.minecraftforge.registries.IRegistryDelegate<PotionType> out = (net.minecraftforge.registries.IRegistryDelegate<PotionType>)output.get(obj);
+	    	 potionTypes.add(in.get());
+	    	 potionTypes.add(out.get());
+	    	 for(ItemStack reagItmStack: reag.getMatchingStacks()){
+	    		 for(Item potClass : potionItems){
+	    			 ItemStack inStack = new ItemStack(potClass);
+	    			 inStack = PotionUtils.addPotionToItemStack(inStack, in.get());
+	    			 ItemStack outStack = new ItemStack(potClass);
+	    			 outStack = PotionUtils.addPotionToItemStack(outStack, out.get());
+	    			 recipeValues = new ArrayList<>();
+	    			 recipeValues.add(NSSItemWithNBT.create(reagItmStack));
+	    			 recipeValues.add(NSSItemWithNBT.create(inStack));
+	    			 recipeValues.add(NSSItemWithNBT.create(inStack));
+	    			 recipeValues.add(NSSItemWithNBT.create(inStack));
+	    			 mapper.addConversion(3, NSSItemWithNBT.create(outStack), recipeValues);
+	    		 }
+	    		 TypeCount++;
+	    	 }
+	    	 }catch (Exception ex){
+	    		 PECore.LOGGER.error("Brewing mapper: could not find fields "+ ex.getMessage());
+	    		 return;
+	    	 }
+	     }
+	     
+	     //finally, add mappings between all potion Types changing classes (ie: Potion of harming to Splash potion of harming) 
+	     for(ItemStack[] potClass: potionItemsConverters){
+	    	 for(PotionType potType: potionTypes){
+	    		 ItemStack inStack = potClass[0].copy();
+    			 inStack = PotionUtils.addPotionToItemStack(inStack, potType);
+    			 ItemStack outStack = potClass[2].copy();
+    			 outStack = PotionUtils.addPotionToItemStack(outStack, potType);
+    			 recipeValues = new ArrayList<>();
+    			 recipeValues.add(NSSItemWithNBT.create(potClass[1]));
+    			 recipeValues.add(NSSItemWithNBT.create(inStack));
+    			 recipeValues.add(NSSItemWithNBT.create(inStack));
+    			 recipeValues.add(NSSItemWithNBT.create(inStack));
+    			 mapper.addConversion(3, NSSItemWithNBT.create(outStack), recipeValues);
+	    	 }
+	     }
+	     //PS: Assume tipped arrows can be crafted with any potionEffect
+	     ItemStack arrow = new ItemStack(Items.ARROW, 8);
+	     for(PotionType potType: potionTypes){
+    		 ItemStack inStack = new ItemStack(Items.LINGERING_POTION);
+			 inStack = PotionUtils.addPotionToItemStack(inStack, potType);
+			 ItemStack outStack = new ItemStack(Items.TIPPED_ARROW);
+			 outStack = PotionUtils.addPotionToItemStack(outStack, potType);
+			 recipeValues = new ArrayList<>();
+			 recipeValues.add(NSSItemWithNBT.create(arrow));
+			 recipeValues.add(NSSItemWithNBT.create(inStack));
+			 mapper.addConversion(8, NSSItemWithNBT.create(outStack), recipeValues);
+    	 }
+	     
+		PECore.debugLog("BrewingMapper Statistics:");	
+		PECore.debugLog("Found {} Recipes of changing Item Type", ItemCount);
+		PECore.debugLog("Found {} Recipes of changing Potion Type", TypeCount);
+	}
+
+	@Override
+	public String getName() {
+		return "BrewingMapper";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Add Conversions for Brewing Recipes gathered from PotionHelper's fields";
+	}
+
+	@Override
+	public boolean isAvailable() {
+		return true;
+	}
+}

--- a/src/main/java/moze_intel/projecte/emc/mappers/BrewingMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/BrewingMapper.java
@@ -79,7 +79,7 @@ public class BrewingMapper implements IEMCMapper<NormalizedSimpleStack, Long> {
 	    	 try{
 	    	 Field input = ReflectionHelper.findField(obj.getClass(), "input", "field_185198_a");
 	    	 Field reagent =ReflectionHelper.findField(obj.getClass(), "reagent", "field_185199_b");
-	    	 Field output =ReflectionHelper.findField(obj.getClass(), "output", "field_185198_c");
+	    	 Field output =ReflectionHelper.findField(obj.getClass(), "output", "field_185200_c");
 	    	 
 	    	 net.minecraftforge.registries.IRegistryDelegate<Item> in = (net.minecraftforge.registries.IRegistryDelegate<Item>)input.get(obj);
 	    	 Ingredient reag = (Ingredient)reagent.get(obj);

--- a/src/main/java/moze_intel/projecte/emc/mappers/CraftingMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/CraftingMapper.java
@@ -4,6 +4,7 @@ import moze_intel.projecte.PECore;
 import moze_intel.projecte.emc.IngredientMap;
 import moze_intel.projecte.emc.json.NSSFake;
 import moze_intel.projecte.emc.json.NSSItem;
+import moze_intel.projecte.emc.json.NSSItemWithNBT;
 import moze_intel.projecte.emc.json.NormalizedSimpleStack;
 import moze_intel.projecte.emc.collector.IMappingCollector;
 import moze_intel.projecte.gameObjs.customRecipes.RecipeShapelessHidden;
@@ -43,7 +44,7 @@ public class CraftingMapper implements IEMCMapper<NormalizedSimpleStack, Long> {
 			boolean handled = false;
 			ItemStack recipeOutput = recipe.getRecipeOutput();
 			if (recipeOutput.isEmpty()) continue;
-			NormalizedSimpleStack recipeOutputNorm = NSSItem.create(recipeOutput);
+			NormalizedSimpleStack recipeOutputNorm = NSSItemWithNBT.create(recipeOutput);
 			for (IRecipeMapper recipeMapper : recipeMappers) {
 				if (!config.getBoolean("enable" + recipeMapper.getName(), "IRecipeImplementations", true, recipeMapper.getDescription()))
 					continue;
@@ -55,9 +56,9 @@ public class CraftingMapper implements IEMCMapper<NormalizedSimpleStack, Long> {
 							if (stack.isEmpty()) continue;
 							try {
 								if (stack.getItemDamage() != OreDictionary.WILDCARD_VALUE && stack.getItem().hasContainerItem(stack)) {
-									ingredientMap.addIngredient(NSSItem.create(stack.getItem().getContainerItem(stack)), -1);
+									ingredientMap.addIngredient(NSSItemWithNBT.create(stack.getItem().getContainerItem(stack)), -1);
 								}
-								ingredientMap.addIngredient(NSSItem.create(stack), 1);
+								ingredientMap.addIngredient(NSSItemWithNBT.create(stack), 1);
 							} catch (Exception e) {
 								PECore.LOGGER.fatal("Exception in CraftingMapper when parsing Recipe Ingredients: RecipeType: {}, Ingredient: {}", recipe.getClass().getName(), stack.toString());
 								e.printStackTrace();
@@ -71,9 +72,9 @@ public class CraftingMapper implements IEMCMapper<NormalizedSimpleStack, Long> {
 								if (stack.isEmpty()) continue;
 								IngredientMap<NormalizedSimpleStack> groupIngredientMap = new IngredientMap<>();
 								if (stack.getItem().hasContainerItem(stack)) {
-									groupIngredientMap.addIngredient(NSSItem.create(stack.getItem().getContainerItem(stack)), -1);
+									groupIngredientMap.addIngredient(NSSItemWithNBT.create(stack.getItem().getContainerItem(stack)), -1);
 								}
-								groupIngredientMap.addIngredient(NSSItem.create(stack), 1);
+								groupIngredientMap.addIngredient(NSSItemWithNBT.create(stack), 1);
 								mapper.addConversion(1, dummy, groupIngredientMap.getMap());
 							}
 						}

--- a/src/main/java/moze_intel/projecte/emc/mappers/CustomEMCMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/CustomEMCMapper.java
@@ -1,9 +1,16 @@
 package moze_intel.projecte.emc.mappers;
 
+import java.util.List;
+
 import moze_intel.projecte.PECore;
 import moze_intel.projecte.config.CustomEMCParser;
+import moze_intel.projecte.config.CustomEMCParser.CustomEMCEntry;
+import moze_intel.projecte.emc.json.NSSItem;
+import moze_intel.projecte.emc.json.NSSOreDictionary;
 import moze_intel.projecte.emc.json.NormalizedSimpleStack;
 import moze_intel.projecte.emc.collector.IMappingCollector;
+import moze_intel.projecte.utils.ItemHelper;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.config.Configuration;
 
 public class CustomEMCMapper implements IEMCMapper<NormalizedSimpleStack, Long> {
@@ -13,7 +20,18 @@ public class CustomEMCMapper implements IEMCMapper<NormalizedSimpleStack, Long> 
 			PECore.debugLog("Adding custom EMC value from mod " + key);
 			for (CustomEMCParser.CustomEMCEntry entry : CustomEMCParser.customEMCEntries.get(key)) {
 				PECore.debugLog("Adding custom EMC value for {}: {}", entry.nss, entry.emc);
-				mapper.setValueBefore(entry.nss, entry.emc);
+				if(entry.nss instanceof NSSOreDictionary){
+					 NSSOreDictionary ore = (NSSOreDictionary)entry.nss;
+					 List<ItemStack> ores = ItemHelper.getODItems(ore.od);
+					 for(ItemStack itm: ores){
+						 NSSItem itm2 = (NSSItem) NSSItem.create(itm);
+						 if(!CustomEMCParser.containsItem(itm2)){
+							 mapper.setValueBefore(itm2, entry.emc);
+						 }
+					 }
+				}else{
+					mapper.setValueBefore(entry.nss, entry.emc);
+				}
 			}
 		}
 	}

--- a/src/main/java/moze_intel/projecte/emc/mappers/CustomEMCMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/CustomEMCMapper.java
@@ -9,9 +9,12 @@ import net.minecraftforge.common.config.Configuration;
 public class CustomEMCMapper implements IEMCMapper<NormalizedSimpleStack, Long> {
 	@Override
 	public void addMappings(IMappingCollector<NormalizedSimpleStack, Long> mapper, Configuration config) {
-		for (CustomEMCParser.CustomEMCEntry entry : CustomEMCParser.currentEntries.entries) {
-			PECore.debugLog("Adding custom EMC value for {}: {}", entry.nss, entry.emc);
-			mapper.setValueBefore(entry.nss, entry.emc);
+		for(String key: CustomEMCParser.customEMCEntries.keySet()){
+			PECore.debugLog("Adding custom EMC value from mod " + key);
+			for (CustomEMCParser.CustomEMCEntry entry : CustomEMCParser.customEMCEntries.get(key)) {
+				PECore.debugLog("Adding custom EMC value for {}: {}", entry.nss, entry.emc);
+				mapper.setValueBefore(entry.nss, entry.emc);
+			}
 		}
 	}
 

--- a/src/main/java/moze_intel/projecte/emc/nbt/ItemStackNBTManager.java
+++ b/src/main/java/moze_intel/projecte/emc/nbt/ItemStackNBTManager.java
@@ -1,0 +1,373 @@
+package moze_intel.projecte.emc.nbt;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.commons.math3.fraction.BigFraction;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+import moze_intel.projecte.PECore;
+import moze_intel.projecte.api.proxy.IItemNBTEmcCalculator;
+import moze_intel.projecte.api.proxy.IItemNBTEmcCalculator.Operation;
+import moze_intel.projecte.api.proxy.IItemNBTFilter;
+import moze_intel.projecte.emc.nbt.calculators.DurabilityCalculator;
+import moze_intel.projecte.emc.nbt.calculators.EnchantmentCalculator;
+import moze_intel.projecte.emc.nbt.calculators.StoredEMCCalculator;
+import moze_intel.projecte.emc.nbt.cleaners.ItemNBTEnchantmentTagCleaner;
+import moze_intel.projecte.emc.nbt.cleaners.ItemNBTNameTagCleaner;
+import moze_intel.projecte.emc.nbt.cleaners.ItemNBTProjectEActiveModeCleaner;
+import moze_intel.projecte.emc.nbt.cleaners.ItemNBTStoredEMCCleaner;
+
+public class ItemStackNBTManager {
+
+	public static final Map<String, List<IItemNBTFilter>> cleanerMap = new HashMap<>();
+	public static final Map<String, List<IItemNBTEmcCalculator>> calcMap = new HashMap<>();
+	
+	public static final IItemNBTFilter enchantmentRemover = new ItemNBTEnchantmentTagCleaner();
+	
+	static{
+		registerCleaner(new ItemNBTNameTagCleaner());
+		registerCleaner(new ItemNBTStoredEMCCleaner());
+		registerCleaner(new ItemNBTProjectEActiveModeCleaner());
+		registerCalculator(new EnchantmentCalculator());
+		registerCalculator(new DurabilityCalculator());
+		registerCalculator(new StoredEMCCalculator());
+	}
+	
+	public static ItemStack clean(ItemStack input){
+		ItemStack filtered = input.copy();
+		if(filtered.getTagCompound() == null)
+			return filtered;
+		if(filtered.getTagCompound().isEmpty()){
+			filtered.setTagCompound(null);
+			return filtered;
+		}
+			
+		if(cleanerMap.containsKey("*")){
+			for(IItemNBTFilter filter: cleanerMap.get("*")){
+				if(filter.canFilterStack(filtered)){
+					filtered = filter.getFilteredItemStack(filtered);
+				}
+			}
+		}
+		if(cleanerMap.containsKey(input.getItem().getRegistryName().getPath()+ ":*")){
+			for(IItemNBTFilter filter: cleanerMap.get(input.getItem().getRegistryName().getPath()+ ":*")){
+				if(filter.canFilterStack(filtered)){
+					filtered = filter.getFilteredItemStack(filtered);
+				}
+			}
+		}
+		if(cleanerMap.containsKey(input.getItem().getRegistryName().toString())){
+			for(IItemNBTFilter filter: cleanerMap.get(input.getItem().getRegistryName().toString())){
+				if(filter.canFilterStack(filtered)){
+					filtered = filter.getFilteredItemStack(filtered);
+				}
+			}
+		}
+		
+		if(cleanerMap.containsKey(input.getItem().getRegistryName().toString() + "|"+input.getMetadata())){
+			for(IItemNBTFilter filter: cleanerMap.get(input.getItem().getRegistryName().toString()+ "|"+input.getMetadata())){
+				if(filter.canFilterStack(filtered)){
+					filtered = filter.getFilteredItemStack(filtered);
+				}
+			}
+		}
+		for(int k: OreDictionary.getOreIDs(input)){
+			if(cleanerMap.containsKey(OreDictionary.getOreName(k))){
+				for(IItemNBTFilter filter: cleanerMap.get(OreDictionary.getOreName(k))){
+					if(filter.canFilterStack(filtered)){
+						filtered = filter.getFilteredItemStack(filtered);
+					}
+				}
+			}
+		}
+		if(filtered.getTagCompound() == null || filtered.getTagCompound().isEmpty())
+			filtered.setTagCompound(null);
+		return filtered;
+	}
+	public static long getEMCValue(ItemStack input){
+		return getEMCValue(input,0);
+	}
+	public static long getEMCValue(ItemStack input, long original){
+		Set<Long> setValues = new TreeSet<Long>();
+		BigFraction added = new BigFraction(0);
+		BigFraction multiply = new BigFraction(1);
+		setValues.add(original);
+		
+		if(calcMap.containsKey("*")){
+			for(IItemNBTEmcCalculator calculator: calcMap.get("*")){
+				if(calculator.canProcessItem(input)){
+					BigFraction total = calculator.getEMC(input);
+					Operation op = calculator.getOperation(input);
+					switch(op){
+					case OP_ADD:
+					case OP_SUBTRACT:
+						added= op.operate(added, total);
+						break;
+					case OP_MUlTIPLY:
+					case OP_DIVIDE:
+						multiply = op.operate(multiply, total);
+						break;
+					case OP_SET:
+						setValues.add(total.longValue());
+					default:
+					}
+				}
+			}
+		}
+		if(calcMap.containsKey(input.getItem().getRegistryName().getPath() + ":*")){
+			for(IItemNBTEmcCalculator calculator: calcMap.get(input.getItem().getRegistryName().getPath() + ":*")){
+				if(calculator.canProcessItem(input)){
+					BigFraction total = calculator.getEMC(input);
+					Operation op = calculator.getOperation(input);
+					switch(op){
+					case OP_ADD:
+					case OP_SUBTRACT:
+						added= op.operate(added, total);
+						break;
+					case OP_MUlTIPLY:
+					case OP_DIVIDE:
+						multiply = op.operate(multiply, total);
+						break;
+					case OP_SET:
+						setValues.add(total.longValue());
+					default:
+					}
+				}
+			}
+		}
+		if(calcMap.containsKey(input.getItem().getRegistryName().toString())){
+			for(IItemNBTEmcCalculator calculator: calcMap.get(input.getItem().getRegistryName().toString())){
+				if(calculator.canProcessItem(input)){
+					BigFraction total = calculator.getEMC(input);
+					Operation op = calculator.getOperation(input);
+					switch(op){
+					case OP_ADD:
+					case OP_SUBTRACT:
+						added= op.operate(added, total);
+						break;
+					case OP_MUlTIPLY:
+					case OP_DIVIDE:
+						multiply = op.operate(multiply, total);
+						break;
+					case OP_SET:
+						setValues.add(total.longValue());
+					default:
+					}
+				}
+			}
+		}
+		if(calcMap.containsKey(input.getItem().getRegistryName().toString() + "|" + input.getMetadata())){
+			for(IItemNBTEmcCalculator calculator: calcMap.get(input.getItem().getRegistryName().toString()+ "|" + input.getMetadata())){
+				if(calculator.canProcessItem(input)){
+					BigFraction total = calculator.getEMC(input);
+					Operation op = calculator.getOperation(input);
+					switch(op){
+					case OP_ADD:
+					case OP_SUBTRACT:
+						added= op.operate(added, total);
+						break;
+					case OP_MUlTIPLY:
+					case OP_DIVIDE:
+						multiply = op.operate(multiply, total);
+						break;
+					case OP_SET:
+						setValues.add(total.longValue());
+					default:
+					}
+				}
+			}
+		}
+		for(int k: OreDictionary.getOreIDs(input)){
+			if(calcMap.containsKey(OreDictionary.getOreName(k))){
+				for(IItemNBTEmcCalculator calculator: calcMap.get(OreDictionary.getOreName(k))){
+					if(calculator.canProcessItem(input)){
+						BigFraction total = calculator.getEMC(input);
+						Operation op = calculator.getOperation(input);
+						switch(op){
+						case OP_ADD:
+						case OP_SUBTRACT:
+							added= op.operate(added, total);
+							break;
+						case OP_MUlTIPLY:
+						case OP_DIVIDE:
+							multiply = op.operate(multiply, total);
+							break;
+						case OP_SET:
+							setValues.add(total.longValue());
+						default:
+						}
+					}
+				}
+			}
+		}
+		BigFraction realEMC = BigFraction.ZERO;
+		if(original > 0){
+			for(long l : setValues){
+				if(l < 0)
+					return 0;
+				if(l > 0)
+					break;
+			}
+			realEMC = new BigFraction(original);
+		}else{
+			for(long l : setValues){
+				if(l < 0)
+					return 0;
+				if(l > 0){
+					realEMC = new BigFraction(l);
+					break;
+				}
+			}
+		}
+		if(realEMC.compareTo(BigFraction.ZERO) > 0){
+			realEMC = realEMC.add(added);
+			realEMC = realEMC.multiply(multiply);
+		}
+		return realEMC.longValue();
+	}
+	
+	public static void registerCalculator(IItemNBTEmcCalculator calc){
+		Collection<String> applied = calc.allowedItems();
+		List<String> ignoreMods = new ArrayList<String>();
+		List<String> ignoreItems = new ArrayList<String>();
+		Map<String, IItemNBTEmcCalculator> calcMap2 = new HashMap<>();
+		for(String key: applied){
+			if(key.equals("*")){
+				addToCalcMap(key, calc);
+				return;
+			}
+			String[] split = key.split(":");
+			if(split.length == 1){
+				calcMap2.put(split[0],calc);
+			}else{
+				if(!ignoreMods.contains(split[0])){
+					String[] meta = split[1].split("|");
+					if(meta.length == 1){
+						if(split[1].equals("*")){
+							ignoreMods.add(split[0]);
+							ArrayList<String> toRemove = new ArrayList<String>();
+							for(String s : calcMap2.keySet()){
+								if(s.startsWith(split[0]+":")){
+									toRemove.add(s);
+								}
+							}
+							for(String s: toRemove){
+								calcMap2.remove(s);
+							}
+						}
+						calcMap2.put(key, calc);
+						ignoreItems.add(key);
+					}else{
+						if(!ignoreItems.contains(split[0]+ ":"+ meta[0])){
+							if(meta[1].equals("*")){
+								ignoreItems.add(split[0]+ ":"+ meta[0]);
+								ArrayList<String> toRemove = new ArrayList<String>();
+								for(String s : calcMap2.keySet()){
+									if(s.startsWith(split[0]+":"+ meta[0]+ "|")){
+										toRemove.add(s);
+									}
+								}
+								for(String s: toRemove){
+									calcMap2.remove(s);
+								}
+								calcMap2.put(split[0]+ ":"+ meta[0],calc);
+							}else{
+								calcMap2.put(key, calc);
+							}
+						}
+					}
+				}
+			}
+		}
+		for(String s: calcMap2.keySet()){
+			addToCalcMap(s, calc);
+		}
+	}
+	
+	public static void registerCleaner(IItemNBTFilter cleaner){
+		Collection<String> applied = cleaner.allowedItems();
+		List<String> ignoreMods = new ArrayList<String>();
+		List<String> ignoreItems = new ArrayList<String>();
+		Map<String, IItemNBTFilter> cleanerMap2 = new HashMap<>();
+		for(String key: applied){
+			if(key.equals("*")){
+				addToCleanerMap(key, cleaner);
+				return;
+			}
+			String[] split = key.split(":");
+			if(split.length == 1){
+				cleanerMap2.put(split[0],cleaner);
+			}else{
+				if(!ignoreMods.contains(split[0])){
+					String[] meta = split[1].split("|");
+					if(meta.length == 1){
+						if(split[1].equals("*")){
+							ignoreMods.add(split[0]);
+							ArrayList<String> toRemove = new ArrayList<String>();
+							for(String s : cleanerMap2.keySet()){
+								if(s.startsWith(split[0]+":")){
+									toRemove.add(s);
+								}
+							}
+							for(String s: toRemove){
+								cleanerMap2.remove(s);
+							}
+						}
+						cleanerMap2.put(key, cleaner);
+						ignoreItems.add(key);
+					}else{
+						if(!ignoreItems.contains(split[0]+ ":"+ meta[0])){
+							if(meta[1].equals("*")){
+								ignoreItems.add(split[0]+ ":"+ meta[0]);
+								ArrayList<String> toRemove = new ArrayList<String>();
+								for(String s : cleanerMap2.keySet()){
+									if(s.startsWith(split[0]+":"+ meta[0]+ "|")){
+										toRemove.add(s);
+									}
+								}
+								for(String s: toRemove){
+									cleanerMap2.remove(s);
+								}
+								cleanerMap2.put(split[0]+ ":"+ meta[0], cleaner);
+							}else{
+								cleanerMap2.put(key, cleaner);
+							}
+						}
+					}
+				}
+			}
+		}
+		for(String s: cleanerMap2.keySet()){
+			addToCleanerMap(s, cleaner);
+		}
+	}
+	
+
+	private static void addToCalcMap(String key, IItemNBTEmcCalculator calc) {
+		if(!calcMap.containsKey(key)){
+			calcMap.put(key, new ArrayList<>());
+		}
+		calcMap.get(key).add(calc);
+	}
+
+	private static void addToCleanerMap(String s, IItemNBTFilter cleaner) {
+		if(!cleanerMap.containsKey(s)){
+			cleanerMap.put(s, new ArrayList<>());
+		}
+		cleanerMap.get(s).add(cleaner);
+	}
+	
+	private static void addAllToCleanerMap(Map<String, IItemNBTFilter> map){
+		for(String s: map.keySet()){
+			addToCleanerMap(s, map.get(s));
+		}
+	}
+	
+}

--- a/src/main/java/moze_intel/projecte/emc/nbt/calculators/DurabilityCalculator.java
+++ b/src/main/java/moze_intel/projecte/emc/nbt/calculators/DurabilityCalculator.java
@@ -1,0 +1,43 @@
+package moze_intel.projecte.emc.nbt.calculators;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import net.minecraft.item.ItemStack;
+
+import org.apache.commons.math3.fraction.BigFraction;
+
+import moze_intel.projecte.api.proxy.IItemNBTEmcCalculator;
+import moze_intel.projecte.utils.ItemHelper;
+
+public class DurabilityCalculator implements IItemNBTEmcCalculator {
+
+	@Override
+	public Collection<String> allowedItems() {
+		ArrayList<String> ans = new ArrayList<String>();
+		ans.add("*");
+		return ans;
+	}
+
+	@Override
+	public boolean canProcessItem(ItemStack input) {
+		return ItemHelper.isDamageable(input);
+	}
+
+	@Override
+	public Operation getOperation(
+			ItemStack input) {
+		return canProcessItem(input)? Operation.OP_MUlTIPLY : Operation.OP_NONE;
+	}
+
+	@Override
+	public BigFraction getEMC(ItemStack input) {
+		if(!canProcessItem(input)) return BigFraction.ONE;
+		int relDamage = (input.getMaxDamage() + 1 - input.getItemDamage());
+		if (relDamage <= 0){
+			return BigFraction.ONE;
+		}
+		return new BigFraction(relDamage, input.getMaxDamage());
+	}
+
+}

--- a/src/main/java/moze_intel/projecte/emc/nbt/calculators/EnchantmentCalculator.java
+++ b/src/main/java/moze_intel/projecte/emc/nbt/calculators/EnchantmentCalculator.java
@@ -1,0 +1,40 @@
+package moze_intel.projecte.emc.nbt.calculators;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.commons.math3.fraction.BigFraction;
+
+import net.minecraft.item.ItemStack;
+import moze_intel.projecte.api.proxy.IItemNBTEmcCalculator;
+import moze_intel.projecte.utils.EMCHelper;
+
+public class EnchantmentCalculator implements IItemNBTEmcCalculator{
+
+	@Override
+	public Collection<String> allowedItems() {
+		ArrayList<String> ans = new ArrayList<String>();
+		ans.add("*");
+		return ans;
+	}
+
+	@Override
+	public boolean canProcessItem(ItemStack input) {
+		return input.getTagCompound() != null && 
+			   (input.getTagCompound().hasKey("StoredEnchantments") || 
+			   (input.getEnchantmentTagList() != null && !input.getEnchantmentTagList().isEmpty()));
+	}
+
+	@Override
+	public Operation getOperation(ItemStack input) {
+		return canProcessItem(input)? Operation.OP_ADD : Operation.OP_NONE;
+	}
+
+	@Override
+	public BigFraction getEMC(ItemStack input) {
+		if(canProcessItem(input))
+			return new BigFraction(EMCHelper.getEnchantEmcBonus(input));
+		return BigFraction.ZERO;
+	}
+
+}

--- a/src/main/java/moze_intel/projecte/emc/nbt/calculators/StoredEMCCalculator.java
+++ b/src/main/java/moze_intel/projecte/emc/nbt/calculators/StoredEMCCalculator.java
@@ -1,0 +1,43 @@
+package moze_intel.projecte.emc.nbt.calculators;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.commons.math3.fraction.BigFraction;
+
+import net.minecraft.item.ItemStack;
+import moze_intel.projecte.api.item.IItemEmc;
+import moze_intel.projecte.api.proxy.IItemNBTEmcCalculator;
+import moze_intel.projecte.utils.EMCHelper;
+
+public class StoredEMCCalculator implements IItemNBTEmcCalculator{
+
+	@Override
+	public Collection<String> allowedItems() {
+		ArrayList<String> ans = new ArrayList<String>();
+		ans.add("*");
+		return ans;
+	}
+
+	@Override
+	public boolean canProcessItem(ItemStack input) {
+		return (input.getTagCompound() != null && input.getTagCompound().hasKey("StoredEMC")) ||
+				(input.getItem() instanceof IItemEmc);
+	}
+
+	@Override
+	public Operation getOperation(ItemStack input) {
+		return canProcessItem(input)? Operation.OP_ADD : Operation.OP_NONE;
+	}
+
+	@Override
+	public BigFraction getEMC(ItemStack input) {
+		if(input.getTagCompound() != null && input.getTagCompound().hasKey("StoredEMC")) {
+			return new BigFraction(input.getTagCompound().getDouble("StoredEMC"));
+		} else if (input.getItem() instanceof IItemEmc) {
+			return new BigFraction(((IItemEmc) input.getItem()).getStoredEmc(input));
+		}
+		return BigFraction.ZERO;
+	}
+
+}

--- a/src/main/java/moze_intel/projecte/emc/nbt/cleaners/ItemNBTEnchantmentTagCleaner.java
+++ b/src/main/java/moze_intel/projecte/emc/nbt/cleaners/ItemNBTEnchantmentTagCleaner.java
@@ -1,0 +1,31 @@
+package moze_intel.projecte.emc.nbt.cleaners;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import net.minecraft.item.ItemStack;
+import moze_intel.projecte.api.proxy.IItemNBTFilter;
+
+public class ItemNBTEnchantmentTagCleaner implements IItemNBTFilter{
+
+	@Override
+	public boolean canFilterStack(ItemStack input) {
+		return (input.getEnchantmentTagList() != null && !input.getEnchantmentTagList().isEmpty());
+	}
+
+	@Override
+	public ItemStack getFilteredItemStack(ItemStack input) {
+		ItemStack ans = input.copy();
+		if(canFilterStack(input))
+			ans.getTagCompound().removeTag("ench");
+		return ans;
+	}
+
+	@Override
+	public Collection<String> allowedItems() {
+		ArrayList<String> ans = new ArrayList<String>();
+		ans.add("*");
+		return ans;
+	}
+
+}

--- a/src/main/java/moze_intel/projecte/emc/nbt/cleaners/ItemNBTNameTagCleaner.java
+++ b/src/main/java/moze_intel/projecte/emc/nbt/cleaners/ItemNBTNameTagCleaner.java
@@ -1,0 +1,31 @@
+package moze_intel.projecte.emc.nbt.cleaners;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import net.minecraft.item.ItemStack;
+import moze_intel.projecte.api.proxy.IItemNBTFilter;
+
+public class ItemNBTNameTagCleaner implements IItemNBTFilter{
+
+	@Override
+	public boolean canFilterStack(ItemStack input) {
+		return input.getTagCompound() != null && input.getTagCompound().hasKey("display");
+	}
+
+	@Override
+	public ItemStack getFilteredItemStack(ItemStack input) {
+		ItemStack ans = input.copy();
+		if(canFilterStack(input))
+			ans.getTagCompound().removeTag("display");
+		return ans;
+	}
+
+	@Override
+	public Collection<String> allowedItems() {
+		ArrayList<String> ans = new ArrayList<String>();
+		ans.add("*");
+		return ans;
+	}
+
+}

--- a/src/main/java/moze_intel/projecte/emc/nbt/cleaners/ItemNBTProjectEActiveModeCleaner.java
+++ b/src/main/java/moze_intel/projecte/emc/nbt/cleaners/ItemNBTProjectEActiveModeCleaner.java
@@ -1,0 +1,40 @@
+package moze_intel.projecte.emc.nbt.cleaners;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import net.minecraft.item.ItemStack;
+import moze_intel.projecte.api.item.IItemEmc;
+import moze_intel.projecte.api.proxy.IItemNBTFilter;
+import moze_intel.projecte.gameObjs.items.ItemPE;
+
+public class ItemNBTProjectEActiveModeCleaner implements IItemNBTFilter{
+
+	@Override
+	public boolean canFilterStack(ItemStack input) {
+		return (input.getTagCompound() != null && 
+				(input.getTagCompound().hasKey(ItemPE.TAG_ACTIVE) ||
+				input.getTagCompound().hasKey(ItemPE.TAG_MODE)));
+	}
+
+	@Override
+	public ItemStack getFilteredItemStack(ItemStack input) {
+		ItemStack ans = input.copy();
+		if(canFilterStack(input)){
+			if(ans.getTagCompound().hasKey(ItemPE.TAG_ACTIVE)){
+				ans.getTagCompound().removeTag(ItemPE.TAG_ACTIVE);
+			}if(ans.getTagCompound().hasKey(ItemPE.TAG_MODE)){
+				ans.getTagCompound().removeTag(ItemPE.TAG_MODE);
+			}
+		}
+		return ans;
+	}
+
+	@Override
+	public Collection<String> allowedItems() {
+		ArrayList<String> ans = new ArrayList<String>();
+		ans.add("*");
+		return ans;
+	}
+
+}

--- a/src/main/java/moze_intel/projecte/emc/nbt/cleaners/ItemNBTStoredEMCCleaner.java
+++ b/src/main/java/moze_intel/projecte/emc/nbt/cleaners/ItemNBTStoredEMCCleaner.java
@@ -1,0 +1,33 @@
+package moze_intel.projecte.emc.nbt.cleaners;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import net.minecraft.item.ItemStack;
+import moze_intel.projecte.api.item.IItemEmc;
+import moze_intel.projecte.api.proxy.IItemNBTFilter;
+
+public class ItemNBTStoredEMCCleaner implements IItemNBTFilter{
+
+	@Override
+	public boolean canFilterStack(ItemStack input) {
+		return (input.getTagCompound() != null && input.getTagCompound().hasKey("StoredEMC")) ||
+				(input.getItem() instanceof IItemEmc);
+	}
+
+	@Override
+	public ItemStack getFilteredItemStack(ItemStack input) {
+		ItemStack ans = input.copy();
+		if(canFilterStack(input))
+			ans.getTagCompound().removeTag("StoredEMC");
+		return ans;
+	}
+
+	@Override
+	public Collection<String> allowedItems() {
+		ArrayList<String> ans = new ArrayList<String>();
+		ans.add("*");
+		return ans;
+	}
+
+}

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
@@ -10,6 +10,7 @@ import moze_intel.projecte.emc.FuelMapper;
 import moze_intel.projecte.emc.SimpleStack;
 import moze_intel.projecte.emc.json.NSSItemWithNBT;
 import moze_intel.projecte.emc.mappers.CustomEMCMapper;
+import moze_intel.projecte.emc.nbt.ItemStackNBTManager;
 import moze_intel.projecte.utils.Constants;
 import moze_intel.projecte.utils.EMCHelper;
 import moze_intel.projecte.utils.ItemHelper;
@@ -64,57 +65,78 @@ public class TransmutationInventory extends CombinedInvWrapper
 	
 	public void handleKnowledge(ItemStack stack)
 	{
-		if (stack.getCount() > 1)
+		ItemStack filtered = stack.copy();
+		ItemStack stack2 = stack.copy();
+        if(filtered.getTagCompound() != null){
+        	if(filtered.getTagCompound().isEmpty()){
+        		filtered.setTagCompound(null);
+        	}else{
+        		filtered = ItemStackNBTManager.clean(stack);
+        	}
+        }
+		
+		if (filtered.getCount() > 1)
 		{
-			stack.setCount(1);
+			filtered.setCount(1);
 		}
 		
-		if (ItemHelper.isDamageable(stack))
+		if (ItemHelper.isDamageable(filtered))
 		{
-			stack.setItemDamage(0);
+			filtered.setItemDamage(0);
 		}
 		
-		if (!provider.hasKnowledge(stack))
+		
+		
+		if (!provider.hasKnowledge(filtered))
 		{
 			if (stack.hasTagCompound()){
-				SimpleStack simStack = new SimpleStack(stack, ItemHelper.isDamageable(stack)?
+				if(!ProjectEConfig.misc.learnEnchantedItems){
+					stack2 = ItemStackNBTManager.enchantmentRemover.getFilteredItemStack(stack2);
+				}
+				
+				SimpleStack simStack = new SimpleStack(filtered, ItemHelper.isDamageable(stack)?
 						NSSItemWithNBT.JUST_IGNORE_DAMAGE:
 						NSSItemWithNBT.NO_IGNORES);
-				if(!EMCMapper.mapContainsWithNBT(simStack, false)){
-					
-					if(stack.getItem().equals(Items.ENCHANTED_BOOK)){
-						if(ProjectEConfig.misc.learnEnchantBooks){
-							long emcVal = EMCHelper.getEmcValue(stack);
-							CustomEMCParser.addWithNBTToFile(stack, NSSItemWithNBT.NO_IGNORES, emcVal);
-							EMCMapper.insertSimpleStackWithNBTintoEMCMap(simStack, emcVal);
-						}else{
-							if(!NBTWhitelist.shouldDupeWithNBT(stack))
-								stack.setTagCompound(null);
+				
+				if(!EMCMapper.mapContainsWithNBT(simStack, false)){ //no emc mapping found for the filtered nbt
+					//try with no NBT
+					SimpleStack simStack2 = simStack.withDamageAndNBT(simStack.damage, null);
+					if(!EMCMapper.mapContains(simStack2)){ //no EMC found for the no-nbt item either.
+						
+						if(ItemStackNBTManager.getEMCValue(stack2) <= 0){//no dynamic emc found for the stack itself
+							return;
 						}
-					}else if (stack.getEnchantmentTagList() != null && !stack.getEnchantmentTagList().isEmpty()){
-						if(ProjectEConfig.misc.learnEnchantedItems){
-							ItemStack toExamine = stack.copy();
-							if(ItemHelper.isDamageable(toExamine)){
-								toExamine.setItemDamage(0);
-							}
-							long emcVal = EMCHelper.getEmcValue(toExamine);
-							CustomEMCParser.addWithNBTToFile(toExamine, NSSItemWithNBT.NO_IGNORES, emcVal);
-							EMCMapper.insertSimpleStackWithNBTintoEMCMap(simStack, emcVal);
-						}else{
-							if(!NBTWhitelist.shouldDupeWithNBT(stack))
-								stack.setTagCompound(null);
+						filtered = stack2;
+					}else{
+						long orgEMC = EMCMapper.getEmcValue(simStack2);
+						long totalEMC = ItemStackNBTManager.getEMCValue(stack2, orgEMC);
+						if(totalEMC <= 0){//EMC mapping canceled by plugin
+							return;
 						}
-					}else if (!EMCMapper.mapContainsWithNBT(simStack, true) && NBTWhitelist.shouldDupeWithNBT(stack)){
-						stack.setTagCompound(null);
+						if(orgEMC == totalEMC && !NBTWhitelist.shouldDupeWithNBT(filtered)){
+							filtered.setTagCompound(null);
+						}
 					}
+				}
+			}else{
+				SimpleStack simStack = new SimpleStack(filtered.getItem().getRegistryName(), 
+						ItemHelper.isDamageable(stack)?0:filtered.getMetadata());
+				if(!EMCMapper.mapContains(simStack)){ //no EMC found for the no-nbt item.
+					
+					if(ItemStackNBTManager.getEMCValue(stack2) <= 0){//no dynamic emc found for the stack itself
+						return;
+					}
+					filtered = stack2;
+				}else{
+					filtered.setTagCompound(null);
 				}
 			}
 
-			if (!MinecraftForge.EVENT_BUS.post(new PlayerAttemptLearnEvent(player, stack))) //Only show the "learned" text if the knowledge was added
+			if (!MinecraftForge.EVENT_BUS.post(new PlayerAttemptLearnEvent(player, filtered))) //Only show the "learned" text if the knowledge was added
 			{
 				learnFlag = 300;
 				unlearnFlag = 0;
-				provider.addKnowledge(stack);
+				provider.addKnowledge(filtered);
 			}
 
 			if (!player.getEntityWorld().isRemote)
@@ -128,32 +150,41 @@ public class TransmutationInventory extends CombinedInvWrapper
 
 	public void handleUnlearn(ItemStack stack)
 	{
-		if (stack.getCount() > 1)
+		ItemStack filtered = stack.copy();
+		ItemStack stack2 = stack.copy();
+		if(filtered.getTagCompound() != null){
+        	filtered = ItemStackNBTManager.clean(stack);
+        	if(filtered.getTagCompound() != null && filtered.getTagCompound().isEmpty()){
+        		filtered.setTagCompound(null);
+        	}
+        }
+		
+		if (filtered.getCount() > 1)
 		{
-			stack.setCount(1);
+			filtered.setCount(1);
+			stack2.setCount(1);
 		}
 
-		if (ItemHelper.isDamageable(stack))
+		if (ItemHelper.isDamageable(filtered))
 		{
-			stack.setItemDamage(0);
+			filtered.setItemDamage(0);
+			stack2.setItemDamage(0);
 		}
-
-		if (provider.hasKnowledge(stack))
+		
+		if(provider.hasKnowledge(filtered)){
+			unlearnFlag = 300;
+			learnFlag = 0;
+			
+			provider.removeKnowledge(filtered);
+			if (!player.getEntityWorld().isRemote)
+			{
+				provider.sync(((EntityPlayerMP) player));
+			}
+		}else if (provider.hasKnowledge(stack2))
 		{
 			unlearnFlag = 300;
 			learnFlag = 0;
-
-			if (stack.hasTagCompound()){
-				if(!EMCMapper.mapContainsWithNBT(
-						new SimpleStack(stack, ItemHelper.isDamageable(stack)?
-												NSSItemWithNBT.JUST_IGNORE_DAMAGE:
-												NSSItemWithNBT.NO_IGNORES))&&
-						!NBTWhitelist.shouldDupeWithNBT(stack)){
-				stack.setTagCompound(null);
-			}
-			}
-
-			provider.removeKnowledge(stack);
+			provider.removeKnowledge(stack2);
 			
 			if (!player.getEntityWorld().isRemote)
 			{

--- a/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/inventory/TransmutationInventory.java
@@ -80,8 +80,8 @@ public class TransmutationInventory extends CombinedInvWrapper
 				SimpleStack simStack = new SimpleStack(stack, ItemHelper.isDamageable(stack)?
 						NSSItemWithNBT.JUST_IGNORE_DAMAGE:
 						NSSItemWithNBT.NO_IGNORES);
-				if(!EMCMapper.mapContainsWithNBT(simStack)
-						){
+				if(!EMCMapper.mapContainsWithNBT(simStack, false)){
+					
 					if(stack.getItem().equals(Items.ENCHANTED_BOOK)){
 						if(ProjectEConfig.misc.learnEnchantBooks){
 							long emcVal = EMCHelper.getEmcValue(stack);
@@ -104,7 +104,7 @@ public class TransmutationInventory extends CombinedInvWrapper
 							if(!NBTWhitelist.shouldDupeWithNBT(stack))
 								stack.setTagCompound(null);
 						}
-					}else if(!NBTWhitelist.shouldDupeWithNBT(stack)){
+					}else if (!EMCMapper.mapContainsWithNBT(simStack, true) && NBTWhitelist.shouldDupeWithNBT(stack)){
 						stack.setTagCompound(null);
 					}
 				}

--- a/src/main/java/moze_intel/projecte/impl/KnowledgeImpl.java
+++ b/src/main/java/moze_intel/projecte/impl/KnowledgeImpl.java
@@ -113,7 +113,7 @@ public final class KnowledgeImpl {
 
             for (ItemStack s : knowledge)
             {
-                if (ItemHelper.basicAreStacksEqual(s, stack))
+                if (ItemHelper.areItemStacksEqual(s, stack))
                 {
                     return true;
                 }

--- a/src/main/java/moze_intel/projecte/network/commands/ProjectECMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/ProjectECMD.java
@@ -15,8 +15,10 @@ public class ProjectECMD extends CommandTreeBase
 		addSubcommand(new ClearKnowledgeCMD());
 		addSubcommand(new ReloadEmcCMD());
 		addSubcommand(new RemoveEmcCMD());
+		addSubcommand(new RemoveEmcNBTCMD());
 		addSubcommand(new ResetEmcCMD());
 		addSubcommand(new SetEmcCMD());
+		addSubcommand(new SetEmcNBTCMD());
 		addSubcommand(new ShowBagCMD());
 	}
 

--- a/src/main/java/moze_intel/projecte/network/commands/RemoveEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/RemoveEmcCMD.java
@@ -10,6 +10,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraftforge.oredict.OreDictionary;
 
 import javax.annotation.Nonnull;
 
@@ -67,12 +68,16 @@ public class RemoveEmcCMD extends CommandBase
 
 				if (meta < 0)
 				{
-					throw new CommandException("pe.command.remove.invalidmeta", params[1]);
+					if(params[1].equals("*")){
+						meta = OreDictionary.WILDCARD_VALUE;
+					}else{
+						throw new CommandException("pe.command.remove.invalidmeta", params[1]);
+					}
 				}
 			}
 		}
 
-		if (CustomEMCParser.addToFile(name, meta, 0))
+		if (CustomEMCParser.removeFromFile(name, meta))
 		{
 			sender.sendMessage(new TextComponentTranslation("pe.command.remove.success", name));
 			sender.sendMessage(new TextComponentTranslation("pe.command.reload.notice"));

--- a/src/main/java/moze_intel/projecte/network/commands/RemoveEmcNBTCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/RemoveEmcNBTCMD.java
@@ -1,0 +1,70 @@
+package moze_intel.projecte.network.commands;
+
+import java.util.ArrayList;
+
+import moze_intel.projecte.config.CustomEMCParser;
+import moze_intel.projecte.emc.json.NSSItemWithNBT;
+import moze_intel.projecte.utils.MathUtils;
+import net.minecraft.command.*;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.text.TextComponentTranslation;
+
+import javax.annotation.Nonnull;
+
+public class RemoveEmcNBTCMD extends CommandBase
+{
+	@Nonnull
+	@Override
+	public String getName()
+	{
+		return "removeEMCNBT";
+	}
+
+	@Nonnull
+	@Override
+	public String getUsage(@Nonnull ICommandSender sender)
+	{
+		return "pe.command.remove.usage";
+	}
+	
+	@Override
+	public int getRequiredPermissionLevel() 
+	{
+		return 4;
+	}
+
+	@Override
+	public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] params) throws CommandException
+	{
+		ItemStack heldItem = getCommandSenderAsPlayer(sender).getHeldItem(EnumHand.MAIN_HAND);
+		if (heldItem.isEmpty())
+		{
+			heldItem = getCommandSenderAsPlayer(sender).getHeldItem(EnumHand.OFF_HAND);
+		}
+		if (heldItem.isEmpty())
+		{
+			throw new WrongUsageException(getUsage(sender));
+		}
+
+		String[] ignores = NSSItemWithNBT.NO_IGNORES;
+		if(params.length > 1){
+			if(params[1].equalsIgnoreCase("ignore:")){
+				ArrayList<String> ignoresList = new ArrayList<>();
+				for(int k = 2; k < params.length; k++){
+					if(params[k].equalsIgnoreCase("$Damage")){
+						heldItem = heldItem.copy();
+						heldItem.setItemDamage(0);
+					}
+					ignoresList.add(params[k]);
+				}
+				ignores = (String[]) ignoresList.toArray(); 
+			}
+		}
+		if(CustomEMCParser.removeWithNBTFromFile(heldItem, ignores)){
+			sender.sendMessage(new TextComponentTranslation("pe.command.remove.success", heldItem.getItem().getRegistryName().getPath()));
+			sender.sendMessage(new TextComponentTranslation("pe.command.reload.notice"));
+		}
+	}
+}

--- a/src/main/java/moze_intel/projecte/network/commands/SetEmcCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/SetEmcCMD.java
@@ -7,6 +7,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraftforge.oredict.OreDictionary;
 
 import javax.annotation.Nonnull;
 
@@ -80,7 +81,11 @@ public class SetEmcCMD extends CommandBase
 
 					if (meta < 0)
 					{
-						throw new CommandException("pe.command.set.invalidmeta", params[1]);
+						if(params[1].equals("*")){
+							meta = OreDictionary.WILDCARD_VALUE;
+						}else{
+							throw new CommandException("pe.command.set.invalidmeta", params[1]);
+						}
 					}
 
 					emc = MathUtils.parseInteger(params[2]);

--- a/src/main/java/moze_intel/projecte/network/commands/SetEmcNBTCMD.java
+++ b/src/main/java/moze_intel/projecte/network/commands/SetEmcNBTCMD.java
@@ -1,0 +1,88 @@
+package moze_intel.projecte.network.commands;
+
+import java.util.ArrayList;
+
+import moze_intel.projecte.config.CustomEMCParser;
+import moze_intel.projecte.emc.json.NSSItemWithNBT;
+import moze_intel.projecte.utils.MathUtils;
+import net.minecraft.command.*;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.text.TextComponentTranslation;
+
+import javax.annotation.Nonnull;
+
+public class SetEmcNBTCMD extends CommandBase
+{
+	@Nonnull
+	@Override
+	public String getName()
+	{
+		return "setEMCNBT";
+	}
+
+	@Nonnull
+	@Override
+	public String getUsage(@Nonnull ICommandSender sender)
+	{
+		return "pe.command.set.usage";
+	}
+	
+	@Override
+	public int getRequiredPermissionLevel() 
+	{
+		return 4;
+	}
+
+	@Override
+	public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] params) throws CommandException
+	{
+		if (params.length < 1)
+		{
+			throw new WrongUsageException(getUsage(sender));
+		}
+
+		String name;
+		int meta;
+		long emc;
+
+		if (params.length >= 1)
+		{
+			ItemStack heldItem = getCommandSenderAsPlayer(sender).getHeldItem(EnumHand.MAIN_HAND);
+			if (heldItem.isEmpty())
+			{
+				heldItem = getCommandSenderAsPlayer(sender).getHeldItem(EnumHand.OFF_HAND);
+			}
+
+			if (heldItem.isEmpty())
+			{
+				throw new WrongUsageException(getUsage(sender));
+			}
+			emc = Long.parseLong(params[0]);
+
+			if (emc < 0)
+			{
+				throw new NumberInvalidException("pe.command.set.invalidemc", params[0]);
+			}
+			String[] ignores = NSSItemWithNBT.NO_IGNORES;
+			if(params.length > 1){
+				if(params[1].equalsIgnoreCase("ignore:")){
+					ArrayList<String> ignoresList = new ArrayList<>();
+					for(int k = 2; k < params.length; k++){
+						if(params[k].equalsIgnoreCase("$Damage")){
+							heldItem = heldItem.copy();
+							heldItem.setItemDamage(0);
+						}
+						ignoresList.add(params[k]);
+					}
+					ignores = (String[]) ignoresList.toArray(); 
+				}
+			}
+			if(CustomEMCParser.addWithNBTToFile(heldItem, ignores, emc)){
+				sender.sendMessage(new TextComponentTranslation("pe.command.set.success", heldItem.getItem().getRegistryName().getPath(), emc));
+				sender.sendMessage(new TextComponentTranslation("pe.command.reload.notice"));	
+			}
+		}
+	}
+}

--- a/src/main/java/moze_intel/projecte/network/packets/SyncEmcPKT.java
+++ b/src/main/java/moze_intel/projecte/network/packets/SyncEmcPKT.java
@@ -8,6 +8,7 @@ import moze_intel.projecte.emc.SimpleStack;
 import moze_intel.projecte.playerData.Transmutation;
 import net.minecraft.client.Minecraft;
 import net.minecraft.item.Item;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
@@ -32,7 +33,7 @@ public class SyncEmcPKT implements IMessage
 
 		for (int i = 0; i < size; i++)
 		{
-			data[i] = new EmcPKTInfo(ByteBufUtils.readVarInt(buf, 5), ByteBufUtils.readVarInt(buf, 5), buf.readLong());
+			data[i] = new EmcPKTInfo(ByteBufUtils.readVarInt(buf, 5), ByteBufUtils.readVarInt(buf, 5), buf.readLong(),(buf.readByte() == 0? null:ByteBufUtils.readTag(buf)));
 		}
 	}
 
@@ -46,6 +47,10 @@ public class SyncEmcPKT implements IMessage
 			ByteBufUtils.writeVarInt(buf, info.getId(), 5);
 			ByteBufUtils.writeVarInt(buf, info.getDamage(), 5);
 			buf.writeLong(info.getEmc());
+			buf.writeBoolean(info.hasNBT);
+			if(info.hasNBT){
+				ByteBufUtils.writeTag(buf, info.nbt);
+			}
 		}
 	}
 
@@ -85,11 +90,22 @@ public class SyncEmcPKT implements IMessage
 	public static class EmcPKTInfo {
 		private int id, damage;
 		private long emc;
+		private boolean hasNBT;
+		private NBTTagCompound nbt;
 
 		public EmcPKTInfo(int id, int damage, long emc) {
 			this.id = id;
 			this.damage = damage;
 			this.emc = emc;
+		}
+		public EmcPKTInfo(int id, int damage, long emc, NBTTagCompound nbt) {
+			this.id = id;
+			this.damage = damage;
+			this.emc = emc;
+			if(nbt != null){
+				hasNBT = true;
+				this.nbt = nbt;
+			}
 		}
 
 		public int getDamage() {
@@ -102,6 +118,12 @@ public class SyncEmcPKT implements IMessage
 
 		public long getEmc() {
 			return emc;
+		}
+		
+		public NBTTagCompound getNBT(){
+			if(hasNBT)
+				return nbt;
+			return null;
 		}
 	}
 }

--- a/src/main/java/moze_intel/projecte/utils/ItemHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/ItemHelper.java
@@ -85,11 +85,15 @@ public final class ItemHelper
 		for (int i = 0; i < list.size(); i++)
 		{
 			ItemStack s = list.get(i);
+			if(s.getTagCompound() != null && s.getTagCompound().isEmpty())
+				s.setTagCompound(null);
 			if (!s.isEmpty())
 			{
 				for (int j = i + 1; j < list.size(); j++)
 				{
 					ItemStack s1 = list.get(j);
+					if(s1.getTagCompound() != null && s1.getTagCompound().isEmpty())
+						s1.setTagCompound(null);
 					if (ItemHandlerHelper.canItemStacksStack(s, s1))
 					{
 						s.grow(s1.getCount());

--- a/src/main/java/moze_intel/projecte/utils/WorldHelper.java
+++ b/src/main/java/moze_intel/projecte/utils/WorldHelper.java
@@ -1,6 +1,7 @@
 package moze_intel.projecte.utils;
 
 import com.google.common.collect.Lists;
+
 import moze_intel.projecte.PECore;
 import moze_intel.projecte.config.ProjectEConfig;
 import net.minecraft.block.*;
@@ -317,7 +318,7 @@ public final class WorldHelper
 		return new AxisAlignedBB(pos.getX() - offset, pos.getY(), pos.getZ() - offset, pos.getX() + offset, pos.getY(), pos.getZ() + offset);
 	}
 
-	public static <T extends Entity> T getNewEntityInstance(Class<T> c, World world)
+	public static <T extends EntityLiving> T getNewEntityInstance(Class<T> c, World world)
 	{
 		try
 		{
@@ -347,11 +348,11 @@ public final class WorldHelper
 
 		if (peacefuls.contains(entClass))
 		{
-			return getNewEntityInstance(CollectionHelper.getRandomListEntry(peacefuls, entClass), world);
+			return getNewEntityInstance((Class<EntityLiving>)CollectionHelper.getRandomListEntry(peacefuls, entClass), world);
 		}
 		else if (mobs.contains(entClass))
 		{
-			EntityLiving ent = getNewEntityInstance(CollectionHelper.getRandomListEntry(mobs, entClass), world);
+			EntityLiving ent = getNewEntityInstance((Class<EntityLiving>) CollectionHelper.getRandomListEntry(mobs, entClass), world);
 			if (ent instanceof EntityRabbit)
 			{
 				((EntityRabbit) ent).setRabbitType(99);

--- a/src/main/resources/defaultCustomConversions/defaults.json
+++ b/src/main/resources/defaultCustomConversions/defaults.json
@@ -220,6 +220,7 @@
       "minecraft:shulker_shell|0": 2048,
       "minecraft:ghast_tear|0": 4096,
       "minecraft:dragon_egg|0": 262144,
+      "minecraft:dragon_breath|0": 512,
       "minecraft:potion|0": 0,
 
       "minecraft:saddle|0": 192,


### PR DESCRIPTION
One of the biggest issues with this mod was the lack of NBT support for items. Items could be registered even when they deeply depend on an NBT, but the result would be an empty item of that kind. One such example of this problem is Minecraft's Potions and Enchantment Books. Learning one of those items in the Transmutation table would result in an empty Enchantment Book, or in a Uncraftable Potion. This problem goes even further with mod support, with Forge-generated buckets producing no liquids or Tinkerer's Construct's Tools and Armor reverting to blank, useless versions of themselves.

This pull provides a simple solution to these problems: either through an API or through the two new "setEMCNBT" and "removeEMCNBT", it is possible to allow users to set their own values to items that should have their NBT stored, and have multiple, different values for each and every variation they can get their hands on. 

This pull also adds automatic knowledge generation for encountered Enchantment Books, however the same cannot be said of potions, even though a solution could be coming if this pull is not outright rejected.

I am aware of the problem of NBTs used as "damage" values (IE: energy capacity), and a solution was pushed forward: allow the users to "Blank Out" the NBT fields they think are not needed, such as the current energy of batteries and the like.

PS: Another small problem that comes with using a varied set of mods while playing is that the emc_custom file gets very bloated, and there is no easy way to share values from specific mods to other players without trying to merge two very large files. For that, I added a config option that allows ProjectE to store the custom emc in files separated by mod, allowing for easy sharing of custom emcs and less bloat than reusing a custom_emc.json in multiple minecraft instances.