### PR TITLE
Add fallback handling for keypress in Transmutation GUI

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/gui/GUITransmutation.java
@@ -121,7 +121,16 @@ public class GUITransmutation extends PEContainerScreen<TransmutationContainer> 
 			//This is where key combos and deletion is handled, and where we bypass the inventory key closing the screen
 			return textBoxFilter.keyPressed(keyCode, scanCode, modifiers);
 		}
-		return super.keyPressed(keyCode, scanCode, modifiers);
+		boolean passedThrough = super.keyPressed(keyCode, scanCode, modifiers);
+		if (passedThrough) {
+			return true;
+		}
+		// try passing the unhandled key to textbox
+		boolean handled = textBoxFilter.keyPressed(keyCode, scanCode, modifiers);
+		if (handled) {
+			textBoxFilter.setFocused(true);
+		}
+		return handled;
 	}
 
 	private void updateFilter(String text) {


### PR DESCRIPTION
Even if the search textbox isn't selected, if pressing a key in Transmutation GUI doesn't do anything, fallback should be for that key to be inserted into textbox and for textbox to then be selected.

Assuming user has stored EMC, this makes it much quicker to start searching for an item because they can start typing right after opening the tablet instead of having to drag their cursor and select the only textbox in the GUI.

# TODO
- [ ] Test interaction with JEI/EMI textbox