### PR TITLE
Add Relay interface to api

### DIFF
--- a/src/api/java/moze_intel/projecte/api/block_entity/IRelay.java
+++ b/src/api/java/moze_intel/projecte/api/block_entity/IRelay.java
@@ -1,0 +1,20 @@
+package moze_intel.projecte.api.block_entity;
+
+import org.jetbrains.annotations.NotNull;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+
+public interface IRelay {
+    /**
+     * @return The bonus emc to add
+     */
+    double getBonusToAdd();
+
+    /**
+     * Add the collector bonus
+     *
+     * @param level The level the Relay is in. (Used for saving, pass in the values that you get passed in)
+     * @param pos   The position the Relay is at. (Used for saving, pass in the values that you get passed in)
+     */
+    void addBonus(@NotNull Level level, @NotNull BlockPos pos);
+}

--- a/src/main/java/moze_intel/projecte/gameObjs/block_entities/CollectorMK1BlockEntity.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/block_entities/CollectorMK1BlockEntity.java
@@ -1,5 +1,6 @@
 package moze_intel.projecte.gameObjs.block_entities;
 
+import moze_intel.projecte.api.block_entity.IRelay;
 import moze_intel.projecte.api.capabilities.PECapabilities;
 import moze_intel.projecte.api.capabilities.item.IItemEmcHolder;
 import moze_intel.projecte.api.proxy.IEMCProxy;
@@ -25,6 +26,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.capabilities.ICapabilityProvider;
 import net.neoforged.neoforge.items.IItemHandler;
@@ -332,9 +334,8 @@ public class CollectorMK1BlockEntity extends EmcBlockEntity implements MenuProvi
 	private static void sendRelayBonus(@NotNull Level level, @NotNull BlockPos pos) {
 		for (Direction dir : Constants.DIRECTIONS) {
 			BlockPos relayPos = pos.relative(dir);
-			RelayMK1BlockEntity relay = WorldHelper.getBlockEntity(RelayMK1BlockEntity.class, level, relayPos);
-			if (relay != null) {
-				//The other tiers of relay extend RelayMK1BlockEntity and add the correct bonus
+			BlockEntity blockEntity = WorldHelper.getBlockEntity(level, relayPos);
+			if (blockEntity instanceof IRelay relay) {
 				relay.addBonus(level, relayPos);
 			}
 		}

--- a/src/main/java/moze_intel/projecte/gameObjs/block_entities/RelayMK1BlockEntity.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/block_entities/RelayMK1BlockEntity.java
@@ -1,5 +1,6 @@
 package moze_intel.projecte.gameObjs.block_entities;
 
+import moze_intel.projecte.api.block_entity.IRelay;
 import moze_intel.projecte.api.capabilities.PECapabilities;
 import moze_intel.projecte.api.capabilities.item.IItemEmcHolder;
 import moze_intel.projecte.api.proxy.IEMCProxy;
@@ -29,7 +30,7 @@ import net.neoforged.neoforge.items.wrapper.CombinedInvWrapper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class RelayMK1BlockEntity extends EmcBlockEntity implements MenuProvider {
+public class RelayMK1BlockEntity extends EmcBlockEntity implements MenuProvider, IRelay {
 
 	public static final ICapabilityProvider<RelayMK1BlockEntity, @Nullable Direction, IItemHandler> INVENTORY_PROVIDER = (relay, side) -> {
 		if (side == null) {
@@ -187,11 +188,13 @@ public class RelayMK1BlockEntity extends EmcBlockEntity implements MenuProvider 
 		tag.putDouble("bonus_emc", bonusEMC);
 	}
 
-	protected double getBonusToAdd() {
+	@Override
+	public double getBonusToAdd() {
 		return 0.05;
 	}
 
-	void addBonus(@NotNull Level level, @NotNull BlockPos pos) {
+	@Override
+	public void addBonus(@NotNull Level level, @NotNull BlockPos pos) {
 		bonusEMC += getBonusToAdd();
 		if (bonusEMC >= 1) {
 			long emcToInsert = (long) bonusEMC;

--- a/src/main/java/moze_intel/projecte/gameObjs/block_entities/RelayMK2BlockEntity.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/block_entities/RelayMK2BlockEntity.java
@@ -31,7 +31,7 @@ public class RelayMK2BlockEntity extends RelayMK1BlockEntity {
 	}
 
 	@Override
-	protected double getBonusToAdd() {
+	public double getBonusToAdd() {
 		return 0.15;
 	}
 }

--- a/src/main/java/moze_intel/projecte/gameObjs/block_entities/RelayMK3BlockEntity.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/block_entities/RelayMK3BlockEntity.java
@@ -31,7 +31,7 @@ public class RelayMK3BlockEntity extends RelayMK1BlockEntity {
 	}
 
 	@Override
-	protected double getBonusToAdd() {
+	public double getBonusToAdd() {
 		return 0.5;
 	}
 }


### PR DESCRIPTION
In my own code I've used addBonus to support external coll.ectors to add bonuses to ProjectE's default relays
https://github.com/DonovanDMC/ProjectExpansion/blob/2804129b4b2d40dca747c1b9a739262ef0123fc3/src/main/java/cool/furry/mc/forge/projectexpansion/block/entity/BlockEntityCollector.java#L299

This method was previously public in the 1.20 version
https://github.com/sinkillerj/ProjectE/blob/68fbb2dea0cf8a6394fa6c7c084063046d94cee5/src/main/java/moze_intel/projecte/gameObjs/block_entities/RelayMK1BlockEntity.java#L172

This method was made package private in the 1.21.1 version
https://github.com/sinkillerj/ProjectE/blob/2ea9cddc0fa03043ff70c4ca9e25611fadf6926f/src/main/java/moze_intel/projecte/gameObjs/block_entities/RelayMK1BlockEntity.java#L194

With this interface mod developers can now add bonuses to ProjectE's relays freely, as well as designate their own blocks as relays, which ProjectE's collectors will dutifully add bonuses to without the need  to mess around with internals