### PR TITLE
Add New options for EMC Display inside Energy Condensers

### DIFF
--- a/src/main/java/moze_intel/projecte/config/ClientConfig.java
+++ b/src/main/java/moze_intel/projecte/config/ClientConfig.java
@@ -1,6 +1,7 @@
 package moze_intel.projecte.config;
 
 import moze_intel.projecte.config.value.CachedBooleanValue;
+import moze_intel.projecte.config.value.CachedIntValue;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.fml.config.ModConfig;
 
@@ -17,6 +18,7 @@ public class ClientConfig extends BasePEConfig {
 	public final CachedBooleanValue statToolTips;
 	public final CachedBooleanValue pedestalToolTips;
 	public final CachedBooleanValue pulsatingOverlay;
+	public final CachedIntValue condenserEmcDisplayMode;
 
 	ClientConfig() {
 		ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
@@ -40,6 +42,9 @@ public class ClientConfig extends BasePEConfig {
 		pulsatingOverlay = CachedBooleanValue.wrap(this, builder
 				.comment("The Philosopher's Stone overlay softly pulsates")
 				.define("pulsatingOverlay", false));
+		condenserEmcDisplayMode = CachedIntValue.wrap(this, builder
+				.comment("Sets how EMC is displayed inside Energy Condensers.\n0: Shows how much EMC is stored or how much is required to make the item if there is Excess stored EMC. (EE2 Style)\n1: Will show the stored amount of EMC and render green if the value exceeds required amount.\n2: If the stored EMC value is greater then required it will display the total EMC stored seperately in green.\nNote: If the value displayed would overrun the edge of the GUI it will instead state 'Overflow'.")
+				.define("showTotalEMCInCondenser", 0));
 		builder.pop();
 		configSpec = builder.build();
 	}

--- a/src/main/java/moze_intel/projecte/gameObjs/gui/AbstractCondenserScreen.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/AbstractCondenserScreen.java
@@ -3,6 +3,7 @@ package moze_intel.projecte.gameObjs.gui;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import moze_intel.projecte.PECore;
+import moze_intel.projecte.config.ProjectEConfig;
 import moze_intel.projecte.gameObjs.container.CondenserContainer;
 import moze_intel.projecte.gameObjs.container.CondenserMK2Container;
 import moze_intel.projecte.utils.Constants;
@@ -39,9 +40,40 @@ public abstract class AbstractCondenserScreen<T extends CondenserContainer> exte
 	@Override
 	protected void renderLabels(@NotNull PoseStack matrix, int x, int y) {
 		//Don't render title or inventory as we don't have space
-		long toDisplay = Math.min(menu.displayEmc.get(), menu.requiredEmc.get());
-		Component emc = TransmutationEMCFormatter.formatEMC(toDisplay);
-		this.font.draw(matrix, emc, 140, 10, 0x404040);
+		switch (ProjectEConfig.client.condenserEmcDisplayMode.get()) {
+		//Normal Old Rendering
+		default:
+			long toDisplay = Math.min(menu.displayEmc.get(), menu.requiredEmc.get());
+			Component emc = TransmutationEMCFormatter.formatEMC(toDisplay);
+			this.font.draw(matrix, emc, 140, 10, 0x404040);
+		break;
+			
+		//Turns green and shows total value if Stored > Required
+		case 1:
+			toDisplay = menu.displayEmc.get();
+			int displayColor = 0x404040;
+			if (toDisplay > menu.requiredEmc.get())
+				displayColor = 0x008000;
+			emc = TransmutationEMCFormatter.formatEMC(toDisplay);
+			this.font.draw(matrix, emc, 140, 10, displayColor);
+		break;
+		
+		case 2:
+			toDisplay = Math.min(menu.displayEmc.get(), menu.requiredEmc.get());
+			emc = TransmutationEMCFormatter.formatEMC(toDisplay);
+			this.font.draw(matrix, emc, 140, 10, 0x404040);
+			
+			if (menu.displayEmc.get() > menu.requiredEmc.get()) {
+				int xOff = 140 + this.font.width(emc);
+				emc = TransmutationEMCFormatter.formatEMC(menu.displayEmc.get());
+				if ((xOff + this.font.width(" / " + emc.getString())) < this.getXSize()) {
+					this.font.draw(matrix, " / " + emc.getString(), xOff, 10, 0x008000);
+				} else {
+					this.font.draw(matrix, " / Overflow", xOff, 10, 0x008000);
+				}
+			}
+		break;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Adds a configurable option to allow Users to see how much "Extra" EMC they have stored in their Energy Condensers.

Mode 1 will just cause the number to turn green when over the required amount.

Mode 2 will add the Stored amount next to the required amount. If the length is too long it will instead just say overflow.

If the stored is less then the required it wont do anything different. (right side in the image).

If you don't want to include this thats fine. Just something I think may be a bit handy while playing with high EMC valued items.

![EMC modes](https://user-images.githubusercontent.com/7415468/164311705-87f6b4ca-dd7a-4d7a-a423-a0404b0e10b9.png)
