### PR TITLE
Make EMC conversion ratios <10% possible to configure

### DIFF
--- a/src/main/java/moze_intel/projecte/config/ServerConfig.java
+++ b/src/main/java/moze_intel/projecte/config/ServerConfig.java
@@ -67,7 +67,7 @@ public final class ServerConfig extends BasePEConfig {
 					.defineInRange("katarDeathAura", 1_000F, 0, Integer.MAX_VALUE));
 			covalenceLoss = CachedDoubleValue.wrap(config, builder
 					.comment("Adjusting this ratio changes how much EMC is received when burning a item. For example setting this to 0.5 will return half of the EMC cost.")
-					.defineInRange("covalenceLoss", 1.0, 0.1, 1.0));
+					.defineInRange("covalenceLoss", 1.0, Double.MIN_VALUE, 1.0));
 			covalenceLossRounding = CachedBooleanValue.wrap(config, builder
 					.comment("How rounding occurs when Covalence Loss results in a burn value less than 1 EMC. If true the value will be rounded up to 1. If false the value will be rounded down to 0.")
 					.define("covalenceLossRounding", true));


### PR DESCRIPTION
This lets people configure any EMC conversion ratio greater than zero and not greater than one.