### PR TITLE
[1.21.1] Fix Philosopher's Stone crafting recipes being hard to find in JEI/EMI

### DIFF
--- a/src/main/java/moze_intel/projecte/integration/recipe_viewer/emi/PEEmiPlugin.java
+++ b/src/main/java/moze_intel/projecte/integration/recipe_viewer/emi/PEEmiPlugin.java
@@ -51,7 +51,6 @@ public class PEEmiPlugin implements EmiPlugin {
 		}
 
 		//Workstations for vanilla categories
-		registry.addWorkstation(VanillaEmiRecipeCategories.CRAFTING, EmiStack.of(PEItems.PHILOSOPHERS_STONE));
 		registry.addWorkstation(VanillaEmiRecipeCategories.SMELTING, EmiIngredient.of(PETags.Items.MATTER_FURNACES));
 		registry.addWorkstation(CollectorEmiRecipe.CATEGORY, EmiIngredient.of(PETags.Items.COLLECTORS));
 		registry.addWorkstation(WorldTransmuteEmiRecipe.CATEGORY, EmiStack.of(PEItems.PHILOSOPHERS_STONE));

--- a/src/main/java/moze_intel/projecte/integration/recipe_viewer/jei/PEJeiPlugin.java
+++ b/src/main/java/moze_intel/projecte/integration/recipe_viewer/jei/PEJeiPlugin.java
@@ -120,7 +120,6 @@ public class PEJeiPlugin implements IModPlugin {
 	@Override
 	public void registerRecipeCatalysts(@NotNull IRecipeCatalystRegistration registry) {
 		if (shouldLoad()) {
-			registry.addRecipeCatalyst(PEItems.PHILOSOPHERS_STONE.asStack(), RecipeTypes.CRAFTING, WorldTransmuteRecipeCategory.RECIPE_TYPE);
 			registry.addRecipeCatalyst(new ItemStack(PEBlocks.COLLECTOR), CollectorRecipeCategory.RECIPE_TYPE);
 			registry.addRecipeCatalyst(new ItemStack(PEBlocks.COLLECTOR_MK2), CollectorRecipeCategory.RECIPE_TYPE);
 			registry.addRecipeCatalyst(new ItemStack(PEBlocks.COLLECTOR_MK3), CollectorRecipeCategory.RECIPE_TYPE);


### PR DESCRIPTION
While the Philosopher's Stone was added to the Vanilla category "Crafting" as a Recipe Catalyst it was hard to navigate to crafting recipes that only involved the Philosopher's Stone.

Before
<img width="1004" height="898" alt="before" src="https://github.com/user-attachments/assets/ccae88fa-0ada-4be0-b6be-e6f81ccf8400" />

After
<img width="970" height="903" alt="after" src="https://github.com/user-attachments/assets/aed4aa32-332b-47a3-9d8d-9ca263762a02" />
