### PR TITLE
Add Mapper for staged recipes (Recipe Stages)

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/mappers/CraftingMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/CraftingMapper.java
@@ -31,7 +31,7 @@ import java.util.Set;
 
 public class CraftingMapper implements IEMCMapper<NormalizedSimpleStack, Long> {
 
-	private final List<IRecipeMapper> recipeMappers = Arrays.asList(new VanillaRecipeMapper(), new PECustomRecipeMapper(), new CraftTweakerRecipeMapper());
+	private final List<IRecipeMapper> recipeMappers = Arrays.asList(new VanillaRecipeMapper(), new PECustomRecipeMapper(), new CraftTweakerRecipeMapper(), new RecipeStagesRecipeMapper());
 	private final Set<Class> canNotMap = new HashSet<>();
 	private final Map<Class, Integer> recipeCount = new HashMap<>();
 

--- a/src/main/java/moze_intel/projecte/emc/mappers/RecipeStagesRecipeMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/RecipeStagesRecipeMapper.java
@@ -1,0 +1,27 @@
+package moze_intel.projecte.emc.mappers;
+
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraftforge.fml.common.Loader;
+
+public class RecipeStagesRecipeMapper implements CraftingMapper.IRecipeMapper {
+    private boolean rsCompat;
+    
+    public RecipeStagesRecipeMapper() {
+        rsCompat = Loader.isModLoaded("recipestages");
+    }
+    
+    @Override
+    public String getName() {
+        return "RecipeStagesRecipeMapper";
+    }
+    
+    @Override
+    public String getDescription() {
+        return "Maps `RecipeStage` implementation of `IRecipe` from Recipe Stages";
+    }
+    
+    @Override
+    public boolean canHandle(IRecipe recipe) {
+            return rsCompat && (recipe.getClass().getName().equals("com.blamejared.recipestages.recipes.RecipeStage"));
+    }
+}


### PR DESCRIPTION
Allows ProjectE to generate EMC automatically in the case where a recipe is staged.