### PR TITLE
Add charcoal Philospher's stone conversions

### DIFF
--- a/src/main/resources/data/projecte/recipes/conversions/charcoal_to_coal.json
+++ b/src/main/resources/data/projecte/recipes/conversions/charcoal_to_coal.json
@@ -1,0 +1,23 @@
+{
+  "result": {
+    "item": "minecraft:coal"
+  },
+  "ingredients": [
+    {
+      "item": "projecte:philosophers_stone"
+    },
+    {
+      "item": "minecraft:charcoal"
+    },
+    {
+      "item": "minecraft:charcoal"
+    },
+    {
+      "item": "minecraft:charcoal"
+    },
+    {
+      "item": "minecraft:charcoal"
+    }
+  ],
+  "type": "minecraft:crafting_shapeless"
+}

--- a/src/main/resources/data/projecte/recipes/conversions/coal_to_charcoal.json
+++ b/src/main/resources/data/projecte/recipes/conversions/coal_to_charcoal.json
@@ -1,0 +1,15 @@
+{
+  "result": {
+    "item": "minecraft:charcoal",
+    "count": 4
+  },
+  "ingredients": [
+    {
+      "item": "projecte:philosophers_stone"
+    },
+    {
+      "item": "minecraft:coal"
+    }
+  ],
+  "type": "minecraft:crafting_shapeless"
+}


### PR DESCRIPTION
EE2 supported converting 4 charcoal to 1 coal. It also had a conversion to go back to charcoal.  This PR adds the necessary recipes.