### PR TITLE
Improve handling of combined fake ingredients

### DIFF
--- a/src/api/java/moze_intel/projecte/api/mapper/recipe/INSSFakeGroupManager.java
+++ b/src/api/java/moze_intel/projecte/api/mapper/recipe/INSSFakeGroupManager.java
@@ -1,0 +1,22 @@
+package moze_intel.projecte.api.mapper.recipe;
+
+import java.util.Set;
+import moze_intel.projecte.api.nss.NormalizedSimpleStack;
+import net.minecraft.util.Tuple;
+
+/**
+ * Interface to make for a cleaner API than using a {@link java.util.function.Function} when creating groupings of {@link NormalizedSimpleStack}s.
+ */
+public interface INSSFakeGroupManager {
+
+	/**
+	 * Gets or creates a singular {@link NormalizedSimpleStack} representing the grouping or "ingredient" of the given stacks. Additionally a boolean is returned
+	 * specifying if it was created or already existed. {@code true} for if it was created.
+	 *
+	 * @param stacks Individual stacks to represent as a single "combined" stack.
+	 *
+	 * @apiNote If the combined representation had to be created ({@code true} for the second element of the {@link Tuple}), then conversions from the individual elements
+	 * to the returned stack <strong>MUST</strong> be added.
+	 */
+	Tuple<NormalizedSimpleStack, Boolean> getOrCreateFakeGroup(Set<NormalizedSimpleStack> stacks);
+}

--- a/src/api/java/moze_intel/projecte/api/mapper/recipe/IRecipeTypeMapper.java
+++ b/src/api/java/moze_intel/projecte/api/mapper/recipe/IRecipeTypeMapper.java
@@ -26,9 +26,10 @@ public interface IRecipeTypeMapper {
 
 	/**
 	 * This method is used to determine the default for enabling/disabling this {@link IRecipeTypeMapper}. If this returns {@code false} {@link #canHandle(IRecipeType)}
-	 * and {@link #handleRecipe(IMappingCollector, IRecipe)} will not be called.
+	 * and {@link #handleRecipe(IMappingCollector, IRecipe, INSSFakeGroupManager)} will not be called.
 	 *
-	 * @return {@code true} if you want {@link #canHandle(IRecipeType)} and {@link #handleRecipe(IMappingCollector, IRecipe)} to be called, {@code false} otherwise.
+	 * @return {@code true} if you want {@link #canHandle(IRecipeType)} and {@link #handleRecipe(IMappingCollector, IRecipe, INSSFakeGroupManager)} to be called, {@code
+	 * false} otherwise.
 	 */
 	default boolean isAvailable() {
 		return true;
@@ -46,12 +47,15 @@ public interface IRecipeTypeMapper {
 	/**
 	 * Attempts to handle an {@link IRecipe} that is of a type restricted by {@link #canHandle(IRecipeType)}.
 	 *
-	 * @param mapper The mapper to add mapping data to.
-	 * @param recipe The recipe to attempt to map.
+	 * @param mapper           The mapper to add mapping data to.
+	 * @param recipe           The recipe to attempt to map.
+	 * @param fakeGroupManager The manager for helping create and manage "groupings" of valid ingredients.
 	 *
 	 * @return {@code true} if the {@link IRecipeTypeMapper} handled the given {@link IRecipe}, {@code false} otherwise
 	 *
 	 * @apiNote Make sure to call {@link #canHandle(IRecipeType)} before calling this method.
+	 * @implNote Due to how the fakeGroupManager works, {@link moze_intel.projecte.api.nss.NSSFake} implementations should only be created in this method with
+	 * descriptions that are more complex than a single integer, as otherwise they may intersect with {@link NormalizedSimpleStack}s created by the fakeGroupManager.
 	 */
-	boolean handleRecipe(IMappingCollector<NormalizedSimpleStack, Long> mapper, IRecipe<?> recipe);
+	boolean handleRecipe(IMappingCollector<NormalizedSimpleStack, Long> mapper, IRecipe<?> recipe, INSSFakeGroupManager fakeGroupManager);
 }

--- a/src/api/java/moze_intel/projecte/api/nss/NSSFake.java
+++ b/src/api/java/moze_intel/projecte/api/nss/NSSFake.java
@@ -24,6 +24,8 @@ public final class NSSFake implements NormalizedSimpleStack {
 
 	/**
 	 * Resets the current namespace that will be used for any newly created {@link NSSFake} objects.
+	 *
+	 * @apiNote For internal use by ProjectE
 	 */
 	public static void resetNamespace() {
 		setCurrentNamespace("");
@@ -33,6 +35,8 @@ public final class NSSFake implements NormalizedSimpleStack {
 	 * Sets the current namespace that will be used for any newly created {@link NSSFake} objects.
 	 *
 	 * @param ns Namespace
+	 *
+	 * @apiNote For internal use by ProjectE
 	 */
 	public static void setCurrentNamespace(@Nonnull String ns) {
 		currentNamespace = ns;

--- a/src/main/java/moze_intel/projecte/emc/mappers/recipe/FallbackRecipeTypeMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/recipe/FallbackRecipeTypeMapper.java
@@ -3,6 +3,7 @@ package moze_intel.projecte.emc.mappers.recipe;
 import java.util.Arrays;
 import java.util.Collection;
 import moze_intel.projecte.api.mapper.collector.IMappingCollector;
+import moze_intel.projecte.api.mapper.recipe.INSSFakeGroupManager;
 import moze_intel.projecte.api.mapper.recipe.RecipeTypeMapper;
 import moze_intel.projecte.api.nss.NormalizedSimpleStack;
 import net.minecraft.item.crafting.AbstractCookingRecipe;
@@ -35,9 +36,9 @@ public class FallbackRecipeTypeMapper extends BaseRecipeTypeMapper {
 	}
 
 	@Override
-	public boolean handleRecipe(IMappingCollector<NormalizedSimpleStack, Long> mapper, IRecipe<?> recipe) {
+	public boolean handleRecipe(IMappingCollector<NormalizedSimpleStack, Long> mapper, IRecipe<?> recipe, INSSFakeGroupManager fakeGroupManager) {
 		if (recipe instanceof ICraftingRecipe || recipe instanceof AbstractCookingRecipe || recipe instanceof SingleItemRecipe || recipe instanceof SmithingRecipe) {
-			return super.handleRecipe(mapper, recipe);
+			return super.handleRecipe(mapper, recipe, fakeGroupManager);
 		}
 		return false;
 	}


### PR DESCRIPTION
I believe this addresses what you were mentioning on discord @MaPePeR regarding the duplicate conversions for identical NormalizedSimpleStacks, as well as the duplicated recipes in cases when the matching stacks may be in a different order. Opening this as a PR for you to review when you get a chance.