### PR TITLE
Allow interdiction torches to connect to walls, fixed #2257

### DIFF
--- a/src/datagen/java/moze_intel/projecte/common/tag/PEBlockTagsProvider.java
+++ b/src/datagen/java/moze_intel/projecte/common/tag/PEBlockTagsProvider.java
@@ -51,6 +51,10 @@ public class PEBlockTagsProvider extends BlockTagsProvider {
 				PEBlocks.MOBIUS_FUEL.getBlock(),
 				PEBlocks.AETERNALIS_FUEL.getBlock()
 		);
+		// Allow interdiction torches to connect to walls.
+		tag(BlockTags.WALL_POST_OVERRIDE).add(
+				PEBlocks.INTERDICTION_TORCH.getBlock()
+		);
 		addImmuneBlocks(BlockTags.DRAGON_IMMUNE);
 		addImmuneBlocks(BlockTags.WITHER_IMMUNE);
 


### PR DESCRIPTION
Allow interdiction torches to connect to walls by applying the correct tag to the interdictiontorch, fixes #2257.

This is the tag used by vanilla torches, redstone torches, tripwires, etc.