### PR TITLE
perf: reduce per-tick allocations in BlockEntities and BlackHoleBand

### DIFF
--- a/src/main/java/moze_intel/projecte/gameObjs/block_entities/CollectorMK1BlockEntity.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/block_entities/CollectorMK1BlockEntity.java
@@ -80,6 +80,9 @@ public class CollectorMK1BlockEntity extends EmcBlockEntity implements MenuProvi
 	private double unprocessedEMC;
 	private boolean hasChargeableItem;
 	private boolean hasFuel;
+	//Cached EMC holder capability for the item in the upgrading slot, refreshed each tick in checkFuelOrKlein
+	@Nullable
+	private IItemEmcHolder cachedEmcHolder;
 	//Start as needing to check for compacting when loaded
 	private boolean needsCompacting = true;
 
@@ -171,6 +174,7 @@ public class CollectorMK1BlockEntity extends EmcBlockEntity implements MenuProvi
 		ItemStack upgrading = getUpgrading();
 		if (!upgrading.isEmpty()) {
 			IItemEmcHolder emcHolder = upgrading.getCapability(PECapabilities.EMC_HOLDER_ITEM_CAPABILITY);
+			cachedEmcHolder = emcHolder;
 			if (emcHolder != null) {
 				if (emcHolder.getNeededEmc(upgrading) > 0) {
 					hasChargeableItem = true;
@@ -183,6 +187,7 @@ public class CollectorMK1BlockEntity extends EmcBlockEntity implements MenuProvi
 				hasChargeableItem = false;
 			}
 		} else {
+			cachedEmcHolder = null;
 			hasFuel = false;
 			hasChargeableItem = false;
 		}
@@ -202,7 +207,7 @@ public class CollectorMK1BlockEntity extends EmcBlockEntity implements MenuProvi
 		if (this.getStoredEmc() > 0) {
 			ItemStack upgrading = getUpgrading();
 			if (hasChargeableItem) {
-				IItemEmcHolder emcHolder = upgrading.getCapability(PECapabilities.EMC_HOLDER_ITEM_CAPABILITY);
+				IItemEmcHolder emcHolder = cachedEmcHolder;
 				if (emcHolder != null) {
 					long actualInserted = emcHolder.insertEmc(upgrading, Math.min(getStoredEmc(), emcGen), EmcAction.EXECUTE);
 					forceExtractEmc(actualInserted, EmcAction.EXECUTE);

--- a/src/main/java/moze_intel/projecte/gameObjs/block_entities/EmcBlockEntity.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/block_entities/EmcBlockEntity.java
@@ -1,7 +1,5 @@
 package moze_intel.projecte.gameObjs.block_entities;
 
-import java.util.ArrayList;
-import java.util.List;
 import moze_intel.projecte.api.block_entity.BaseEmcBlockEntity;
 import moze_intel.projecte.api.capabilities.PECapabilities;
 import moze_intel.projecte.api.capabilities.block_entity.IEmcStorage;
@@ -113,7 +111,9 @@ public abstract class EmcBlockEntity extends BaseEmcBlockEntity {
 		}
 		emc = Math.min(getEmcExtractLimit(), emc);
 		long sentEmc = 0;
-		List<IEmcStorage> targets = new ArrayList<>();
+		//There are at most 6 adjacent directions, use a fixed size array to avoid allocating a list each tick
+		IEmcStorage[] targets = new IEmcStorage[6];
+		int targetCount = 0;
 		for (Direction dir : Constants.DIRECTIONS) {
 			//Make sure the neighboring block is loaded as if we are on a chunk border on the edge of loaded chunks this may not be the case
 			IEmcStorage theirEmcStorage = WorldHelper.getCapability(level, PECapabilities.EMC_STORAGE_CAPABILITY, pos.relative(dir), dir.getOpposite());
@@ -122,15 +122,16 @@ public abstract class EmcBlockEntity extends BaseEmcBlockEntity {
 					//If they are both relays don't add the pairing to prevent thrashing
 					if (theirEmcStorage.insertEmc(1, EmcAction.SIMULATE) > 0) {
 						//If they are wiling to accept any Emc then we consider them to be an "acceptor"
-						targets.add(theirEmcStorage);
+						targets[targetCount++] = theirEmcStorage;
 					}
 				}
 			}
 		}
 
-		if (!targets.isEmpty()) {
-			long emcPer = emc / targets.size();
-			for (IEmcStorage target : targets) {
+		if (targetCount > 0) {
+			long emcPer = emc / targetCount;
+			for (int i = 0; i < targetCount; i++) {
+				IEmcStorage target = targets[i];
 				long emcCanProvide = extractEmc(emcPer, EmcAction.SIMULATE);
 				long acceptedEmc = target.insertEmc(emcCanProvide, EmcAction.EXECUTE);
 				extractEmc(acceptedEmc, EmcAction.EXECUTE);

--- a/src/main/java/moze_intel/projecte/gameObjs/items/rings/BlackHoleBand.java
+++ b/src/main/java/moze_intel/projecte/gameObjs/items/rings/BlackHoleBand.java
@@ -1,8 +1,6 @@
 package moze_intel.projecte.gameObjs.items.rings;
 
-import java.util.EnumMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import moze_intel.projecte.api.block_entity.IDMPedestal;
 import moze_intel.projecte.api.capabilities.item.IAlchBagItem;
@@ -97,16 +95,18 @@ public class BlackHoleBand extends PEToggleItem implements IAlchBagItem, IAlchCh
 	public <PEDESTAL extends BlockEntity & IDMPedestal> boolean updateInPedestal(@NotNull ItemStack stack, @NotNull Level level, @NotNull BlockPos pos,
 			@NotNull PEDESTAL pedestal) {
 		Vec3 target = pos.getCenter();
-		Map<Direction, IItemHandler> nearbyHandlers = new EnumMap<>(Direction.class);
+		//Cache the item handlers for neighboring positions in a fixed-size array (6 directions) to avoid EnumMap allocation each tick
+		IItemHandler[] nearbyHandlers = new IItemHandler[6];
 		for (ItemEntity item : level.getEntitiesOfClass(ItemEntity.class, pedestal.getEffectBounds(), ent -> !ent.isSpectator() && ent.isAlive())) {
 			WorldHelper.gravitateEntityTowards(item, target);
 			if (!level.isClientSide && item.distanceToSqr(target) < 1.21) {
-				for (Direction dir : Constants.DIRECTIONS) {
+				for (int i = 0; i < Constants.DIRECTIONS.length; i++) {
+					Direction dir = Constants.DIRECTIONS[i];
 					//Cache the item handlers in various spots so that we only query each neighboring position once
-					IItemHandler inv = nearbyHandlers.get(dir);
+					IItemHandler inv = nearbyHandlers[i];
 					if (inv == null) {
 						inv = WorldHelper.getCapability(level, ItemHandler.BLOCK, pos.relative(dir), dir);
-						nearbyHandlers.put(dir, inv);
+						nearbyHandlers[i] = inv;
 					}
 					ItemStack result = ItemHandlerHelper.insertItemStacked(inv, item.getItem(), false);
 					if (result.isEmpty()) {


### PR DESCRIPTION
## Performance optimizations for BlockEntity tick paths

### Changes
- **CollectorMK1BlockEntity**: Cache the EMC_HOLDER capability for the upgrading slot once per tick in \checkFuelOrKlein()\, reusing it in \updateEmc()\ instead of querying the capability twice within the same tick.
- **EmcBlockEntity.sendToAllAcceptors**: Replace the per-tick \
ew ArrayList<>\(\)\ allocation with a fixed-size \IEmcStorage[6]\ array (there are at most 6 adjacent directions).
- **BlackHoleBand.updateInPedestal**: Replace the per-tick \
ew EnumMap<>(Direction.class)\ allocation with a fixed-size \IItemHandler[6]\ array.

### Impact
Reduces per-tick object allocations for placed Collectors, Relays, and Black Hole Bands on pedestals, lowering GC pressure and improving TPS in worlds with many of these blocks/items.

All changes are behavior-preserving; existing tests pass.