### PR TITLE
perf: optimize numeric computations to avoid floating-point and string parsing

### DIFF
--- a/src/main/java/moze_intel/projecte/utils/MathUtils.java
+++ b/src/main/java/moze_intel/projecte/utils/MathUtils.java
@@ -23,8 +23,9 @@ public final class MathUtils {
 		} else if (currentAmount >= max) {
 			return 15;
 		}
-		double proportion = currentAmount / (double) max;
-		return (int) Math.round(proportion * 13 + 1);
+		//Integer arithmetic equivalent to Math.round(currentAmount * 13.0 / max + 1)
+		//Avoids floating point overhead; numerator cannot overflow for realistic EMC storage values
+		return (int) ((currentAmount * 26L + 3L * max) / (2L * max));
 	}
 
 	public static float tickToSec(int ticks, float tickRate) {

--- a/src/main/java/moze_intel/projecte/utils/TransmutationEMCFormatter.java
+++ b/src/main/java/moze_intel/projecte/utils/TransmutationEMCFormatter.java
@@ -26,14 +26,21 @@ public class TransmutationEMCFormatter {
 			return PELang.EMC_TOO_MUCH.translate();
 		}
 		//Otherwise we need to manually format it
+		//Extract leading significant digits directly via char arithmetic to avoid string concatenation + Double.parseDouble
 		int extraDigits = length % 3;
 		double value;
 		if (extraDigits == 0) {
-			value = Double.parseDouble(emcAsString.substring(0, 3) + "." + emcAsString.substring(3, 5));
+			int intPart = (emcAsString.charAt(0) - '0') * 100 + (emcAsString.charAt(1) - '0') * 10 + (emcAsString.charAt(2) - '0');
+			int fracPart = (emcAsString.charAt(3) - '0') * 10 + (emcAsString.charAt(4) - '0');
+			value = intPart + fracPart / 100.0;
 		} else if (extraDigits == 1) {
-			value = Double.parseDouble(emcAsString.charAt(0) + "." + emcAsString.substring(1, 3));
+			int intPart = emcAsString.charAt(0) - '0';
+			int fracPart = (emcAsString.charAt(1) - '0') * 10 + (emcAsString.charAt(2) - '0');
+			value = intPart + fracPart / 100.0;
 		} else {//if (extraDigits == 2)
-			value = Double.parseDouble(emcAsString.substring(0, 2) + "." + emcAsString.substring(2, 4));
+			int intPart = (emcAsString.charAt(0) - '0') * 10 + (emcAsString.charAt(1) - '0');
+			int fracPart = (emcAsString.charAt(2) - '0') * 10 + (emcAsString.charAt(3) - '0');
+			value = intPart + fracPart / 100.0;
 		}
 		return TextComponentUtil.smartTranslate(Util.makeDescriptionId("emc", PECore.rl("postfix." + postfixIndex)), EMCHelper.formatEmc(value));
 	}


### PR DESCRIPTION
## Performance optimization for numeric computations

### Changes
- **MathUtils.scaleToRedstone**: Replace the floating-point \Math.round(currentAmount / max * 13 + 1)\ with equivalent integer arithmetic \(currentAmount * 26 + 3 * max) / (2 * max)\, avoiding \double\ conversion and \Math.round\ overhead.
- **TransmutationEMCFormatter.formatEMC**: Replace string concatenation + \Double.parseDouble\ with direct character-to-digit arithmetic (\char - '0'\) when computing the abbreviated EMC display value.

### Impact
These methods are called frequently (redstone comparator updates, transmutation GUI rendering). Avoiding floating-point operations and string parsing reduces CPU overhead.

All changes are behavior-preserving (mathematically equivalent); existing tests pass.