### PR TITLE
Slight cleanup to conversion validation and potentially performance

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/SimpleGraphMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/SimpleGraphMapper.java
@@ -177,11 +177,7 @@ public class SimpleGraphMapper<T, V extends Comparable<V>, A extends IValueArith
 		boolean hasPositiveIngredientValues = false;
 		for (Map.Entry<T, Integer> entry : conversion.ingredientsWithAmount.entrySet()) {
 			if (values.containsKey(entry.getKey())) {
-				//The ingredient has a value
-				if (entry.getValue() == 0) {
-					//Ingredients with an amount of 'zero' do not need to be handled.
-					continue;
-				}
+				//The ingredient has a value and
 				//value = value + amount * ingredientcost
 				V ingredientValue = conversion.arithmeticForConversion.mul(entry.getValue(), values.get(entry.getKey()));
 				if (ingredientValue.compareTo(ZERO) != 0) {


### PR DESCRIPTION
I addressed the first few things in https://github.com/sinkillerj/ProjectE/issues/2133#issuecomment-1008120735, but for the last part about the loop, if I understand correctly:
- for all new ingredients it is getting any existing uses for the ingredient
- removing the old conversion for them.

If it looped the old conversion then it would be removing conversions that might not exist with the new one that is overwriting it I think? So I left it as is for now as I think that may be intended.