### PR TITLE
Fix NPE in TransmutationContainer.fromNetwork when buf is null

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/container/TransmutationContainer.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/container/TransmutationContainer.java
@@ -35,7 +35,7 @@ public class TransmutationContainer extends PEHandContainer {
 	private SlotUnlearn unlearn;
 
 	public static TransmutationContainer fromNetwork(int windowId, Inventory playerInv, FriendlyByteBuf buf) {
-		if (buf.readBoolean()) {
+		if (buf != null && buf.readBoolean()) {
 			return new TransmutationContainer(windowId, playerInv, buf.readEnum(InteractionHand.class), buf.readByte());
 		}
 		return new TransmutationContainer(windowId, playerInv);


### PR DESCRIPTION
Issue: In NeoForge 1.21.1, returning to the Transmutation Table from a nested GUI (like a portable crafting table) causes a disconnect because the client receives a null FriendlyByteBuf. #2471 

Fix: Added a buf != null check before buf.readBoolean() in TransmutationContainer.fromNetwork.