### PR TITLE
Fix ProjectE's Dark Matter axe causes a crash when the skill cuts a tree which try to get ore from an empty ItemStack

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/items/tools/PEToolBase.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/tools/PEToolBase.java
@@ -129,6 +129,7 @@ public abstract class PEToolBase extends ItemMode
 			}
 
 			ItemStack s = new ItemStack(block);
+			if(s.isEmpty()) continue;
 			int[] oreIds = OreDictionary.getOreIDs(s);
 
 			String oreName;


### PR DESCRIPTION
Fix https://github.com/CleanroomMC/Cleanroom/issues/72
Cause by empty Item without check.

same at https://github.com/sinkillerj/ProjectE/blob/mc1.11.x/src/main/java/moze_intel/projecte/gameObjs/items/tools/PEToolBase.java#L129
https://github.com/sinkillerj/ProjectE/blob/mc1.10.x/src/main/java/moze_intel/projecte/gameObjs/items/tools/PEToolBase.java#L128