### PR TITLE
Transmutation table search by identifier

### DIFF
--- a/src/main/java/moze_intel/projecte/utils/text/SearchQueryParser.java
+++ b/src/main/java/moze_intel/projecte/utils/text/SearchQueryParser.java
@@ -12,7 +12,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import moze_intel.projecte.PECore;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -221,10 +223,17 @@ public class SearchQueryParser {
 				return false;
 			}
 		},
-		TAG('#') {
+        TAG('#') {
+            @Override
+            public boolean matches(@Nullable Level level, @Nullable Player player, String key, ItemStack stack) {
+                return stack.getTags().anyMatch(tag -> tag.location().toString().toLowerCase(Locale.ROOT).contains(key));
+            }
+        },
+		IDENTIFIER('&') {
 			@Override
 			public boolean matches(@Nullable Level level, @Nullable Player player, String key, ItemStack stack) {
-				return stack.getTags().anyMatch(tag -> tag.location().toString().toLowerCase(Locale.ROOT).contains(key));
+                ResourceLocation stackIdentifier = BuiltInRegistries.ITEM.getKey(stack.getItem());
+                return stackIdentifier.toString().toLowerCase(Locale.ROOT).contains(key);
 			}
 		};
 


### PR DESCRIPTION
Added the ability to search for an item by its identifier using the & prefix, e.g. &minecraft:cobble.

Relates to issue #2454 