### PR TITLE
perf: use fastutil maps for EMC mapping to improve generation speed

### DIFF
--- a/src/main/java/moze_intel/projecte/emc/SimpleGraphMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/SimpleGraphMapper.java
@@ -2,7 +2,7 @@ package moze_intel.projecte.emc;
 
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
-import java.util.HashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -64,15 +64,15 @@ public class SimpleGraphMapper<T, V extends Comparable<V>, A extends IValueArith
 
 	@Override
 	public Map<T, V> generateValues() {
-		Map<@NotNull T, @NotNull V> values = new HashMap<>();
+		Map<@NotNull T, @NotNull V> values = new Object2ObjectOpenHashMap<>();
 
 		// All values that changed in previous iteration, so everything depending on it needs to be updated
 		@Nullable
-		Map<@NotNull T, @NotNull V> changedValues = new HashMap<>(fixValueBeforeInherit);
+		Map<@NotNull T, @NotNull V> changedValues = new Object2ObjectOpenHashMap<>(fixValueBeforeInherit);
 		@Nullable
 		Map<@NotNull T, @NotNull Object> reasonForChange = null;
 		if (isDebugGraphmapper()) {
-			reasonForChange = new HashMap<>(changedValues.size());
+			reasonForChange = new Object2ObjectOpenHashMap<>(changedValues.size());
 			for (Map.Entry<T, V> entry : fixValueBeforeInherit.entrySet()) {
 				reasonForChange.put(entry.getKey(), "fixValueBefore");
 			}
@@ -114,7 +114,7 @@ public class SimpleGraphMapper<T, V extends Comparable<V>, A extends IValueArith
 								if (storedValue == null || storedValue.compareTo(resultValueConversion) > 0) {
 									//And there is no smaller value for that conversion output yet
 									if (nextChangedValues == null) {//Lazily init nextChangedValues so if there aren't any we don't have to initialize it
-										nextChangedValues = new HashMap<>();
+										nextChangedValues = new Object2ObjectOpenHashMap<>();
 									}
 									if (updateMapWithMinimum(nextChangedValues, conversion.output, resultValueConversion)) {
 										//So we mark that new value to set it in the next iteration.
@@ -169,7 +169,7 @@ public class SimpleGraphMapper<T, V extends Comparable<V>, A extends IValueArith
 								addReason(reasonForChange, conversion.output, "exploit recipe");
 							}
 							if (changedValues == null) {//Lazily init changedValues so if there aren't any we don't have to initialize it
-								changedValues = new HashMap<>();
+								changedValues = new Object2ObjectOpenHashMap<>();
 							}
 							changedValues.put(conversion.output, ZERO);
 						} else if (logFoundExploits) {
@@ -189,7 +189,7 @@ public class SimpleGraphMapper<T, V extends Comparable<V>, A extends IValueArith
 						//but the value for the conversion output is > 0, so we set it to 0.
 						debugFormat("Removing Value for {} because it does not have any nonzero-conversions anymore.", key);
 						if (changedValues == null) {//Lazily init changedValues so if there aren't any we don't have to initialize it
-							changedValues = new HashMap<>();
+							changedValues = new Object2ObjectOpenHashMap<>();
 						}
 						changedValues.put(key, ZERO);
 						addReason(reasonForChange, key, "all conversions dead");

--- a/src/main/java/moze_intel/projecte/emc/collector/MappingCollector.java
+++ b/src/main/java/moze_intel/projecte/emc/collector/MappingCollector.java
@@ -3,7 +3,7 @@ package moze_intel.projecte.emc.collector;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-import java.util.HashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -40,11 +40,11 @@ public abstract class MappingCollector<T, V extends Comparable<V>, A extends IVa
 		debugFormat(s);
 	}
 
-	protected final Map<@NotNull T, @NotNull Conversion> overwriteConversion = new HashMap<>();
-	protected final Map<@NotNull T, @NotNull Set<Conversion>> conversionsFor = new HashMap<>();
-	protected final Map<@NotNull T, @NotNull Set<Conversion>> usedIn = new HashMap<>();
-	protected final Map<@NotNull T, @NotNull V> fixValueBeforeInherit = new HashMap<>();
-	protected final Map<@NotNull T, @NotNull V> fixValueAfterInherit = new HashMap<>();
+	protected final Map<@NotNull T, @NotNull Conversion> overwriteConversion = new Object2ObjectOpenHashMap<>();
+	protected final Map<@NotNull T, @NotNull Set<Conversion>> conversionsFor = new Object2ObjectOpenHashMap<>();
+	protected final Map<@NotNull T, @NotNull Set<Conversion>> usedIn = new Object2ObjectOpenHashMap<>();
+	protected final Map<@NotNull T, @NotNull V> fixValueBeforeInherit = new Object2ObjectOpenHashMap<>();
+	protected final Map<@NotNull T, @NotNull V> fixValueAfterInherit = new Object2ObjectOpenHashMap<>();
 
 	private Set<Conversion> getConversionsFor(@NotNull T something) {
 		return conversionsFor.computeIfAbsent(something, CREATE_CONVERSIONS);

--- a/src/main/java/moze_intel/projecte/emc/mappers/recipe/CraftingMapper.java
+++ b/src/main/java/moze_intel/projecte/emc/mappers/recipe/CraftingMapper.java
@@ -4,12 +4,12 @@ import com.mojang.logging.LogUtils;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectMaps;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +45,7 @@ public class CraftingMapper implements IEMCMapper<NormalizedSimpleStack, Long> {
 
 	//Note: None of our defaults just directly support all recipe types, as mods may extend it for "random" things and have more input types required than just items
 	// We also do this via annotations to allow for broader support for looping specific recipes and handling them
-	private final Map<String, BooleanSupplier> enabledRecipeMappers = new HashMap<>();
+	private final Map<String, BooleanSupplier> enabledRecipeMappers = new Object2ObjectOpenHashMap<>();
 	private final List<IRecipeTypeMapper> recipeMappers;
 
 	public CraftingMapper() {
@@ -204,8 +204,8 @@ public class CraftingMapper implements IEMCMapper<NormalizedSimpleStack, Long> {
 				.map(entry -> entry.getKey() + ":" + entry.getIntValue()).collect(Collectors.joining(", "));
 		private static final boolean DEBUG_GROUP_CONTENTS = false;
 
-		private final Map<Object2IntMap<NormalizedSimpleStack>, FakeGroupData> ingredientGroupsWithCount = new HashMap<>();
-		private final Map<Object2IntMap<NormalizedSimpleStack>, FakeGroupData> groupsWithCount = new HashMap<>();
+		private final Map<Object2IntMap<NormalizedSimpleStack>, FakeGroupData> ingredientGroupsWithCount = new Object2ObjectOpenHashMap<>();
+		private final Map<Object2IntMap<NormalizedSimpleStack>, FakeGroupData> groupsWithCount = new Object2ObjectOpenHashMap<>();
 		private final IMappingCollector<NormalizedSimpleStack, Long> mapper;
 		private int fakeIndex;
 


### PR DESCRIPTION
## Performance optimization for EMC mapping

### Changes
Replace \HashMap\ with fastutil's \Object2ObjectOpenHashMap\ in the EMC mapping pipeline:
- **MappingCollector**: \overwriteConversion\, \conversionsFor\, \usedIn\, \ixValueBeforeInherit\, \ixValueAfterInherit\
- **SimpleGraphMapper.generateValues**: \alues\, \changedValues\, \
extChangedValues\
- **CraftingMapper**: \enabledRecipeMappers\, \ingredientGroupsWithCount\, \groupsWithCount\

### Impact
fastutil's open-addressing hash maps have better memory locality and lower allocation overhead than \HashMap\, improving EMC value generation speed during server startup and \/projecte reload\.

The project already depends on fastutil (used for \Object2IntMap\ etc.), so no new dependencies are introduced.

All changes are behavior-preserving; existing tests pass.